### PR TITLE
add support for old(er) versions of avro 1.7

### DIFF
--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -129,8 +129,10 @@ public class Avro14Adapter implements AvroAdapter {
       Schema schema = result.getMainSchema();
       SchemaValidator validator = new SchemaValidator(desiredConf, known);
       AvroSchemaUtil.traverseSchema(schema, validator); //will throw on issues
+      return new SchemaParseResult(result.getMainSchema(), result.getAllSchemas(), desiredConf);
+    } else {
+      return result;
     }
-    return result;
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -131,7 +131,10 @@ public class Avro15Adapter implements AvroAdapter {
     boolean validateDefaults = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
+      validateDefaults = desiredConf.validateDefaultValues();
     }
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+
     parser.setValidate(validateNames);
     if (known != null && !known.isEmpty()) {
       Map<String, Schema> knownByFullName = new HashMap<>(known.size());
@@ -143,15 +146,14 @@ public class Avro15Adapter implements AvroAdapter {
     }
     Schema mainSchema = parser.parse(schemaJson);
 
-    if (desiredConf != null && desiredConf.validateDefaultValues()) {
+    if (validateDefaults) {
       //avro 1.5 doesnt properly validate default values, so we have to do it ourselves
-      SchemaValidator validator = new SchemaValidator(desiredConf, known);
+      SchemaValidator validator = new SchemaValidator(configUsed, known);
       AvroSchemaUtil.traverseSchema(mainSchema, validator); //will throw on issues
     }
 
     Map<String, Schema> knownByFullName = parser.getTypes();
-    //noinspection ConstantConditions
-    return new SchemaParseResult(mainSchema, knownByFullName, new SchemaParseConfiguration(validateNames, validateDefaults));
+    return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -65,8 +65,16 @@ public class Avro17Adapter implements AvroAdapter {
 
   //"optional" methods - things added in later 1.7.* versions that may not exist if we're running with earlier 1.7.*
 
+  /**
+   * method {@link org.apache.avro.Schema.Parser#setValidateDefaults(boolean)}.
+   */
   private Method setValidateDefaultsMethod;
-  private Method getSpecificDefaultValueMethod; //we use this method's existence to also imply the existence of the generic one
+  /**
+   * method {@link SpecificData#getDefaultValue(Schema.Field)}.
+   * we use this method's existence to also imply the existence of
+   * {@link GenericData#getDefaultValue(Schema.Field)}
+   */
+  private Method getSpecificDefaultValueMethod;
 
   public Avro17Adapter() {
     tryInitializeCompilerFields();

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -8,10 +8,13 @@ package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.compatibility.AvroAdapter;
 import com.linkedin.avroutil1.compatibility.AvroGeneratedSourceCode;
+import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaParseResult;
+import com.linkedin.avroutil1.compatibility.SchemaValidator;
+import com.linkedin.avroutil1.compatibility.avro17.backports.Avro17DefaultValuesCache;
 import com.linkedin.avroutil1.compatibility.backports.ObjectInputToInputStreamAdapter;
 import com.linkedin.avroutil1.compatibility.backports.ObjectOutputToOutputStreamAdapter;
 import java.io.IOException;
@@ -47,6 +50,8 @@ import org.slf4j.LoggerFactory;
 public class Avro17Adapter implements AvroAdapter {
   private final static Logger LOG = LoggerFactory.getLogger(Avro17Adapter.class);
 
+  //compiler-related fields and methods (if the compiler jar is on the classpath)
+
   private boolean compilerSupported;
   private Constructor<?> specificCompilerCtr;
   private Method compilerEnqueueMethod;
@@ -57,6 +62,11 @@ public class Avro17Adapter implements AvroAdapter {
   private Method setFieldVisibilityMethod;
   private Object charSequenceStringTypeEnumInstance;
   private Method setStringTypeMethod;
+
+  //"optional" methods - things added in later 1.7.* versions that may not exist if we're running with earlier 1.7.*
+
+  private Method setValidateDefaultsMethod;
+  private Method getSpecificDefaultValueMethod; //we use this method's existence to also imply the existence of the generic one
 
   public Avro17Adapter() {
     tryInitializeCompilerFields();
@@ -90,6 +100,28 @@ public class Avro17Adapter implements AvroAdapter {
       //but if we're missing a transitive dependency we will get NoClassDefFoundError
       compilerSupported = false;
       //ignore
+    }
+
+    boolean warned = false;
+
+    try {
+      setValidateDefaultsMethod = Schema.Parser.class.getMethod("setValidateDefaults", Boolean.TYPE);
+    } catch (Exception | LinkageError e) {
+      if (!warned) {
+        LOG.warn("you are using an older version of avro 1.7. please consider upgrading to latest 1.7.*");
+        warned = true;
+      }
+      setValidateDefaultsMethod = null;
+    }
+
+    try {
+      getSpecificDefaultValueMethod = SpecificData.class.getMethod("getDefaultValue", Schema.Field.class);
+    } catch (Exception | LinkageError e) {
+      if (!warned) {
+        LOG.warn("you are using an older version of avro 1.7. please consider upgrading to latest 1.7.*");
+        warned = true;
+      }
+      getSpecificDefaultValueMethod = null;
     }
   }
 
@@ -142,8 +174,15 @@ public class Avro17Adapter implements AvroAdapter {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
     }
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+
     parser.setValidate(validateNames);
-    parser.setValidateDefaults(validateDefaults);
+
+    //must check the method exists before trying to call it
+    if (setValidateDefaultsMethod != null) {
+      parser.setValidateDefaults(validateDefaults);
+    }
+
     if (known != null && !known.isEmpty()) {
       Map<String, Schema> knownByFullName = new HashMap<>(known.size());
       for (Schema s : known) {
@@ -154,10 +193,14 @@ public class Avro17Adapter implements AvroAdapter {
     }
     Schema mainSchema = parser.parse(schemaJson);
 
-    //avro 1.7 can (optionally) validate defaults - so even if the user asked for that we have no further work to do
+    if (validateDefaults && setValidateDefaultsMethod == null) {
+      //older avro 1.7 doesnt support validating default values, so we have to do it ourselves
+      SchemaValidator validator = new SchemaValidator(configUsed, known);
+      AvroSchemaUtil.traverseSchema(mainSchema, validator); //will throw on issues
+    }
 
     Map<String, Schema> knownByFullName = parser.getTypes();
-    return new SchemaParseResult(mainSchema, knownByFullName, new SchemaParseConfiguration(validateNames, validateDefaults));
+    return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
   }
 
   @Override
@@ -172,7 +215,12 @@ public class Avro17Adapter implements AvroAdapter {
 
   @Override
   public Object getSpecificDefaultValue(Schema.Field field) {
-    return SpecificData.get().getDefaultValue(field);
+    if (getSpecificDefaultValueMethod != null) {
+      return SpecificData.get().getDefaultValue(field);
+    } else {
+      //old avro 1.7 - punt to backported code
+      return Avro17DefaultValuesCache.getDefaultValue(field, true);
+    }
   }
 
   @Override
@@ -192,7 +240,12 @@ public class Avro17Adapter implements AvroAdapter {
 
   @Override
   public Object getGenericDefaultValue(Schema.Field field) {
-    return GenericData.get().getDefaultValue(field);
+    if (getSpecificDefaultValueMethod != null) {
+      return GenericData.get().getDefaultValue(field);
+    } else {
+      //old avro 1.7 - punt to backported code
+      return Avro17DefaultValuesCache.getDefaultValue(field, false);
+    }
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/backports/Avro17DefaultValuesCache.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/backports/Avro17DefaultValuesCache.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro17.backports;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.io.parsing.ResolvingGrammarGenerator;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.codehaus.jackson.JsonNode;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+
+/**
+ * this class holds a cache of generic and specific default values for various
+ * schema fields. the implementations were taken out of avro 1.7.7 classes and
+ * exists here for use with older 1.7.* versions that do not have this functionality
+ * {@link org.apache.avro.specific.SpecificData} and
+ * {@link org.apache.avro.generic.GenericData}
+ */
+public class Avro17DefaultValuesCache {
+
+  private static final Map<Schema.Field, Object> GENERIC_CACHED_DEFAULTS = Collections.synchronizedMap(new WeakHashMap<>());
+  private static final Map<Schema.Field, Object> SPECIFIC_CACHED_DEFAULTS = Collections.synchronizedMap(new WeakHashMap<>());
+
+  /**
+   * Gets the default value of the given field, if any.
+   * @param field the field whose default value should be retrieved.
+   * @return the default value associated with the given field,
+   * or null if none is specified in the schema.
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public static Object getDefaultValue(Schema.Field field, boolean specific) {
+
+    JsonNode json = field.defaultValue();
+    if (json == null) {
+      throw new AvroRuntimeException("Field " + field + " not set and has no default value");
+    }
+    if (json.isNull()
+        && (field.schema().getType() == Schema.Type.NULL
+        || (field.schema().getType() == Schema.Type.UNION
+        && field.schema().getTypes().get(0).getType() == Schema.Type.NULL))) {
+      return null;
+    }
+
+    Map<Schema.Field, Object> cache = specific ? SPECIFIC_CACHED_DEFAULTS : GENERIC_CACHED_DEFAULTS;
+
+    // Check the cache
+    Object defaultValue = cache.get(field);
+
+    // If not cached, get the default Java value by encoding the default JSON
+    // value and then decoding it:
+    if (defaultValue == null)
+      try {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        BinaryEncoder encoder = EncoderFactory.get().directBinaryEncoder(baos, null);
+        ResolvingGrammarGenerator.encode(encoder, field.schema(), json);
+        encoder.flush();
+        ByteArrayInputStream is = new ByteArrayInputStream(baos.toByteArray());
+        BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(is, null);
+        DatumReader reader;
+        if (specific) {
+          reader = new SpecificDatumReader(field.schema());
+        } else {
+          reader = new GenericDatumReader(field.schema());
+        }
+        defaultValue = reader.read(null, decoder);
+        cache.put(field, defaultValue);
+      } catch (IOException e) {
+        throw new AvroRuntimeException(e);
+      }
+
+    return defaultValue;
+  }
+}

--- a/helper/tests/helper-tests-allavro/build.gradle
+++ b/helper/tests/helper-tests-allavro/build.gradle
@@ -17,6 +17,8 @@ configurations {
   avro16NoCompiler
   avro17
   avro17NoCompiler
+  avro17Old
+  avro17OldNoCompiler
   avro18
   avro18NoCompiler
   avro19
@@ -89,6 +91,16 @@ dependencies {
     exclude group: "org.slf4j"
   }
 
+  avro17Old ("org.apache.avro:avro:1.7.0") {
+    exclude group: "org.slf4j"
+  }
+  avro17Old ("org.apache.avro:avro-compiler:1.7.0") {
+    exclude group: "org.slf4j"
+  }
+  avro17OldNoCompiler ("org.apache.avro:avro:1.7.0") {
+    exclude group: "org.slf4j"
+  }
+
   avro18 ("org.apache.avro:avro:1.8.2") {
     exclude group: "org.slf4j"
   }
@@ -110,7 +122,21 @@ dependencies {
   }
 }
 
-def avroVersions = ["14", "15", "15NoCompiler", "16", "16NoCompiler", "17", "17NoCompiler", "18", "18NoCompiler", "19", "19NoCompiler"]
+def avroVersions = [
+        "14",
+        "15",
+        "15NoCompiler",
+        "16",
+        "16NoCompiler",
+        "17",
+        "17NoCompiler",
+        "17Old",
+        "17OldNoCompiler",
+        "18",
+        "18NoCompiler",
+        "19",
+        "19NoCompiler"
+]
 
 for (String avroVersion : avroVersions) {
 
@@ -142,5 +168,3 @@ for (String avroVersion : avroVersions) {
   }
 
 }
-
-//build.dependsOn testAvro14, testAvro15, testAvro16, testAvro17, testAvro18, testAvro19


### PR DESCRIPTION
Schema.Parser.setValidateDefaults(), SpecificData.getDefaultValue() and GenericData.getDefaultValue() were all added to 1.7 after 1.7.0.

This code mainly provides alternative implementations for these if they are not found (meaning we are running under older 1.7). The alternative implementations are the same we use under avro 1.6.

Under older 1.7 a warning is printed to log once (since presumably upgrading to latest 1.7 should be an easy operation for users)

Also fixed the return value of parse() under avro < 1.7 to correctly reflect the configuration used for parsing.