### PR TITLE
JMH benchmark suite for avro-fastserde

### DIFF
--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "java-library"
+  id "me.champeau.gradle.jmh" version "0.5.0"
 }
 
 configurations {
@@ -30,6 +31,15 @@ if (USE_AVRO_14) {
   USE_AVRO_18 = false
 }
 
+jmh {
+  profilers = ['gc', 'pauses']
+  duplicateClassesStrategy = 'warn'
+  clean {
+    delete "$buildDir/jmh-generated-classes"
+    delete "$buildDir/jmh-generated-sources"
+  }
+}
+
 dependencies {
   compile project(":helper:helper")
 
@@ -46,6 +56,8 @@ dependencies {
   compileOnly AVRO_LIB
 
   testCompileOnly AVRO_LIB
+
+  jmh AVRO_LIB
 
   testCompile 'org.testng:testng:6.14.3'
   testCompile "org.openjdk.jmh:jmh-core:1.19"
@@ -65,6 +77,10 @@ dependencies {
   avro18 ("org.apache.avro:avro-compiler:1.8.2") {
     exclude group: "org.slf4j"
   }
+}
+
+compileJmhJava {
+  dependsOn compileTestJava
 }
 
 def avroVersions = ["14", "17", "18"]
@@ -118,6 +134,10 @@ task generateAvroClasses18(type:Exec) {
 task whetherToCompileAvroClasses18() {
   if (USE_AVRO_18) {
     dependsOn generateAvroClasses18
+  } else if (USE_AVRO_17) {
+    dependsOn generateAvroClasses17
+  } else if (USE_AVRO_14) {
+    dependsOn generateAvroClasses14
   }
 }
 // Only pre-compile for Avro-1.8 since the default Avro version is 1.8

--- a/avro-fastserde/regenerate_avro.sh
+++ b/avro-fastserde/regenerate_avro.sh
@@ -29,7 +29,10 @@ AVRO_SCHEMAS_PATH=(
   "src/test/avro/fastserdetest.avsc"
   "src/test/avro/defaultsTest.avsc"
   "src/test/avro/stringableTest.avsc"
+  "src/test/avro/benchmarkSchema.avsc"
 )
+AVRO_SCHEMAS_ROOT_PATH="src/test/avro"
+
 # path to store the generated
 CODE_GEN_PATH="src/test/java"
 
@@ -39,7 +42,9 @@ FULL_CODE_GEN_PATH=(
   "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
   "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
   "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
+  "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
 )
+FULL_CODE_GEN_ROOT_PATH="${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro"
 
 if [[ $# < 1 ]]; then
   echo "Usage: $0 avro_tools_path"
@@ -58,14 +63,14 @@ if [[ $# < 1 ]]; then
   echo ""
   echo "The $0 script uses avro-tools to generate SpecificRecord classes for the Avro schemas stored in:"
   echo ""
-  for path in ${AVRO_SCHEMAS_PATH[@]}; do
-      echo "    $path"
+  for path in `ls ${AVRO_SCHEMAS_ROOT_PATH}/*.avsc`; do
+    echo "    $path"
   done
   echo ""
   echo "The auto-generated classes are purged before each run and then re-generated here:"
   echo ""
-  for path in ${FULL_CODE_GEN_PATH[@]}; do
-      echo "    $path"
+  for path in `ls ${FULL_CODE_GEN_ROOT_PATH}/*.java`; do
+    echo "    $path"
   done
   echo ""
   exit 1
@@ -84,17 +89,16 @@ else
     AVRO_TOOLS_JAR=$AVRO_TOOLS_PATH_PARAM
 fi
 
-echo "Using AVRO_TOOLS_JAR=$AVRO_TOOLS_JAR"
-
-for path in ${FULL_CODE_GEN_PATH[@]}; do
-  rm -f $path
+for file in `ls ${FULL_CODE_GEN_ROOT_PATH}/*.java`; do
+  rm -f ${file}
 done
 
 echo "Finished deleting old files. About to generate new ones..."
 
-for (( i=0; i<${#FULL_CODE_GEN_PATH[@]}; i++ )); do
-  java -jar $AVRO_TOOLS_JAR compile schema ${AVRO_SCHEMAS_PATH[i]} $CODE_GEN_PATH
-  echo "Finished generation for schema path:  ${AVRO_SCHEMAS_PATH[i]}"
+for file in `ls ${AVRO_SCHEMAS_ROOT_PATH}/*.avsc`; do
+  echo ${file}
+  java -jar $AVRO_TOOLS_JAR compile schema ${file} $CODE_GEN_PATH
+  echo "Finished generation for schema path:  ${file}"
 done
 
 echo "Done!"

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/BenchmarkConstants.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/BenchmarkConstants.java
@@ -1,0 +1,21 @@
+package com.linkedin.avro.fastserde;
+
+
+public class BenchmarkConstants {
+  /**
+   * Length of the generated AVRO Arrays
+   */
+  public static final Integer ARRAY_SIZE = 10;
+  /**
+   * Size of the generated random AVRO Primitive Strings
+   */
+  public static final Integer STRING_SIZE = 20;
+  /**
+   * Size of the generated AVRO Maps
+   */
+  public static final Integer MAP_SIZE = 10;
+  /**
+   * Size of the genreted AVRO Primitive Bytes
+   */
+  public static final Integer BYTES_SIZE = 20;
+}

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/FastAvroSerdesBenchmark.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/FastAvroSerdesBenchmark.java
@@ -1,0 +1,110 @@
+package com.linkedin.avro.fastserde;
+
+import com.linkedin.avro.fastserde.generated.avro.BenchmarkSchema;
+import com.linkedin.avro.fastserde.generator.AvroRandomDataGenerator;
+import com.linkedin.avro.fastserde.micro.benchmark.AvroGenericDeserializer;
+import com.linkedin.avro.fastserde.micro.benchmark.AvroGenericSerializer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+
+/**
+ * A benchmark that evaluates the performance of serialize and deserialize of the given Avro Schema and
+ * parameters using original Apache Avro GenericDatumReader/Writer and FastGenericDatumReader/Writer in
+ * different Avro versions
+ *
+ * To run this benchmark:
+ * <code>
+ *   ./gradlew :avro-fastserde:jmh -PUSE_AVRO_14/17/18
+ * </code>
+ *
+ * You also can test by your own AVRO schema by replacing the contents in
+ *   avro-util/avro-fastserde/src/test/avro/benchmarkSchema.avsc
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+//@Fork(value = 1, jvmArgsAppend = {"-XX:+PrintGCDetails", "-Xms16g", "-Xmx16g"})
+//@Threads(10)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+public class FastAvroSerdesBenchmark {
+  private final Random random = new Random();;
+  private final Map<Object, Object> properties = new HashMap<>();
+
+  private byte[] serializedBytes;
+  private GenericData.Record generatedRecord;
+
+  private final Schema benchmarkSchame = BenchmarkSchema.SCHEMA$;
+  private static AvroRandomDataGenerator generator;
+
+  private static AvroGenericSerializer serializer;
+  private static AvroGenericSerializer fastSerializer;
+  private static AvroGenericDeserializer<GenericRecord> deserializer;
+  private static AvroGenericDeserializer<GenericRecord> fastDeserializer;
+
+  public FastAvroSerdesBenchmark() {
+    // load configuration parameters to avro data generator
+    properties.put(AvroRandomDataGenerator.ARRAY_LENGTH_PROP, BenchmarkConstants.ARRAY_SIZE);
+    properties.put(AvroRandomDataGenerator.STRING_LENGTH_PROP, BenchmarkConstants.STRING_SIZE);
+    properties.put(AvroRandomDataGenerator.BYTES_LENGTH_PROP, BenchmarkConstants.BYTES_SIZE);
+    properties.put(AvroRandomDataGenerator.MAP_LENGTH_PROP, BenchmarkConstants.MAP_SIZE);
+    generator = new AvroRandomDataGenerator(benchmarkSchame, random);
+  }
+
+  public byte[] serializeGeneratedRecord(GenericData.Record generatedRecord) throws Exception {
+    AvroGenericSerializer serializer = new AvroGenericSerializer(benchmarkSchame);
+    return serializer.serialize(generatedRecord);
+  }
+
+  @Setup(Level.Trial)
+  public void prepare() throws Exception {
+    // generate avro record and bytes data
+    generatedRecord = (GenericData.Record) generator.generate(properties);
+    serializedBytes = serializeGeneratedRecord(generatedRecord);
+
+    serializer = new AvroGenericSerializer(benchmarkSchame);
+    fastSerializer = new AvroGenericSerializer(new FastGenericDatumWriter<>(benchmarkSchame));
+    deserializer = new AvroGenericDeserializer<>(new GenericDatumReader<>(benchmarkSchame));
+    fastDeserializer = new AvroGenericDeserializer<>(new FastGenericDatumReader<>(benchmarkSchame));
+  }
+
+  @Benchmark
+  public void testAvroSerialization() throws Exception {
+    // use vanilla avro 1.4 encoder, do not use buffer binary encoder
+    serializer.serialize(generatedRecord);
+  }
+
+  @Benchmark
+  public void testFastAvroSerialization() throws Exception {
+    fastSerializer.serialize(generatedRecord);
+  }
+
+  @Benchmark
+  public void testAvroDeserialization() throws Exception {
+    deserializer.deserialize(serializedBytes);
+  }
+
+  @Benchmark
+  public void testFastAvroDeserialization() throws Exception {
+    fastDeserializer.deserialize(serializedBytes);
+  }
+}

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/AvroRandomDataGenerator.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/AvroRandomDataGenerator.java
@@ -1,0 +1,589 @@
+/*
+   Copyright 2018 Confluent Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you may not
+   use this file except in compliance with the License. You may obtain a copy of
+   the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+   License for the specific language governing permissions and limitations under
+   the License.
+ */
+
+package com.linkedin.avro.fastserde.generator;
+
+import com.linkedin.avro.fastserde.generator.GenericRecordBuilder;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+
+
+/**
+ * Generates Java objects according to an {@link Schema Avro Schema}.
+ */
+@SuppressWarnings("WeakerAccess")
+public class AvroRandomDataGenerator {
+
+  /**
+   * The name to use for the top-level JSON property when specifying ARG-specific attributes.
+   */
+  public static final String ARG_PROPERTIES_PROP = "arg.properties";
+
+  /**
+   * The name of the attribute for specifying length of array. Can be given as either
+   * an integral number or an object with at least one of {@link #LENGTH_PROP_MIN} or
+   * {@link #LENGTH_PROP_MAX} specified.
+   */
+  public static final String ARRAY_LENGTH_PROP = "arrayLength";
+  /**
+   * The name of the attribute for specifying length of string. Can be given as either
+   * an integral number or an object with at least one of {@link #LENGTH_PROP_MIN} or
+   * {@link #LENGTH_PROP_MAX} specified.
+   */
+  public static final String STRING_LENGTH_PROP = "stringLength";
+  /**
+   * The name of the attribute for specifying length of bytes. Can be given as either
+   * an integral number or an object with at least one of {@link #LENGTH_PROP_MIN} or
+   * {@link #LENGTH_PROP_MAX} specified.
+   */
+  public static final String BYTES_LENGTH_PROP = "bytesLength";
+  /**
+   * The name of the attribute for specifying length of Map. Can be given as either
+   * an integral number or an object with at least one of {@link #LENGTH_PROP_MIN} or
+   * {@link #LENGTH_PROP_MAX} specified.
+   */
+  public static final String MAP_LENGTH_PROP = "mapLength";
+  /**
+   * The name of the attribute for specifying the minimum length a generated value should have.
+   * Must be given as an integral number greater than or equal to zero.
+   */
+  public static final String LENGTH_PROP_MIN = "min";
+  /**
+   * The name of the attribute for specifying the maximum length a generated value should have.
+   * Must be given as an integral number strictly greater than the value given for
+   * {@link #LENGTH_PROP_MIN}, or strictly greater than zero if none is specified.
+   */
+  public static final String LENGTH_PROP_MAX = "max";
+
+  /**
+   * The name of the attribute for specifying a prefix that generated values should begin with. Will
+   * be prepended to the beginning of any string values generated. Can be used in conjunction with
+   * {@link #SUFFIX_PROP}.
+   */
+  public static final String PREFIX_PROP = "prefix";
+  /**
+   * The name of the attribute for specifying a suffix that generated values should end with. Will
+   * be appended to the end of any string values generated. Can be used in conjunction with
+   * {@link #PREFIX_PROP}.
+   */
+  public static final String SUFFIX_PROP = "suffix";
+
+  /**
+   * The name of the attribute for specifying a possible range of values for numeric types. Must be
+   * given as an object.
+   */
+  public static final String RANGE_PROP = "range";
+  /**
+   * The name of the attribute for specifying the (inclusive) minimum value in a range. Must be
+   * given as a numeric type that is integral if the given schema is as well.
+   */
+  public static final String RANGE_PROP_MIN = "min";
+  /**
+   * The name of the attribute for specifying the (exclusive) maximum value in a range. Must be
+   * given as a numeric type that is integral if the given schema is as well.
+   */
+  public static final String RANGE_PROP_MAX = "max";
+
+  /**
+   * The name of the attribute for specifying the likelihood that the value true is generated for a
+   * boolean schema. Must be given as a floating type in the range [0.0, 1.0].
+   */
+  public static final String ODDS_PROP = "odds";
+
+  private final Schema topLevelSchema;
+  private final Random random;
+
+  /**
+   * Creates a generator out of an already-parsed {@link Schema}.
+   * @param topLevelSchema The schema to generate values for.
+   * @param random The object to use for generating randomness when producing values.
+   */
+  public AvroRandomDataGenerator(Schema topLevelSchema, Random random) {
+    this.topLevelSchema = topLevelSchema;
+    this.random = random;
+  }
+
+  /**
+   * @return The schema that the generator produces values for.
+   */
+  public Schema schema() {
+    return topLevelSchema;
+  }
+
+  /**
+   * Generate an object that matches the given schema and its specified properties.
+   * @return An object whose type corresponds to the top-level schema as follows:
+   * <table summary="Schema Type-to-Java class specifications">
+   *   <tr>
+   *     <th>Schema Type</th>
+   *     <th>Java Class</th>
+   *   </tr>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#ARRAY ARRAY}</td>
+   *     <td>{@link Collection}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#BOOLEAN BOOLEAN}</td>
+   *     <td>{@link Boolean}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#BYTES BYTES}</td>
+   *     <td>{@link ByteBuffer}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#DOUBLE DOUBLE}</td>
+   *     <td>{@link Double}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#ENUM ENUM}</td>
+   *     <td>{@link GenericEnumSymbol}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#FIXED FIXED}</td>
+   *     <td>{@link GenericFixed}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#FLOAT FLOAT}</td>
+   *     <td>{@link Float}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#INT INT}</td>
+   *     <td>{@link Integer}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#LONG LONG}</td>
+   *     <td>{@link Long}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#MAP MAP}</td>
+   *     <td>
+   *       {@link Map}&lt;{@link String}, V&gt; where V is the corresponding Java class for the
+   *       Avro map's values
+   *     </td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#NULL NULL}</td>
+   *     <td>{@link Object} (but will always be null)</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#RECORD RECORD}</td>
+   *     <td>{@link GenericRecord}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#STRING STRING}</td>
+   *     <td>{@link String}</td>
+   *   <tr>
+   *     <td>{@link org.apache.avro.Schema.Type#UNION UNION}</td>
+   *     <td>
+   *       The corresponding Java class for whichever schema is chosen to be generated out of the
+   *       ones present in the given Avro union.
+   *     </td>
+   * </table>
+   */
+  public Object generate(Map propertiesProp) {
+    return generateObject(topLevelSchema, propertiesProp);
+  }
+
+  private Object generateObject(Schema schema,  Map propertiesProp) {
+    switch (schema.getType()) {
+      case ARRAY:
+        return generateArray(schema, propertiesProp);
+      case BOOLEAN:
+        return generateBoolean(propertiesProp);
+      case BYTES:
+        return generateBytes(propertiesProp);
+      case DOUBLE:
+        return generateDouble(propertiesProp);
+      case ENUM:
+        return generateEnumSymbol(schema);
+      case FIXED:
+        return generateFixed(schema);
+      case FLOAT:
+        return generateFloat(propertiesProp);
+      case INT:
+        return generateInt(propertiesProp);
+      case LONG:
+        return generateLong(propertiesProp);
+      case MAP:
+        return generateMap(schema, propertiesProp);
+      case NULL:
+        return generateNull();
+      case RECORD:
+        return generateRecord(schema, propertiesProp);
+      case STRING:
+        return generateString(propertiesProp);
+      case UNION:
+        return generateUnion(schema, propertiesProp);
+      default:
+        throw new RuntimeException("Unrecognized schema type: " + schema.getType());
+    }
+  }
+
+  private Collection<Object> generateArray(Schema schema, Map propertiesProp) {
+    int length = getLengthBounds(propertiesProp, ARRAY_LENGTH_PROP).random();
+    Collection<Object> result = new ArrayList<>(length);
+    for (int i = 0; i < length; i++) {
+      result.add(generateObject(schema.getElementType(), propertiesProp));
+    }
+    return result;
+  }
+
+  private Boolean generateBoolean(Map propertiesProp) {
+    Double odds = getDecimalNumberField(ARG_PROPERTIES_PROP, ODDS_PROP, propertiesProp);
+    if (odds == null) {
+      return random.nextBoolean();
+    } else {
+      if (odds < 0.0 || odds > 1.0) {
+        throw new RuntimeException(String.format(
+            "%s property must be in the range [0.0, 1.0]",
+            ODDS_PROP
+        ));
+      }
+      return random.nextDouble() < odds;
+    }
+  }
+
+  private ByteBuffer generateBytes(Map propertiesProp) {
+    byte[] bytes = new byte[getLengthBounds(propertiesProp.get(BYTES_LENGTH_PROP), BYTES_LENGTH_PROP).random()];
+    random.nextBytes(bytes);
+    return ByteBuffer.wrap(bytes);
+  }
+
+  private Double generateDouble(Map propertiesProp) {
+    Object rangeProp = propertiesProp.get(RANGE_PROP);
+    if (rangeProp != null) {
+      if (rangeProp instanceof Map) {
+        Map rangeProps = (Map) rangeProp;
+        Double rangeMinField = getDecimalNumberField(RANGE_PROP, RANGE_PROP_MIN, rangeProps);
+        Double rangeMaxField = getDecimalNumberField(RANGE_PROP, RANGE_PROP_MAX, rangeProps);
+        double rangeMin = rangeMinField != null ? rangeMinField : -1 * Double.MAX_VALUE;
+        double rangeMax = rangeMaxField != null ? rangeMaxField : Double.MAX_VALUE;
+        if (rangeMin >= rangeMax) {
+          throw new RuntimeException(String.format(
+              "'%s' field must be strictly less than '%s' field in %s property",
+              RANGE_PROP_MIN,
+              RANGE_PROP_MAX,
+              RANGE_PROP
+          ));
+        }
+        return rangeMin + (random.nextDouble() * (rangeMax - rangeMin));
+      } else {
+        throw new RuntimeException(String.format(
+            "%s property must be an object",
+            RANGE_PROP
+        ));
+      }
+    }
+    return random.nextDouble();
+  }
+
+  private GenericEnumSymbol generateEnumSymbol(Schema schema) {
+    List<String> enums = schema.getEnumSymbols();
+    return AvroCompatibilityHelper.newEnumSymbol(schema, enums.get(random.nextInt(enums.size())));
+  }
+
+  private GenericFixed generateFixed(Schema schema) {
+    byte[] bytes = new byte[schema.getFixedSize()];
+    random.nextBytes(bytes);
+    return AvroCompatibilityHelper.newFixedField(schema, bytes);
+  }
+
+  private Float generateFloat(Map propertiesProp) {
+    Object rangeProp = propertiesProp.get(RANGE_PROP);
+    if (rangeProp != null) {
+      if (rangeProp instanceof Map) {
+        Map rangeProps = (Map) rangeProp;
+        Float rangeMinField = getFloatNumberField(
+            RANGE_PROP,
+            RANGE_PROP_MIN,
+            rangeProps
+        );
+        Float rangeMaxField = getFloatNumberField(
+            RANGE_PROP,
+            RANGE_PROP_MAX,
+            rangeProps
+        );
+        float rangeMin = Optional.ofNullable(rangeMinField).orElse(-1 * Float.MAX_VALUE);
+        float rangeMax = Optional.ofNullable(rangeMaxField).orElse(Float.MAX_VALUE);
+        if (rangeMin >= rangeMax) {
+          throw new RuntimeException(String.format(
+              "'%s' field must be strictly less than '%s' field in %s property",
+              RANGE_PROP_MIN,
+              RANGE_PROP_MAX,
+              RANGE_PROP
+          ));
+        }
+        return rangeMin + (random.nextFloat() * (rangeMax - rangeMin));
+      }
+    }
+    return random.nextFloat();
+  }
+
+  private Integer generateInt(Map propertiesProp) {
+    Object rangeProp = propertiesProp.get(RANGE_PROP);
+    if (rangeProp != null) {
+      if (rangeProp instanceof Map) {
+        Map rangeProps = (Map) rangeProp;
+        Integer rangeMinField = getIntegerNumberField(RANGE_PROP, RANGE_PROP_MIN, rangeProps);
+        Integer rangeMaxField = getIntegerNumberField(RANGE_PROP, RANGE_PROP_MAX, rangeProps);
+        int rangeMin = Optional.ofNullable(rangeMinField).orElse(Integer.MIN_VALUE);
+        int rangeMax = Optional.ofNullable(rangeMaxField).orElse(Integer.MAX_VALUE);
+        if (rangeMin >= rangeMax) {
+          throw new RuntimeException(String.format(
+              "'%s' field must be strictly less than '%s' field in %s property",
+              RANGE_PROP_MIN,
+              RANGE_PROP_MAX,
+              RANGE_PROP
+          ));
+        }
+        return rangeMin + ((int) (random.nextDouble() * (rangeMax - rangeMin)));
+      }
+    }
+    return random.nextInt();
+  }
+
+  private Long generateLong(Map propertiesProp) {
+    Object rangeProp = propertiesProp.get(RANGE_PROP);
+    if (rangeProp != null) {
+      if (rangeProp instanceof Map) {
+        Map rangeProps = (Map) rangeProp;
+        Long rangeMinField = getIntegralNumberField(RANGE_PROP, RANGE_PROP_MIN, rangeProps);
+        Long rangeMaxField = getIntegralNumberField(RANGE_PROP, RANGE_PROP_MAX, rangeProps);
+        long rangeMin = Optional.ofNullable(rangeMinField).orElse(Long.MIN_VALUE);
+        long rangeMax = Optional.ofNullable(rangeMaxField).orElse(Long.MAX_VALUE);
+        if (rangeMin >= rangeMax) {
+          throw new RuntimeException(String.format(
+              "'%s' field must be strictly less than '%s' field in %s property",
+              RANGE_PROP_MIN,
+              RANGE_PROP_MAX,
+              RANGE_PROP
+          ));
+        }
+        return rangeMin + (((long) (random.nextDouble() * (rangeMax - rangeMin))));
+      }
+    }
+    return random.nextLong();
+  }
+
+  private Map<String, Object> generateMap(Schema schema, Map propertiesProp) {
+    Map<String, Object> result = new HashMap<>();
+    int length = getLengthBounds(propertiesProp, MAP_LENGTH_PROP).random();
+    for (int i = 0; i < length; i++) {
+      result.put(generateRandomString(5), generateObject(schema.getValueType(), propertiesProp));
+    }
+    return result;
+  }
+
+  private Object generateNull() {
+    return null;
+  }
+
+  private GenericRecord generateRecord(Schema schema, Map propertyProps) {
+    GenericRecordBuilder builder = new GenericRecordBuilder(schema);
+    for (Schema.Field field : schema.getFields()) {
+      builder.set(field, generateObject(field.schema(), propertyProps));
+    }
+    return builder.build();
+  }
+
+  private String generateRandomString(int length) {
+    byte[] bytes = new byte[length];
+    for (int i = 0; i < length; i++) {
+      bytes[i] = (byte) random.nextInt(128);
+    }
+    return new String(bytes, StandardCharsets.US_ASCII);
+  }
+
+  private String generateString(Map propertiesProp) {
+
+    String result = generateRandomString(getLengthBounds(propertiesProp, STRING_LENGTH_PROP).random());
+
+    return  prefixAndSuffixString(result, propertiesProp);
+  }
+
+  private String prefixAndSuffixString(String result, Map propertiesProp) {
+    Object prefixProp = propertiesProp.get(PREFIX_PROP);
+    if (prefixProp != null && !(prefixProp instanceof String)) {
+      throw new RuntimeException(String.format("%s property must be a string", PREFIX_PROP));
+    }
+    String prefix = prefixProp != null ? (String) prefixProp : "";
+
+    Object suffixProp = propertiesProp.get(SUFFIX_PROP);
+    if (suffixProp != null && !(suffixProp instanceof String)) {
+      throw new RuntimeException(String.format("%s property must be a string", SUFFIX_PROP));
+    }
+    String suffix = suffixProp != null ? (String) suffixProp : "";
+
+    return prefix + result + suffix;
+  }
+
+  // try to generate not null field for Union field
+  private Object generateUnion(Schema schema, Map propertiesProp) {
+    List<Schema> schemas = schema.getTypes();
+    int count = 0;
+    Object generatedUnionObject = null;
+    while (count < 5) {
+      generatedUnionObject = generateObject(schemas.get(random.nextInt(schemas.size())), propertiesProp);
+      if (generatedUnionObject != null) {
+        break;
+      }
+      count++;
+    }
+    return generatedUnionObject;
+  }
+
+  private LengthBounds getLengthBounds(Map propertiesProp, String lengthKey) {
+    return getLengthBounds(propertiesProp.get(lengthKey), lengthKey);
+  }
+
+  private LengthBounds getLengthBounds(Object lengthProp, String lengthKey) {
+    if (lengthProp == null) {
+      return new LengthBounds();
+    } else if (lengthProp instanceof Integer) {
+      Integer length = (Integer) lengthProp;
+      if (length < 0) {
+        throw new RuntimeException(String.format(
+            "when given as integral number, %s property cannot be negative",
+            lengthKey
+        ));
+      }
+      return new LengthBounds(length);
+    } else if (lengthProp instanceof Map) {
+      Map lengthProps = (Map) lengthProp;
+      Integer minLength = getIntegerNumberField(lengthKey, LENGTH_PROP_MIN, lengthProps);
+      Integer maxLength = getIntegerNumberField(lengthKey, LENGTH_PROP_MAX, lengthProps);
+      if (minLength == null && maxLength == null) {
+        throw new RuntimeException(String.format(
+            "%s property must contain at least one of '%s' or '%s' fields when given as object",
+            lengthKey,
+            LENGTH_PROP_MIN,
+            LENGTH_PROP_MAX
+        ));
+      }
+      minLength = minLength != null ? minLength : 0;
+      maxLength = maxLength != null ? maxLength : Integer.MAX_VALUE;
+      if (minLength < 0) {
+        throw new RuntimeException(String.format(
+            "%s field of %s property cannot be negative",
+            LENGTH_PROP_MIN,
+            lengthKey
+        ));
+      }
+      if (maxLength <= minLength) {
+        throw new RuntimeException(String.format(
+            "%s field must be strictly greater than %s field for %s property",
+            LENGTH_PROP_MAX,
+            LENGTH_PROP_MIN,
+            lengthKey
+        ));
+      }
+      return new LengthBounds(minLength, maxLength);
+    } else {
+      throw new RuntimeException(String.format(
+          "%s property must either be an integral number or an object, was %s instead",
+          lengthKey,
+          lengthProp.getClass().getName()
+      ));
+    }
+  }
+
+  private Integer getIntegerNumberField(String property, String field, Map propsMap) {
+    Long result = getIntegralNumberField(property, field, propsMap);
+    if (result != null && (result < Integer.MIN_VALUE || result > Integer.MAX_VALUE)) {
+      throw new RuntimeException(String.format(
+          "'%s' field of %s property must be a valid int for int schemas",
+          field,
+          property
+      ));
+    }
+    return result != null ? result.intValue() : null;
+  }
+
+  private Long getIntegralNumberField(String property, String field, Map propsMap) {
+    Object result = propsMap.get(field);
+    if (result == null || result instanceof Long) {
+      return (Long) result;
+    } else if (result instanceof Integer) {
+      return ((Integer) result).longValue();
+    } else {
+      throw new RuntimeException(String.format(
+          "'%s' field of %s property must be an integral number, was %s instead",
+          field,
+          property,
+          result.getClass().getName()
+      ));
+    }
+  }
+
+  private Float getFloatNumberField(String property, String field, Map propsMap) {
+    Double result = getDecimalNumberField(property, field, propsMap);
+    if (result != null && (result > Float.MAX_VALUE || result < -1 * Float.MAX_VALUE)) {
+      throw new RuntimeException(String.format(
+          "'%s' field of %s property must be a valid float for float schemas",
+          field,
+          property
+      ));
+    }
+    return result != null ? result.floatValue() : null;
+  }
+
+  private Double getDecimalNumberField(String property, String field, Map propsMap) {
+    Object result = propsMap.get(field);
+    if (result == null || result instanceof Double) {
+      return (Double) result;
+    } else if (result instanceof Float) {
+      return ((Float) result).doubleValue();
+    } else if (result instanceof Integer) {
+      return ((Integer) result).doubleValue();
+    } else if (result instanceof Long) {
+      return ((Long) result).doubleValue();
+    } else {
+      throw new RuntimeException(String.format(
+          "'%s' field of %s property must be a number, was %s instead",
+          field,
+          property,
+          result.getClass().getName()
+      ));
+    }
+  }
+
+  private class LengthBounds {
+    public static final int DEFAULT_MIN = 8;
+    public static final int DEFAULT_MAX = 16;
+
+    private final int min;
+    private final int max;
+
+    public LengthBounds(int min, int max) {
+      this.min = min;
+      this.max = max;
+    }
+
+    public LengthBounds(int exact) {
+      this(exact, exact + 1);
+    }
+
+    public LengthBounds() {
+      this(DEFAULT_MIN, DEFAULT_MAX);
+    }
+
+    public int random() {
+      return min + random.nextInt(max - min);
+    }
+  }
+
+}

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/GenericRecordBuilder.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/GenericRecordBuilder.java
@@ -1,0 +1,141 @@
+//
+// Source code recreated from a .class file by IntelliJ IDEA
+// (powered by Fernflower decompiler)
+//
+
+package com.linkedin.avro.fastserde.generator;
+
+import java.io.IOException;
+import java.util.Iterator;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import com.linkedin.avro.fastserde.generator.RecordBuilderBase;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericData.Record;
+
+public class GenericRecordBuilder extends RecordBuilderBase<Record> {
+  private final Record record;
+
+  public GenericRecordBuilder(Schema schema) {
+    super(schema, GenericData.get());
+    this.record = new Record(schema);
+  }
+
+  public Object get(String fieldName) {
+    return this.get(this.schema().getField(fieldName));
+  }
+
+  public Object get(Field field) {
+    return this.get(field.pos());
+  }
+
+  protected Object get(int pos) {
+    return this.record.get(pos);
+  }
+
+  public GenericRecordBuilder set(String fieldName, Object value) {
+    return this.set(this.schema().getField(fieldName), value);
+  }
+
+  public GenericRecordBuilder set(Field field, Object value) {
+    return this.set(field, field.pos(), value);
+  }
+
+  protected GenericRecordBuilder set(int pos, Object value) {
+    return this.set(this.fields()[pos], pos, value);
+  }
+
+  private GenericRecordBuilder set(Field field, int pos, Object value) {
+    this.record.put(pos, value);
+    this.fieldSetFlags()[pos] = true;
+    return this;
+  }
+
+  public boolean has(String fieldName) {
+    return this.has(this.schema().getField(fieldName));
+  }
+
+  public boolean has(Field field) {
+    return this.has(field.pos());
+  }
+
+  protected boolean has(int pos) {
+    return this.fieldSetFlags()[pos];
+  }
+
+  public GenericRecordBuilder clear(String fieldName) {
+    return this.clear(this.schema().getField(fieldName));
+  }
+
+  public GenericRecordBuilder clear(Field field) {
+    return this.clear(field.pos());
+  }
+
+  protected GenericRecordBuilder clear(int pos) {
+    this.record.put(pos, (Object)null);
+    this.fieldSetFlags()[pos] = false;
+    return this;
+  }
+
+  public Record build() {
+    Record record;
+    try {
+      record = new Record(this.schema());
+    } catch (Exception var9) {
+      throw new AvroRuntimeException(var9);
+    }
+
+    Field[] arr$ = this.fields();
+    int len$ = arr$.length;
+
+    for(int i$ = 0; i$ < len$; ++i$) {
+      Field field = arr$[i$];
+
+      Object value;
+      try {
+        value = this.getWithDefault(field);
+      } catch (IOException var8) {
+        throw new AvroRuntimeException(var8);
+      }
+
+      if (value != null) {
+        record.put(field.pos(), value);
+      }
+    }
+
+    return record;
+  }
+
+  private Object getWithDefault(Field field) throws IOException {
+    return this.fieldSetFlags()[field.pos()] ? this.record.get(field.pos()) : this.defaultValue(field);
+  }
+
+  public int hashCode() {
+    int prime = 1;
+    int result = super.hashCode();
+    result = 31 * result + (this.record == null ? 0 : this.record.hashCode());
+    return result;
+  }
+
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (!super.equals(obj)) {
+      return false;
+    } else if (this.getClass() != obj.getClass()) {
+      return false;
+    } else {
+      GenericRecordBuilder other = (GenericRecordBuilder)obj;
+      if (this.record == null) {
+        if (other.record != null) {
+          return false;
+        }
+      } else if (!this.record.equals(other.record)) {
+        return false;
+      }
+
+      return true;
+    }
+  }
+}

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/RecordBuilder.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/RecordBuilder.java
@@ -1,0 +1,10 @@
+//
+// Source code recreated from a .class file by IntelliJ IDEA
+// (powered by Fernflower decompiler)
+//
+
+package com.linkedin.avro.fastserde.generator;
+
+public interface RecordBuilder<T> {
+  T build();
+}

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/RecordBuilderBase.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/RecordBuilderBase.java
@@ -1,0 +1,109 @@
+//
+// Source code recreated from a .class file by IntelliJ IDEA
+// (powered by Fernflower decompiler)
+//
+
+package com.linkedin.avro.fastserde.generator;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+
+public abstract class RecordBuilderBase<T extends IndexedRecord> implements RecordBuilder<T> {
+  private static final Field[] EMPTY_FIELDS = new Field[0];
+  private final Schema schema;
+  private final Field[] fields;
+  private final boolean[] fieldSetFlags;
+  private final GenericData data;
+
+  protected final Schema schema() {
+    return this.schema;
+  }
+
+  protected final Field[] fields() {
+    return this.fields;
+  }
+
+  protected final boolean[] fieldSetFlags() {
+    return this.fieldSetFlags;
+  }
+
+  protected final GenericData data() {
+    return this.data;
+  }
+
+  protected RecordBuilderBase(Schema schema, GenericData data) {
+    this.schema = schema;
+    this.data = data;
+    this.fields = (Field[])((Field[])schema.getFields().toArray(EMPTY_FIELDS));
+    this.fieldSetFlags = new boolean[this.fields.length];
+  }
+
+  protected RecordBuilderBase(RecordBuilderBase<T> other, GenericData data) {
+    this.schema = other.schema;
+    this.data = data;
+    this.fields = (Field[])((Field[])this.schema.getFields().toArray(EMPTY_FIELDS));
+    this.fieldSetFlags = new boolean[other.fieldSetFlags.length];
+    System.arraycopy(other.fieldSetFlags, 0, this.fieldSetFlags, 0, this.fieldSetFlags.length);
+  }
+
+  protected static boolean isValidValue(Field f, Object value) {
+    if (value != null) {
+      return true;
+    } else {
+      Schema schema = f.schema();
+      Type type = schema.getType();
+      if (type == Type.NULL) {
+        return true;
+      } else {
+        if (type == Type.UNION) {
+          Iterator i$ = schema.getTypes().iterator();
+
+          while(i$.hasNext()) {
+            Schema s = (Schema)i$.next();
+            if (s.getType() == Type.NULL) {
+              return true;
+            }
+          }
+        }
+
+        return false;
+      }
+    }
+  }
+
+  protected Object defaultValue(Field field) throws IOException {
+    return null;
+  }
+
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj == null) {
+      return false;
+    } else if (this.getClass() != obj.getClass()) {
+      return false;
+    } else {
+      RecordBuilderBase other = (RecordBuilderBase)obj;
+      if (!Arrays.equals(this.fieldSetFlags, other.fieldSetFlags)) {
+        return false;
+      } else {
+        if (this.schema == null) {
+          if (other.schema != null) {
+            return false;
+          }
+        } else if (!this.schema.equals(other.schema)) {
+          return false;
+        }
+
+        return true;
+      }
+    }
+  }
+}

--- a/avro-fastserde/src/test/avro/benchmarkSchema.avsc
+++ b/avro-fastserde/src/test/avro/benchmarkSchema.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "BenchmarkSchema",
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "doc": "JMH micro benchmark schema template",
+  "fields": [
+    {
+      "name": "testArray",
+      "type": {
+        "type": "array",
+        "items": "float"
+      }
+    }
+  ]
+}

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/micro/benchmark/AvroGenericSerializer.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/micro/benchmark/AvroGenericSerializer.java
@@ -16,7 +16,7 @@ public class AvroGenericSerializer<K> {
     this(new GenericDatumWriter<>(schema));
   }
 
-  protected AvroGenericSerializer(DatumWriter datumWriter) {
+  public AvroGenericSerializer(DatumWriter datumWriter) {
     this.datumWriter = datumWriter;
   }
 


### PR DESCRIPTION
Use JMH suite benchmark performance of vanilla avro and fast-serde serialization and deserialization. It ueses AvroRandomDataGenerator to generate avro data according to specified Schema.

To run this benchmark: `./gradlew :avro-fastserde:jmh -PUSE_AVRO_14/17/18`

Then it will benchmark the average serdes latency and print GC details of vanilla Avro and fast-serdes.

You also can test your own AVRO schema by replacing the schema in
`avro-util/avro-fastserde/src/test/avro/benchmarkSchema.avsc`

JMH benchmark is very helpful for -
1. Benchmark the serdes latency reduction of customer schema brought by applying avro-fastserde
2. Investigate in the performance improvement and bottleneck of different schema pattern and avro version

@gaojieliu @FelixGV 