### PR TITLE
Initialize ByteBuffer for PrimitiveFloatList List<Float> interface usage

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 
@@ -10,8 +11,8 @@ public class CompositeByteBuffer {
   private int byteBufferCount;
   private List<ByteBuffer> byteBuffers;
 
-  public CompositeByteBuffer() {
-    byteBuffers = new ArrayList<>(2);
+  public CompositeByteBuffer(boolean createEmpty) {
+    byteBuffers = createEmpty ? Collections.emptyList() : new ArrayList<>(2);
   }
 
   public ByteBuffer allocate(int index, int size) {

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/PrimitiveFloatList.java
@@ -48,10 +48,8 @@ public class PrimitiveFloatList extends AbstractList<Float>
     if (capacity != 0) {
       elements = new float[capacity];
     }
-  }
-
-  public PrimitiveFloatList() {
-    byteBuffer = new CompositeByteBuffer();
+    // create empty ByteBuffer if capacity != 0 ( List<Float> interface usage case)
+    byteBuffer = new CompositeByteBuffer(capacity != 0);
   }
 
   public PrimitiveFloatList(Collection<Float> c) {
@@ -59,6 +57,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
       elements = new float[c.size()];
       addAll(c);
     }
+    byteBuffer = new CompositeByteBuffer(c != null);
   }
 
   /**
@@ -129,7 +128,7 @@ public class PrimitiveFloatList extends AbstractList<Float>
       return oldFloatList;
     } else {
       // Just a place holder, will set up the elements later.
-      return new PrimitiveFloatList();
+      return new PrimitiveFloatList(0);
     }
   }
 

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
@@ -81,6 +81,26 @@ public class FastDeserializerDefaultsTest {
   }
 
   @Test
+  public void testPrimitiveFloatListAddPrimitive() {
+    int array_size = 250, iteration = 100;
+    float w = 0;
+    long startTime = System.currentTimeMillis();
+
+    for (int i = 0; i < iteration; i++) {
+      PrimitiveFloatList list = new PrimitiveFloatList(array_size);
+
+      for (int l = 0; l < array_size; l++) {
+        list.addPrimitive((float) l);
+      }
+      for (Float f : list) {
+        w += f;
+      }
+    }
+    long endTime = System.currentTimeMillis();
+    System.out.println(String.format("time taken to addPrimitive to float list: %d", endTime - startTime));
+  }
+
+  @Test
   public void testFastFloatArraySerDes()  {
     int array_size = 2500, iteration = 100_000;
     long total = 0, endTime, startTime, w = 0;


### PR DESCRIPTION
Setup composite byte buffer even for general non-avro List<Float> interface implementation of PrimitiveFloatList usage.
eg
PrimitiveFloatList list = new PrimitiveFloatList(10);

The above use-case will not use the ByteBuffer data buffer, but cacheFromByteBuffer tries to read from the ByteBuffer to fill in float array, which would fail if it is not initialized.