### PR TITLE
Change log level to debug in FastDatumReader/Writer to improve perf

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
@@ -38,12 +38,12 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
 
     if (!Utils.isSupportedAvroVersionsForDeserializer()) {
       this.cachedFastDeserializer = getRegularAvroImpl(writerSchema, readerSchema);
-      LOGGER.info("Current avro version: " + Utils.getRuntimeAvroVersion() + " is not supported, and only the following"
+      LOGGER.debug("Current avro version: " + Utils.getRuntimeAvroVersion() + " is not supported, and only the following"
           + " versions are supported: " + Utils.getAvroVersionsSupportedForDeserializer() + ", so skip the FastDeserializer generation");
     } else if (!FastSerdeCache.isSupportedForFastDeserializer(readerSchema.getType())) {
       // For unsupported schema type, we won't try to fetch it from FastSerdeCache since it is inefficient.
       this.cachedFastDeserializer = getRegularAvroImpl(writerSchema, readerSchema);
-      LOGGER.info("Skip the FastGenericDeserializer generation since read schema type: " + readerSchema.getType()
+      LOGGER.debug("Skip the FastGenericDeserializer generation since read schema type: " + readerSchema.getType()
           + " is not supported");
     }
   }
@@ -73,7 +73,7 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
         // don't cache
       } else {
         cachedFastDeserializer = fastDeserializer;
-        LOGGER.info("FastGenericDeserializer was generated and cached for reader schema: [" + readerSchema
+        LOGGER.debug("FastGenericDeserializer was generated and cached for reader schema: [" + readerSchema
             + "], writer schema: [" + writerSchema + "]");
       }
     }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumWriter.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumWriter.java
@@ -25,13 +25,13 @@ public class FastGenericDatumWriter<T> implements DatumWriter<T> {
     this.cache = cache != null ? cache : FastSerdeCache.getDefaultInstance();
     if (!Utils.isSupportedAvroVersionsForSerializer()) {
       this.cachedFastSerializer = getRegularAvroImpl(writerSchema);
-      LOGGER.info("Current avro version: " + Utils.getRuntimeAvroVersion() + " is not supported, and only the following"
+      LOGGER.debug("Current avro version: " + Utils.getRuntimeAvroVersion() + " is not supported, and only the following"
           + " versions are supported: " + Utils.getAvroVersionsSupportedForSerializer()
           + ", so will skip the FastSerializer generation");
     } else if (!FastSerdeCache.isSupportedForFastSerializer(schema.getType())) {
       // For unsupported schema type, we won't try to fetch it from FastSerdeCache since it is inefficient.
       this.cachedFastSerializer = getRegularAvroImpl(writerSchema);
-      LOGGER.info("Skip the FastGenericSerializer generation since read schema type: " + schema.getType()
+      LOGGER.debug("Skip the FastGenericSerializer generation since read schema type: " + schema.getType()
           + " is not supported");
     }
   }
@@ -54,7 +54,7 @@ public class FastGenericDatumWriter<T> implements DatumWriter<T> {
         // don't cache
       } else {
         cachedFastSerializer = fastSerializer;
-        LOGGER.info("FastSerializer has been generated and cached for writer schema: [" + writerSchema + "]");
+        LOGGER.debug("FastSerializer has been generated and cached for writer schema: [" + writerSchema + "]");
       }
     }
 


### PR DESCRIPTION
Previous log level in FastGenericDatumReader/Writer was "info" which affected performance greatly when trying to reuse cached fastDeserializer/Serializer in FastSerdeCache.

By removing log, we can take better advantage of cached fastDeserializer/Serializer.

According one of the JMH benchmark results:
Fast-deserialization latency can be improved from **1.1 ms** to **0.5ms** by this change.

@gaojieliu @FelixGV 