### PR TITLE
Add new APIs to AvroCompatibilityHelper

### DIFF
--- a/avro-migration-helper/src/main/java/com/linkedin/avro/compatibility/AvroCompatibilityHelper.java
+++ b/avro-migration-helper/src/main/java/com/linkedin/avro/compatibility/AvroCompatibilityHelper.java
@@ -12,6 +12,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.OutputStream;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -67,13 +68,17 @@ public class AvroCompatibilityHelper {
     return newBinaryEncoder(new ObjectOutputToOutputStreamAdapter(out));
   }
 
+  public static BinaryDecoder newBinaryDecoder(InputStream in) {
+    return FACTORY.newBinaryDecoder(in);
+  }
+
   /**
    * to be migrated to SpecificData.getDecoder() in avro 1.8+
    * @param in object input
    * @return a binary decoder on top of the given ObjectInput
    */
   public static BinaryDecoder newBinaryDecoder(ObjectInput in) {
-    return DecoderFactory.defaultFactory().createBinaryDecoder(new ObjectInputToInputStreamAdapter(in), null);
+    return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in));
   }
 
   public static JsonEncoder newJsonEncoder(Schema schema, OutputStream out) throws IOException {
@@ -102,6 +107,33 @@ public class AvroCompatibilityHelper {
 
   public static GenericData.Fixed newFixedField(Schema ofType, byte[] contents) {
     return FACTORY.newFixedField(ofType, contents);
+  }
+
+  /**
+   * Create an instance of a class. If the class implements {@link SchemaConstructable},
+   * call a constructor with a {@link Schema} parameter, otherwise use a no-arg constructor.
+   * @param clazz class type to instantiate
+   * @param schema Avro schema to use for instantiating {@param clazz} if it implements {@link SchemaConstructable}
+   */
+  public static Object newInstance(Class clazz, Schema schema) {
+    return FACTORY.newInstance(clazz, schema);
+  }
+
+  /**
+   * Find the Avro schema for a Java type
+   */
+  public static Schema getSchema(Type type) {
+    return FACTORY.getSchema(type);
+  }
+
+  /**
+   * Get the default value of the given field, if any.
+   * @param field the field whose default value should be retrieved.
+   * @return the default value associated with the given field,
+   * or null if none is specified in the schema.
+   */
+  public static Object getDefaultValue(Schema.Field field) {
+    return FACTORY.getDefaultValue(field);
   }
 
   /**

--- a/avro-migration-helper/src/main/java/org/apache/avro/io/AbstractAvroAdapter.java
+++ b/avro-migration-helper/src/main/java/org/apache/avro/io/AbstractAvroAdapter.java
@@ -8,15 +8,18 @@ package org.apache.avro.io;
 
 import com.linkedin.avro.compatibility.AvroGeneratedSourceCode;
 import com.linkedin.avro.compatibility.AvroVersion;
+import java.io.InputStream;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
 
 
 //package private ON PURPOSE
@@ -35,6 +38,16 @@ abstract class AbstractAvroAdapter implements AvroAdapter {
   public AbstractAvroAdapter(Constructor enumSymbolCtr, Constructor fixedCtr) throws Exception {
     _enumSymbolCtr = enumSymbolCtr;
     _fixedCtr = fixedCtr;
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(InputStream inputStream) {
+    return DecoderFactory.defaultFactory().createBinaryDecoder(inputStream, null);
+  }
+
+  @Override
+  public Schema getSchema(Type type) {
+    return SpecificData.get().getSchema(type);
   }
 
   @Override

--- a/avro-migration-helper/src/main/java/org/apache/avro/io/AvroAdapter.java
+++ b/avro-migration-helper/src/main/java/org/apache/avro/io/AvroAdapter.java
@@ -11,6 +11,7 @@ import com.linkedin.avro.compatibility.AvroVersion;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Type;
 import java.util.Collection;
 
 import com.linkedin.avro.compatibility.SchemaParseResult;
@@ -28,6 +29,8 @@ import org.codehaus.jackson.JsonGenerator;
 public interface AvroAdapter {
 
   BinaryEncoder newBinaryEncoder(OutputStream out);
+
+  BinaryDecoder newBinaryDecoder(InputStream in);
 
   default JsonEncoder newJsonEncoder(Schema schema, OutputStream out) throws IOException {
     return new JsonEncoder(schema, out); //was made package-private in 1.7
@@ -53,6 +56,12 @@ public interface AvroAdapter {
   }
 
   GenericData.Fixed newFixedField(Schema ofType, byte[] contents);
+
+  Object newInstance(Class clazz, Schema schema);
+
+  Schema getSchema(Type type);
+
+  Object getDefaultValue(Schema.Field field);
 
   /**
    * invokes the avro {@link org.apache.avro.specific.SpecificCompiler} to generate java code

--- a/avro-migration-helper/src/test/java/com/linkedin/avro/compatibility/AvroCompatibilityHelperTest.java
+++ b/avro-migration-helper/src/test/java/com/linkedin/avro/compatibility/AvroCompatibilityHelperTest.java
@@ -11,10 +11,8 @@ import com.acme.generatedbylatest.Event;
 import com.acme.generatedbylatest.Guid;
 import com.acme.generatedbylatest.Header;
 import com.linkedin.avro.TestUtil;
-import com.linkedin.avro.compatibility.AvroGeneratedSourceCode;
-import com.linkedin.avro.compatibility.AvroVersion;
 import com.linkedin.avro.legacy.LegacyAvroSchema;
-import com.linkedin.avro.compatibility.AvroCompatibilityHelper;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.StringWriter;
@@ -32,7 +30,9 @@ import javax.tools.ToolProvider;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.util.Utf8;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
@@ -69,7 +69,7 @@ public class AvroCompatibilityHelperTest {
           + "       \"name\":\"EnumType\"\n"
           + "     }\n"
           + "    },\n"
-          + "    {\"name\":\"strField\", \"type\":\"string\"}\n"
+          + "    {\"name\":\"strField\", \"type\":\"string\", \"default\":\"str\"}\n"
           + "  ]\n"
           + "}"
   );
@@ -82,10 +82,23 @@ public class AvroCompatibilityHelperTest {
   }
 
   @Test
+  public void testGetDefaultValue() {
+    Object defaultValue = AvroCompatibilityHelper.getDefaultValue(_schema.getField("strField"));
+    Assert.assertEquals(defaultValue, new Utf8("str"));
+  }
+
+  @Test
   public void testBinaryEncoder() throws Exception {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     BinaryEncoder binaryEncoder = AvroCompatibilityHelper.newBinaryEncoder(os);
     Assert.assertNotNull(binaryEncoder);
+  }
+
+  @Test
+  public void testBinaryDecoder() {
+    ByteArrayInputStream is = new ByteArrayInputStream(new byte[0]);
+    BinaryDecoder binaryDecoder = AvroCompatibilityHelper.newBinaryDecoder(is);
+    Assert.assertNotNull(binaryDecoder);
   }
 
   @Test


### PR DESCRIPTION
Add the following APIs to `AvroCompatibilityHelper`:
  - `newInstance(Class, Schema)`:    Instantiates objects of a specific type 
  - `getSchema(Type)`: 		  	   Locates the Avro schema associated with a Java (SpecificRecord) type
  - `getDefaultValue(Schema.Field)`: Retrieves the default value of an Avro field, if any