### PR TITLE
Dynamically infer classpath by classloader according to the class usage

### DIFF
--- a/avro-fastserde/gettingstarted.md
+++ b/avro-fastserde/gettingstarted.md
@@ -71,8 +71,4 @@ FastSpecificDatumWriter<T> fastSpecificDatumWriter = new FastSpecificDatumWriter
 fastSpecificDatumWriter.write(data, binaryEncoder);
 
 
-## Troubleshooting
-
-
-## Related Documentation
 

--- a/avro-fastserde/gettingstarted.md
+++ b/avro-fastserde/gettingstarted.md
@@ -1,0 +1,78 @@
+Getting Started
+===============
+
+## Introduction
+
+This lib is a fork of the open-source project: https://github.com/RTBHOUSE/avro-fastserde.
+You could get more information regarding the original thinking of this lib by this comprehensive
+blog: https://techblog.rtbhouse.com/2017/04/18/fast-avro/.
+
+In the high-level, this is an alternative of the standard Avro serialization/de-serialization
+framework, but with better performance by doing runtime code generation.
+According to the prod experiment, the de-serlialization time could be reduced by 90% for
+some complicated schema, and the serialization time is also improved substantially.
+
+If your application is encountering performance issue with Avro serialization/de-serialization,
+you might want to give it a try.
+
+When bringing this lib to LinkedIn, we have done the following improvements so far:
+1. Made the lib work with both Avro-1.4 and Avro-1.7;
+2. Modified the lib to return "Utf8" instead of "String" to align with
+the standard Avro lib;
+3. Improved the performance of the original lib by caching the generated
+de-serlializer in "FastSpecificDatumReader" and "FastGenericDatumReader";
+4. Improved the unit tests to always run the tests against both this fast lib
+and the standard Avro lib;
+5. Improved the de-serialization generator to support object reuse;
+6. Introduced some GC optimization for float vectors;
+
+We will continue to improve this lib in the future since we are seeing this lib could
+be widely used.
+
+
+## Requirements
+
+## Installation/Setting Up
+
+Gradle dependency:
+com.linkedin.avroutil:avro-codegen:0.1.1
+
+## Using the Product or Service
+
+Since all the APIs in this lib is compatible with the generic Avro lib, so it is very
+straightforward to use them.
+
+For de-serialization, there are two classes:
+FastGenericDatumReader
+FastSpecificDatumReader
+
+For serialization, there are also two classes:
+FastGenericDatumWriter
+FastSpecificDatumWriter
+
+Code example:
+import com.linkedin.avro.fastserde.FastGenericDatumReader;
+import com.linkedin.avro.fastserde.FastGenericDatumWriter;
+import com.linkedin.avro.fastserde.FastSpecificDatumReader;
+import com.linkedin.avro.fastserde.FastSpecificDatumWriter;
+
+...
+
+FastGenericDatumReader<GenericData.Record> fastGenericDatumReader = new FastGenericDatumReader<>(writerSchema, readerSchema);
+fastGenericDatumReader.read(reuse, binaryDecoder);
+
+FastGenericDatumWriter<GenericData.Record> fastGenericDatumWriter = new FastGenericDatumWriter<>(schema);
+fastGenericDatumWriter.write(data, binaryEncoder);
+
+FastSpecificDatumReader<T> fastSpecificDatumReader = new FastSpecificDatumReader<>(writerSchema, readerSchema);
+fastSpecificDatumReader.read(reuse, binaryDecoder);
+
+FastSpecificDatumWriter<T> fastSpecificDatumWriter = new FastSpecificDatumWriter<>(schema);
+fastSpecificDatumWriter.write(data, binaryEncoder);
+
+
+## Troubleshooting
+
+
+## Related Documentation
+

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -154,7 +154,7 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
       deserializeMethod.param(readerSchemaClass, VAR_NAME_FOR_REUSE);
       deserializeMethod.param(Decoder.class, DECODER);
 
