### PR TITLE
Change to use IdentityHashMap to cache schemaId for Avro 1.4

### DIFF
--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   compile "org.apache.commons:commons-lang3:3.4"
   compile "com.sun.codemodel:codemodel:2.6"
   compile "com.google.guava:guava:19.0"
+  compile "org.jboss:jboss-common-core:2.5.0.Final"
 
   // By default, the compile and testCompile configuration is using avro-1.8, and
   // if you need to switch to an old version of Avro, we need to make

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
@@ -11,7 +11,6 @@ import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -19,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
+import org.jboss.util.collection.WeakIdentityHashMap;
 
 
 public class Utils {
@@ -29,14 +29,13 @@ public class Utils {
   private static final Map<Schema, Long> SCHEMA_IDS_CACHE = new ConcurrentHashMap<>();
 
   // Schema#hashCode is not performance efficient in Avro 1.4. It has been improved
-  // by caching hashcode in the later version. Change to use IdentityHashMap for
+  // by caching hashcode in the later version. Change to use WeakIdentityHashMap for
   // Avro 1.4 helps to improve the cache lookup performance. However, it requires
-  // the client to resuse the schame instance. Or, it will ventually lead to
-  // "Too many schema objects" issue
+  // the client to resuse the schame instance.
   // TODO - LRU Cache with size limit
-  private static final Map<Schema, Long> SCHEMA_IDS_CACHE_AVRO_14 = new IdentityHashMap<>();
+  private static final Map<Schema, Long> SCHEMA_IDS_CACHE_AVRO_14 = new WeakIdentityHashMap();
 
-  private static ReentrantReadWriteLock reentrantReadWriteLock = new ReentrantReadWriteLock();
+  private static final ReentrantReadWriteLock reentrantReadWriteLock = new ReentrantReadWriteLock();
 
   private Utils() {
   }


### PR DESCRIPTION
In Avro 1.4, Schema#hashCode is not performance efficient. It has been improved
by caching computed hashcode in the later avro version.

Change to use IdentityHashMap for Avro 1.4 helps to improve the schemaId cache
lookup performance. Here's JMH benchmark of deserialization latency of a example
schema using different approaches:

>  - vanilla avro 1.4:                                                                                     0.26ms
>  - avro-fastserde with ConcurrentHashMap as schemaId cache:   0.22ms
>  - avro-fastserde with IdentityHashMap as schemaId cache:          0.14ms

However, it requires the client to resuse the schame instance. Or, it will eventually
lead to "Too many schema objects" issue. I think it's ok for now since a typical
client generally reuse the schema instance and that's one of the best practices as well.
We can build a LRU Cache with size limit in the future.

@gaojieliu @FelixGV @radai-rosenblatt 