### PR TITLE
Improve fast deserialization by avoiding field schema retrieval cost

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -291,7 +291,7 @@ public class SchemaAssistant {
     return codeModel.ref(Utf8.class);
   }
 
-  public JExpression getEnumValueByName(Schema enumSchema, JExpression nameExpr, JInvocation getSchemaExpr) {
+  public JExpression getEnumValueByName(Schema enumSchema, JExpression nameExpr, JExpression getSchemaExpr) {
     if (useGenericTypes) {
       if (Utils.isAvro14()) {
         return JExpr._new(codeModel.ref(GenericData.EnumSymbol.class)).arg(nameExpr);
@@ -303,7 +303,7 @@ public class SchemaAssistant {
     }
   }
 
-  public JExpression getEnumValueByIndex(Schema enumSchema, JExpression indexExpr, JInvocation getSchemaExpr) {
+  public JExpression getEnumValueByIndex(Schema enumSchema, JExpression indexExpr, JExpression getSchemaExpr) {
     if (useGenericTypes) {
       if (Utils.isAvro14()) {
         return JExpr._new(codeModel.ref(GenericData.EnumSymbol.class))


### PR DESCRIPTION
Improved fast deserialization speed by avoiding current field schema retrieval cost.
Changed to use fields' schema directly instead of registering and then retrieving
them from HashMap.

JMH benchmark results of fast-deserialization time
1. Enum array with 200 elements
```
        |   Avro 1.4(ns)   |  Avro 1.8(ns)
Before  |   7452           |   13101 
After   |   5374           |   7858 
```

2. Record array with 200 elements
```
        |   Avro 1.4(ns)   |   Avro 1.8(ns)
Before  |   23068          |   24519
After   |   17854          |   18549
```

@gaojieliu @FelixGV @radai-rosenblatt 