-      Class<FastDeserializer<T>> clazz = compileClass(className);
+      Class<FastDeserializer<T>> clazz = compileClass(className, schemaAssistant.getUsedFullyQualifiedClassNameSet());
       return clazz.getConstructor(Schema.class).newInstance(reader);
     } catch (JClassAlreadyExistsException e) {
       throw new FastDeserializerGeneratorException("Class: " + className + " already exists");

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.ListIterator;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
@@ -44,7 +45,7 @@ public abstract class FastDeserializerGeneratorBase<T> {
     this.reader = reader;
     this.destination = destination;
     this.classLoader = classLoader;
-    this.compileClassPath = compileClassPath;
+    this.compileClassPath = (null == compileClassPath ? "" : compileClassPath);
     this.codeModel = new JCodeModel();
   }
 
@@ -106,21 +107,24 @@ public abstract class FastDeserializerGeneratorBase<T> {
   public abstract FastDeserializer<T> generateDeserializer();
 
   @SuppressWarnings("unchecked")
-  protected Class<FastDeserializer<T>> compileClass(final String className) throws IOException, ClassNotFoundException {
+  protected Class<FastDeserializer<T>> compileClass(final String className, Set<String> knownUsedFullyQualifiedClassNameSet)
+      throws IOException, ClassNotFoundException {
     codeModel.build(destination);
 
     String filePath = destination.getAbsolutePath() + GENERATED_SOURCES_PATH + className + ".java";
     LOGGER.info("Generated deserializer source file: " + filePath);
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    String compileClassPathForCurrentFile = Utils.inferCompileDependencies(compileClassPath, filePath, knownUsedFullyQualifiedClassNameSet);
+    LOGGER.info("For source file: " + filePath + ", and the inferred compile class path: " + compileClassPathForCurrentFile);
     int compileResult;
-    if (compileClassPath != null) {
-      compileResult = compiler.run(null, null, null, "-cp", compileClassPath, filePath);
-    } else {
-      compileResult = compiler.run(null, null, null, filePath);
+    try {
+      compileResult = compiler.run(null, null, null, "-cp", compileClassPathForCurrentFile, filePath);
+    } catch (Exception e) {
+      throw new FastDeserializerGeneratorException("Unable to compile:" + className, e);
     }
 
     if (compileResult != 0) {
-      throw new FastDeserializerGeneratorException("unable to compile:" + className);
+      throw new FastDeserializerGeneratorException("Unable to compile:" + className);
     }
 
     return (Class<FastDeserializer<T>>) classLoader.loadClass(GENERATED_PACKAGE_NAME + "." + className);

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
@@ -163,6 +163,7 @@ public final class FastSerdeCache {
                   classPath += ":" + lib.getAbsolutePath();
                 }
               }
+              LOGGER.info("Inferred class path: " + classPath);
             } catch (ClassNotFoundException e) {
               throw new RuntimeException("Failed to find class: " + avroSchemaClassName);
             }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
@@ -70,7 +70,7 @@ public class FastSerializerGenerator<T> extends FastSerializerGeneratorBase<T> {
       serializeMethod.param(codeModel.ref(Encoder.class), ENCODER);
       serializeMethod._throws(codeModel.ref(IOException.class));
 
-      final Class<FastSerializer<T>> clazz = compileClass(className);
+      final Class<FastSerializer<T>> clazz = compileClass(className, schemaAssistant.getUsedFullyQualifiedClassNameSet());
       return clazz.newInstance();
     } catch (JClassAlreadyExistsException e) {
       throw new FastSerializerGeneratorException("Class: " + className + " already exists");

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
@@ -15,6 +15,10 @@ import org.apache.log4j.Logger;
 import static com.linkedin.avro.fastserde.Utils.*;
 
 
+/**
+ * TODO: refactor {@link FastSerializerGeneratorBase} and {@link FastDeserializerGeneratorBase} to eliminate the duplicate code.
+ * @param <T>
+ */
 public abstract class FastSerializerGeneratorBase<T> {
   public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.serialization.generated";
   public static final String GENERATED_SOURCES_PATH = generateSourcePathFromPackageName(GENERATED_PACKAGE_NAME);

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
@@ -4,6 +4,7 @@ import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
 import java.io.File;
 import java.io.IOException;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
@@ -33,7 +34,7 @@ public abstract class FastSerializerGeneratorBase<T> {
     this.schema = schema;
     this.destination = destination;
     this.classLoader = classLoader;
-    this.compileClassPath = compileClassPath;
+    this.compileClassPath = (null == compileClassPath ? "" : compileClassPath);
     codeModel = new JCodeModel();
   }
 
@@ -60,22 +61,25 @@ public abstract class FastSerializerGeneratorBase<T> {
   public abstract FastSerializer<T> generateSerializer();
 
   @SuppressWarnings("unchecked")
-  protected Class<FastSerializer<T>> compileClass(final String className) throws IOException, ClassNotFoundException {
+  protected Class<FastSerializer<T>> compileClass(final String className, Set<String> knownUsedFullyQualifiedClassNameSet)
+      throws IOException, ClassNotFoundException {
     codeModel.build(destination);
 
     String filePath = destination.getAbsolutePath() + GENERATED_SOURCES_PATH + className + ".java";
     LOGGER.info("Generated serializer source file: " + filePath);
 
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    String compileClassPathForCurrentFile = Utils.inferCompileDependencies(compileClassPath, filePath, knownUsedFullyQualifiedClassNameSet);
+    LOGGER.info("For source file: " + filePath + ", and the inferred compile class path: " + compileClassPathForCurrentFile);
     int compileResult;
-    if (compileClassPath != null) {
-      compileResult = compiler.run(null, null, null, "-cp", compileClassPath, filePath);
-    } else {
-      compileResult = compiler.run(null, null, null, filePath);
+    try {
+      compileResult = compiler.run(null, null, null, "-cp", compileClassPathForCurrentFile, filePath);
+    } catch (Exception e) {
+      throw new FastSerializerGeneratorException("Unable to compile:" + className, e);
     }
 
     if (compileResult != 0) {
-      throw new FastSerializerGeneratorException("unable to compile:" + className);
+      throw new FastSerializerGeneratorException("Unable to compile:" + className);
     }
 
     return (Class<FastSerializer<T>>) classLoader.loadClass(GENERATED_PACKAGE_NAME + "." + className);

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
@@ -159,7 +159,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
    *
    * TODO: verify if it's enough to simply store the data as primitives in order to benefit from the GC optimization.
    */
-  private boolean addPrimitive(float o) {
+  public boolean addPrimitive(float o) {
     if (size == elements.length) {
       float[] newElements = new float[(size * 3) / 2 + 1];
       System.arraycopy(elements, 0, newElements, 0, size);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeCacheTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeCacheTest.java
@@ -49,8 +49,8 @@ public class FastSerdeCacheTest {
     }
   }
 
-  @Test(groups = "deserializationTest", expectedExceptions = FastDeserializerGeneratorException.class)
-  public void testBuildFastGenericDeserializerWithWrongClasspath() throws Exception {
+  @Test(groups = "deserializationTest")
+  public void testBuildFastGenericDeserializerSurviveFromWrongClasspath() throws Exception {
     String wrongClasspath = ".";
     FastSerdeCache cache = new FastSerdeCache(wrongClasspath);
     Schema testRecord = Schema.parse("{\"type\": \"record\", \"name\": \"test_record\", \"fields\":[]}");
@@ -64,8 +64,8 @@ public class FastSerdeCacheTest {
     cache.buildFastGenericDeserializer(testRecord, testRecord);
   }
 
-  @Test(groups = "deserializationTest", expectedExceptions = FastDeserializerGeneratorException.class)
-  public void testBuildFastSpecificDeserializerWithWrongClasspath() throws Exception {
+  @Test(groups = "deserializationTest")
+  public void testBuildFastSpecificDeserializerSurviveFromWrongClasspath() throws Exception {
     String wrongClasspath = ".";
     FastSerdeCache cache = new FastSerdeCache(wrongClasspath);
     cache.buildFastSpecificDeserializer(TestRecord.SCHEMA$, TestRecord.SCHEMA$);


### PR DESCRIPTION
When application is using play framework with hot-reload enabled, fast-avro
couldn't find the right classpath by extracting from system property:java.class.path.
So this code change will explicitly find all the classes being used in the
generated files and put the corresponding libraries in the compile classpath.
Play framework is using both current classloader and the thread context classloader
to discover class path in hot reload feature. In fast-avro class generation/compilation,
we have to do the same time to align with this behavior.
Once the generated file is compiled successfully, loading the compiled classes
is not a problem in play framework with hot-reload enabled.