### PR TITLE
Performance improvement of PrimitiveFloatList by lazy deserialization

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
@@ -1,0 +1,57 @@
+package com.linkedin.avro.fastserde;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class CompositeByteBuffer {
+  private int byteBufferCount;
+  private List<ByteBuffer> byteBuffers;
+
+  public CompositeByteBuffer() {
+    byteBuffers = new ArrayList<>(2);
+  }
+
+  public ByteBuffer allocate(int index, int size) {
+    ByteBuffer byteBuffer;
+
+    // Check if we can reuse the old record's byteBuffers, else allocate a new one.
+    if (byteBuffers.size() > index && byteBuffers.get(index).capacity() > size) {
+      byteBuffer = byteBuffers.get(index);
+      byteBuffer.clear();
+    } else {
+      byteBuffer = ByteBuffer.allocate((int)size).order(ByteOrder.LITTLE_ENDIAN);
+    }
+    if (index < byteBuffers.size()) {
+      byteBuffers.set(index, byteBuffer);
+    } else {
+      byteBuffers.add(byteBuffer);
+    }
+    return byteBuffer;
+  }
+
+  public void clear() {
+    for (ByteBuffer byteBuffer : byteBuffers)  {
+      byteBuffer.clear();
+    }
+  }
+
+  public void setByteBufferCount(int count) {
+    byteBufferCount = count;
+  }
+
+  public float readFloat(int i) {
+    return byteBuffers.get(0).getFloat(i*4);
+  }
+  public void setArray(float[] array) {
+    int k = 0;
+    for (int i = 0; i < byteBufferCount; i++) {
+      ByteBuffer byteBuffer = byteBuffers.get(i);
+      for (int j = 0; j < byteBuffer.limit(); j += Float.BYTES) {
+        array[k++] = byteBuffer.getFloat(j);
+      }
+    }
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
@@ -42,9 +42,6 @@ public class CompositeByteBuffer {
     byteBufferCount = count;
   }
 
-  public float readFloat(int i) {
-    return byteBuffers.get(0).getFloat(i*4);
-  }
   public void setArray(float[] array) {
     int k = 0;
     for (int i = 0; i < byteBufferCount; i++) {

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
@@ -1,9 +1,13 @@
 package com.linkedin.avro.fastserde;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericData;
@@ -25,21 +29,32 @@ import org.apache.avro.io.Decoder;
  * - It re-implements {@link #compareTo(GenericArray)}, {@link #equals(Object)} and {@link #hashCode()}
  *   in order to leverage the primitive types, rather than causing unintended boxing.
  *
- * TODO: Provide arrays for other primitive types.
+ *   Using ByteBuffer to speed up float-array deserialization: We allocate ByteBuffer to store the raw bytes from
+ *   BinaryDecoder and deserialize them only during array element access. We cache the results into the elements array
+ *   after the first get access of the array so that sub-sequent array access are fast.
+ *
+ *   TODO: Provide arrays for other primitive types.
  */
 public class PrimitiveFloatList extends AbstractList<Float>
     implements GenericArray<Float>, Comparable<GenericArray<Float>> {
   private static final float[] EMPTY = new float[0];
+  private static final int FLOAT_SIZE = Float.BYTES;
   private static final Schema FLOAT_SCHEMA = Schema.create(Schema.Type.FLOAT);
   private static final Schema SCHEMA = Schema.createArray(FLOAT_SCHEMA);
-
   private int size;
+  private int byteBufferCount;
   private float[] elements = EMPTY;
+  private List<ByteBuffer> byteBuffers;
+  private boolean isCached = false;
 
   public PrimitiveFloatList(int capacity) {
     if (capacity != 0) {
       elements = new float[capacity];
     }
+  }
+
+  public PrimitiveFloatList() {
+    byteBuffers = new ArrayList<>(2);
   }
 
   public PrimitiveFloatList(Collection<Float> c) {
@@ -60,44 +75,73 @@ public class PrimitiveFloatList extends AbstractList<Float>
    * @throws IOException on io errors
    */
   public static Object readPrimitiveFloatArray(Object old, Decoder in) throws IOException {
-    long l = in.readArrayStart();
-    if (l > 0) {
-      PrimitiveFloatList array = (PrimitiveFloatList) newPrimitiveFloatArray(old, (int) l);
+    long length = in.readArrayStart();
+    long totalLength = 0;
+
+    if (length > 0) {
+      PrimitiveFloatList array = (PrimitiveFloatList) newPrimitiveFloatArray(old);
+      int cnt = 0;
+
       do {
-        for (long i = 0; i < l; i++) {
-          array.addPrimitive(in.readFloat());
+        ByteBuffer byteBuffer;
+        // Allocate ByeBuffer of size array length * Float.BYTES to hold the array values
+        if (array.byteBuffers.size() > cnt && (array.byteBuffers.get(cnt).limit() > (length * FLOAT_SIZE))) {
+          byteBuffer = array.byteBuffers.get(cnt);
+          byteBuffer.clear();
+        } else {
+          byteBuffer = ByteBuffer.allocate((int)length * FLOAT_SIZE).order(ByteOrder.LITTLE_ENDIAN);
         }
-        l = in.arrayNext();
-      } while (l > 0);
+        in.readFixed(byteBuffer.array(), 0, (int)(length * FLOAT_SIZE));
+        array.byteBuffers.add(cnt++, byteBuffer);
+        totalLength += length;
+        length = in.arrayNext();
+      } while (length > 0);
+
+      array.byteBufferCount = cnt;
+      setupElements(array, (int)totalLength);
       return array;
     } else {
-      return newPrimitiveFloatArray(old, 0);
+      return new PrimitiveFloatList(0);
     }
   }
 
+  private static void setupElements(PrimitiveFloatList list, int total_size) {
+    if (list.elements.length != 0) {
+      if (total_size <= list.getCapacity()) {
+        // reuse the float array directly
+        list.clear();
+      } else {
+        list.resizeAndClear(total_size);
+      }
+      list.size = total_size;
+      return;
+    }
+    list.elements = new float[total_size];
+    list.size = total_size;
+  }
+
   /**
-   * @param expected {@link Schema} to inspect
-   * @return true if the {@code expected} SCHEMA is of the right type to decode as a {@link PrimitiveFloatList}
-   *         false otherwise
-   */
+     * @param expected {@link Schema} to inspect
+     * @return true if the {@code expected} SCHEMA is of the right type to decode as a {@link PrimitiveFloatList}
+     *         false otherwise
+     */
   public static boolean isFloatArray(Schema expected) {
     return expected != null && Schema.Type.ARRAY.equals(expected.getType()) && FLOAT_SCHEMA.equals(
         expected.getElementType());
   }
 
-  private static Object newPrimitiveFloatArray(Object old, int size) {
+  private static Object newPrimitiveFloatArray(Object old) {
     if (old instanceof PrimitiveFloatList) {
       PrimitiveFloatList oldFloatList = (PrimitiveFloatList) old;
-      if (size <= oldFloatList.getCapacity()) {
-        // reuse the float array directly
-        oldFloatList.clear();
-        return old;
-      } else {
-        oldFloatList.resizeAndClear(size);
-        return oldFloatList;
+      for (ByteBuffer byteBuffer : oldFloatList.byteBuffers)  {
+        byteBuffer.clear();
       }
+      oldFloatList.isCached = false;
+      oldFloatList.size = 0;
+      return oldFloatList;
     } else {
-      return new PrimitiveFloatList(size);
+      // Just a place holder, will set up the elements later.
+      return new PrimitiveFloatList();
     }
   }
 
@@ -137,7 +181,9 @@ public class PrimitiveFloatList extends AbstractList<Float>
 
       @Override
       public Float next() {
-        return elements[position++];
+        float f = getPrimitive(position);
+        position++;
+        return f;
       }
 
       @Override
@@ -151,6 +197,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
     if (i >= size) {
       throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
     }
+    cacheFromByteBuffer();
     return elements[i];
   }
 
@@ -167,6 +214,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
    * @return true?
    */
   public boolean addPrimitive(float o) {
+    cacheFromByteBuffer();
     if (size == elements.length) {
       float[] newElements = new float[(size * 3) / 2 + 1];
       System.arraycopy(elements, 0, newElements, 0, size);
@@ -186,6 +234,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
     if (location > size || location < 0) {
       throw new IndexOutOfBoundsException("Index " + location + " out of bounds.");
     }
+    cacheFromByteBuffer();
     if (size == elements.length) {
       float[] newElements = new float[(size * 3) / 2 + 1];
       System.arraycopy(elements, 0, newElements, 0, size);
@@ -201,6 +250,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
     if (i >= size) {
       throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
     }
+    cacheFromByteBuffer();
     Float response = elements[i];
     elements[i] = o;
 
@@ -212,6 +262,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
     if (i >= size) {
       throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
     }
+    cacheFromByteBuffer();
     Float result = elements[i];
     --size;
     System.arraycopy(elements, i + 1, elements, i, (size - i));
@@ -219,7 +270,26 @@ public class PrimitiveFloatList extends AbstractList<Float>
     return result;
   }
 
+  private void cacheFromByteBuffer() {
+    if (isCached) {
+      return;
+    }
+    synchronized (this) {
+      if (!isCached) {
+        for (int i = 0; i < byteBufferCount; i++) {
+          ByteBuffer byteBuffer = byteBuffers.get(i);
+          int length = byteBuffer.limit() >> 2;
+          for (int j = 0; j < length; j++) {
+            elements[j] = byteBuffer.getFloat(j * FLOAT_SIZE);
+          }
+        }
+        isCached = true;
+      }
+    }
+  }
+
   public float peekPrimitive() {
+    cacheFromByteBuffer();
     return (size < elements.length) ? elements[size] : null;
   }
 
@@ -230,6 +300,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
 
   @Override
   public int compareTo(GenericArray<Float> that) {
+    cacheFromByteBuffer();
     if (that instanceof PrimitiveFloatList) {
       PrimitiveFloatList thatPrimitiveList = (PrimitiveFloatList) that;
       if (this.size == thatPrimitiveList.size) {
@@ -253,6 +324,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
 
   @Override
   public void reverse() {
+    cacheFromByteBuffer();
     int left = 0;
     int right = elements.length - 1;
 
@@ -283,6 +355,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
 
   @Override
   public boolean equals(Object o) {
+    cacheFromByteBuffer();
     if (o instanceof GenericArray) {
       return compareTo((GenericArray) o) == 0;
     } else {
@@ -292,6 +365,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
 
   @Override
   public int hashCode() {
+    cacheFromByteBuffer();
     int hashCode = 1;
     for (int i = 0; i < this.size; i++) {
       hashCode = 31 * hashCode + Float.hashCode(elements[i]);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
@@ -43,7 +43,6 @@ import static com.linkedin.avro.fastserde.FastSerdeTestsSupport.*;
 
 
 public class FastDeserializerDefaultsTest {
-
   private File tempDir;
   private ClassLoader classLoader;
 
@@ -82,7 +81,7 @@ public class FastDeserializerDefaultsTest {
   }
 
   @Test
-  public void testFastFloatArraySerDes() throws IOException {
+  public void testFastFloatArraySerDes()  {
     int array_size = 2500, iteration = 100_000;
     long total = 0, endTime, startTime, w = 0;
     String schemaString = "{\"type\":\"record\",\"name\":\"KeyRecord\",\"fields\":[{\"name\":\"name\",\"type\":\"string\",\"doc\":\"name field\"}, {\"name\":\"inventory\", \"type\" : {  \"type\" : \"array\", \"items\" : \"float\" }}] }";
@@ -149,10 +148,8 @@ public class FastDeserializerDefaultsTest {
 
       List<Float> list = (List<Float>) (testRecord).get(1);
       w += list.get(0);
-
-      int l = 0;
       for (Float aFloat : list) {
-        Assert.assertEquals(l++, (int)aFloat.floatValue());
+        w += aFloat;
       }
       total += (after - before);
     }

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
@@ -193,6 +193,7 @@ public class FastDeserializerGeneratorForReuseTest {
     GenericRecord deserRecord = deserializer.deserialize(getDecoder(serializedBytes));
 
     // Generate a different record
+    // new record array length larger than reuse record.
     GenericData.Record record1 = new GenericData.Record(oldRecordSchema);
     record1.put("name", "test1");
     arrayList.add((float)30);
@@ -203,6 +204,7 @@ public class FastDeserializerGeneratorForReuseTest {
     List<Float> list = (List<Float>)genericRecord.get(1);
     Assert.assertEquals(list.size(), 3);
 
+    // new record array length shorter than reuse record.
     arrayList.clear();
     arrayList.add((float)10);
     record1.put("inventory", arrayList);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
@@ -156,9 +156,10 @@ public class FastDeserializerGeneratorForReuseTest {
     // Generate a different record
     GenericRecord reuseRecord = newComplicateRecord('1');
 
+
     GenericRecord deserializedRecordWithFastAvro = deserializer.deserialize(getDecoder(serializedBytes));
     GenericRecord deserializedRecordWithFastAvroWithReuse =
-        deserializer.deserialize(reuseRecord, getDecoder(serializedBytes));
+        deserializer.deserialize(deserializedRecordWithFastAvro, getDecoder(serializedBytes));
     compareTwoRecords(deserializedRecordWithFastAvro, deserializedRecordWithFastAvroWithReuse);
 
     DatumReader datumReader = new GenericDatumReader(COMPLICATE_SCHEMA);
@@ -170,5 +171,45 @@ public class FastDeserializerGeneratorForReuseTest {
         (GenericRecord) datumReader.read(reuseRecord, getDecoder(serializedBytes));
     compareTwoRecords(deserializedRecordWithFastAvro, deserializedRecordWithRegularAvro);
     compareTwoRecords(deserializedRecordWithFastAvro, deserializedRecordWithRegularAvroWithReuse);
+  }
+
+  @Test(groups = {"deserializationTest"})
+  public void testFastGenericDeserializerPrimitFloatList() throws Exception {
+    String schemaString = "{\"type\":\"record\",\"name\":\"KeyRecord\",\"fields\":[{\"name\":\"name\",\"type\":\"string\",\"doc\":\"name field\"}, {\"name\":\"inventory\", \"type\" : {  \"type\" : \"array\", \"items\" : \"float\" }}] }";
+
+    Schema oldRecordSchema = Schema.parse(schemaString);
+    FastSerdeCache cache = FastSerdeCache.getDefaultInstance();
+    FastDeserializer<GenericRecord> deserializer =
+        (FastDeserializer<GenericRecord>) cache.buildFastGenericDeserializer(oldRecordSchema, oldRecordSchema);
+
+    GenericData.Record record = new GenericData.Record(oldRecordSchema);
+    ArrayList<Float> arrayList = new ArrayList();
+    arrayList.add((float)10);
+    arrayList.add((float)20);
+
+    record.put("name", "test");
+    record.put("inventory", arrayList);
+    byte[] serializedBytes = serialize(record, oldRecordSchema);
+    GenericRecord deserRecord = deserializer.deserialize(getDecoder(serializedBytes));
+
+    // Generate a different record
+    GenericData.Record record1 = new GenericData.Record(oldRecordSchema);
+    record1.put("name", "test1");
+    arrayList.add((float)30);
+    record1.put("inventory", arrayList);
+    serializedBytes = serialize(record1, oldRecordSchema);
+    // generate a record to reuse bytebuffer
+    GenericRecord genericRecord = deserializer.deserialize(deserRecord, getDecoder(serializedBytes));
+    List<Float> list = (List<Float>)genericRecord.get(1);
+    Assert.assertEquals(list.size(), 3);
+
+    arrayList.clear();
+    arrayList.add((float)10);
+    record1.put("inventory", arrayList);
+    serializedBytes = serialize(record1, oldRecordSchema);
+    genericRecord = deserializer.deserialize(deserRecord, getDecoder(serializedBytes));
+    list = (List<Float>)genericRecord.get(1);
+    Assert.assertEquals(list.size(), 1);
+
   }
 }


### PR DESCRIPTION
Improving the deserialization performance of PrimitiveFloatList. 
1. Using ByteBuffer instead of byte[] . ByeBuffer#getFloat has faster performance than avro readFloat.
2. I am moving the deserialization to array access time only, so that clients can deserialize the records extremely fast. The full deserialization happens only when client tries to access array element. Also cache the deserialized elements into the float array after the first access so later accesses will not see any impact.
Regular fast-avro performance of 1M records of 10kb sized float array:  ~18s
Using the lazy deserialization using ByteBuffer: ~ 2s