### PR TITLE
Fix a bug in object reuse in CompositeByteBuffer

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
@@ -19,7 +19,7 @@ public class CompositeByteBuffer {
     ByteBuffer byteBuffer;
 
     // Check if we can reuse the old record's byteBuffers, else allocate a new one.
-    if (byteBuffers.size() > index && byteBuffers.get(index).capacity() > size) {
+    if (byteBuffers.size() > index && byteBuffers.get(index).capacity() >= size) {
       byteBuffer = byteBuffers.get(index);
       byteBuffer.clear();
     } else {

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
@@ -207,11 +207,13 @@ public class FastDeserializerGeneratorForReuseTest {
     // new record array length shorter than reuse record.
     arrayList.clear();
     arrayList.add((float)10);
+    arrayList.add((float)20);
+    arrayList.add((float)30);
     record1.put("inventory", arrayList);
     serializedBytes = serialize(record1, oldRecordSchema);
     genericRecord = deserializer.deserialize(deserRecord, getDecoder(serializedBytes));
     list = (List<Float>)genericRecord.get(1);
-    Assert.assertEquals(list.size(), 1);
+    Assert.assertEquals(list.size(), 3);
 
   }
 }

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorForReuseTest.java
@@ -204,7 +204,7 @@ public class FastDeserializerGeneratorForReuseTest {
     List<Float> list = (List<Float>)genericRecord.get(1);
     Assert.assertEquals(list.size(), 3);
 
-    // new record array length shorter than reuse record.
+    // new record array length same as before for reusing byte buffers
     arrayList.clear();
     arrayList.add((float)10);
     arrayList.add((float)20);


### PR DESCRIPTION
The buffer size should be less than equal to the new size for object reuse to utilize the existing buffer in CompositeByteBuffer. The bug did not check for equality.