### PR TITLE
Fixed a bug in processUnion of FastSerializer

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -68,6 +68,15 @@ public class SchemaAssistant {
     }
   }
 
+  public static String getSchemaFullName(Schema schema) {
+    Schema.Type type = schema.getType();
+    boolean isNamedType = type.equals(Schema.Type.ENUM) || type.equals(Schema.Type.FIXED) || type.equals(Schema.Type.RECORD);
+    /**
+     * Avro-1.4 doesn't support {@link Schema#getFullName()} if the Schema is not a NamedSchema.
+     */
+    return isNamedType ? schema.getFullName() : type.name();
+  }
+
   public static boolean isNamedType(Schema schema) {
     switch (schema.getType()) {
       case RECORD:

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastGenericSerializerGeneratorTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastGenericSerializerGeneratorTest.java
@@ -188,6 +188,27 @@ public class FastGenericSerializerGeneratorTest {
   }
 
   @Test(groups = {"serializationTest"})
+  public void shouldWriteRightUnionIndex() {
+    // Create two record schemas
+    Schema recordSchema1 = createRecord("record1", createField("record1_field1", Schema.create(Schema.Type.STRING)));
+    Schema recordSchema2 = createRecord("record2", createField("record2_field1", Schema.create(Schema.Type.STRING)));
+    Schema unionSchema = createUnionSchema(recordSchema1, recordSchema2);
+    Schema recordWrapperSchema = createRecord("recordWrapper", createField("union_field", unionSchema));
+
+    GenericData.Record objectOfRecordSchema2 = new GenericData.Record(recordSchema2);
+    objectOfRecordSchema2.put("record2_field1", "abc");
+    GenericData.Record wrapperObject = new GenericData.Record(recordWrapperSchema);
+    wrapperObject.put("union_field", objectOfRecordSchema2);
+
+    GenericRecord record = decodeRecord(recordWrapperSchema, dataAsBinaryDecoder(wrapperObject));
+
+    Object unionField = record.get("union_field");
+    Assert.assertTrue(unionField instanceof GenericData.Record);
+    GenericData.Record unionRecord = (GenericData.Record)unionField;
+    Assert.assertEquals(unionRecord.getSchema().getName(), "record2");
+  }
+
+  @Test(groups = {"serializationTest"})
   public void shouldWriteSubRecordCollectionsField() {
     // given
     Schema subRecordSchema = createRecord("subRecord", createPrimitiveUnionFieldSchema("subField", Schema.Type.STRING));

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/SchemaAssistantTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/SchemaAssistantTest.java
@@ -1,0 +1,27 @@
+package com.linkedin.avro.fastserde;
+
+import java.util.Collections;
+import org.apache.avro.Schema;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SchemaAssistantTest {
+
+  @Test
+  public void testGetSchemaFullName() {
+    String namespace = "com.linkedin.avro.fastserde";
+    Assert.assertEquals("STRING", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.STRING)));
+    Assert.assertEquals("BYTES", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.BYTES)));
+    Assert.assertEquals("INT", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.INT)));
+    Assert.assertEquals("LONG", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.LONG)));
+    Assert.assertEquals("FLOAT", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.FLOAT)));
+    Assert.assertEquals("DOUBLE", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.DOUBLE)));
+    Assert.assertEquals("BOOLEAN", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.BOOLEAN)));
+    Assert.assertEquals("NULL", SchemaAssistant.getSchemaFullName(Schema.create(Schema.Type.NULL)));
+    Assert.assertEquals("com.linkedin.avro.fastserde.TestRecord", SchemaAssistant.getSchemaFullName(Schema.createRecord("TestRecord", "", namespace, false)));
+    Assert.assertEquals("com.linkedin.avro.fastserde.TestFixed", SchemaAssistant.getSchemaFullName(Schema.createFixed("TestFixed", "", namespace, 16)));
+    Assert.assertEquals("com.linkedin.avro.fastserde.TestEnum", SchemaAssistant.getSchemaFullName(Schema.createEnum("TestEnum", "", namespace, Collections
+        .emptyList())));
+  }
+}


### PR DESCRIPTION
Previously, the code is checking schema type to decide the right index,
and this change was introduced to accommodate Avro-1.4, but this is
not appropriate since Union could contain multiple record types, which
will cause the writen index will always be the index of the first record.
The fix is to check the full name of the schema instead of type name.

@volauvent @FelixGV 