### PR TITLE
add configureBinaryDecoder in AvroCompatibilityHelper

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -37,6 +37,9 @@ public interface AvroAdapter {
 
   BinaryDecoder newBinaryDecoder(ObjectInput in);
 
+  BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse);
+
   JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException;
 
   JsonDecoder newJsonDecoder(Schema schema, InputStream in) throws IOException;

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -134,6 +134,21 @@ public class AvroCompatibilityHelper {
   }
 
   /**
+   * configureBinaryDecoder reinitializes a {@link BinaryDecoder} with the byte array
+   * provided as the source of data.
+   * @param bytes The byte array to initialize to
+   * @param offset The offset to start reading from
+   * @param length The maximum number of bytes to read from the byte array
+   * @param reuse The BinaryDecoder to attempt to reinitialize.
+   * @return A BinaryDecoder that uses <i>bytes</i> as its source of data.
+   */
+  public static BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    assertAvroAvailable();
+    return ADAPTER.configureBinaryDecoder(bytes, offset, length, reuse);
+  }
+
+  /**
    * convenience method for getting a {@link BinaryDecoder} for a given byte[]
    * @param in byte array with data
    * @return a {@link BinaryDecoder} for decoding the given array

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -36,6 +36,7 @@ import org.apache.avro.Avro14SchemaAccessUtil;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro14BinaryDecoderConfigurer;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -55,6 +56,7 @@ public class Avro14Adapter implements AvroAdapter {
   private final Method compilerCompileMethod;
   private final Field outputFilePathField;
   private final Field outputFileContentsField;
+  private final Avro14BinaryDecoderConfigurer configurer;
 
   public Avro14Adapter() {
     try {
@@ -67,6 +69,7 @@ public class Avro14Adapter implements AvroAdapter {
       outputFilePathField.setAccessible(true);
       outputFileContentsField = outputFileClass.getDeclaredField("contents");
       outputFileContentsField.setAccessible(true);
+      configurer = new Avro14BinaryDecoderConfigurer();
     } catch (Exception e) {
       //avro 1.4 bundles the compiler into the regular jar, hence this is not expected
       throw new IllegalStateException("error initializing compiler-related fields", e);
@@ -104,6 +107,11 @@ public class Avro14Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return configurer.configureBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-14/src/main/java/org/apache/avro/io/Avro14BinaryDecoderConfigurer.java
+++ b/helper/impls/helper-impl-14/src/main/java/org/apache/avro/io/Avro14BinaryDecoderConfigurer.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+public class Avro14BinaryDecoderConfigurer {
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    reuse.init(bytes, offset, length);
+    return reuse;
+  }
+}

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro15BinaryDecoderConfigurer;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -56,6 +57,7 @@ public class Avro15Adapter implements AvroAdapter {
   private Method compilerCompileMethod;
   private Field outputFilePathField;
   private Field outputFileContentsField;
+  private Avro15BinaryDecoderConfigurer configurer;
 
   public Avro15Adapter() {
     tryInitializeCompilerFields();
@@ -82,6 +84,7 @@ public class Avro15Adapter implements AvroAdapter {
       compilerSupported = false;
       //ignore
     }
+    configurer = new Avro15BinaryDecoderConfigurer();
   }
 
   @Override
@@ -107,6 +110,11 @@ public class Avro15Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return configurer.configureBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/org/apache/avro/io/Avro15BinaryDecoderConfigurer.java
+++ b/helper/impls/helper-impl-15/src/main/java/org/apache/avro/io/Avro15BinaryDecoderConfigurer.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+public class Avro15BinaryDecoderConfigurer {
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    return reuse.configure(bytes, offset, length);
+  }
+}

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro16BinaryDecoderConfigurer;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -58,6 +59,7 @@ public class Avro16Adapter implements AvroAdapter {
   private Field outputFileContentsField;
   private Object charSequenceStringTypeEnumInstance;
   private Method setStringTypeMethod;
+  private Avro16BinaryDecoderConfigurer configurer;
 
   public Avro16Adapter() {
     tryInitializeCompilerFields();
@@ -88,6 +90,7 @@ public class Avro16Adapter implements AvroAdapter {
       compilerSupported = false;
       //ignore
     }
+    configurer = new Avro16BinaryDecoderConfigurer();
   }
 
   @Override
@@ -113,6 +116,11 @@ public class Avro16Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return configurer.configureBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-16/src/main/java/org/apache/avro/io/Avro16BinaryDecoderConfigurer.java
+++ b/helper/impls/helper-impl-16/src/main/java/org/apache/avro/io/Avro16BinaryDecoderConfigurer.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+public class Avro16BinaryDecoderConfigurer {
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    return reuse.configure(bytes, offset, length);
+  }
+}

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro17BinaryDecoderConfigurer;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -62,6 +63,8 @@ public class Avro17Adapter implements AvroAdapter {
   private Method setFieldVisibilityMethod;
   private Object charSequenceStringTypeEnumInstance;
   private Method setStringTypeMethod;
+  private Avro17BinaryDecoderConfigurer configurer;
+
 
   //"optional" methods - things added in later 1.7.* versions that may not exist if we're running with earlier 1.7.*
 
@@ -131,6 +134,8 @@ public class Avro17Adapter implements AvroAdapter {
       }
       getSpecificDefaultValueMethod = null;
     }
+
+    configurer = new Avro17BinaryDecoderConfigurer();
   }
 
   @Override
@@ -156,6 +161,11 @@ public class Avro17Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return configurer.configureBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/org/apache/avro/io/Avro17BinaryDecoderConfigurer.java
+++ b/helper/impls/helper-impl-17/src/main/java/org/apache/avro/io/Avro17BinaryDecoderConfigurer.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+public class Avro17BinaryDecoderConfigurer {
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    return reuse.configure(bytes, offset, length);
+  }
+}

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro18BinaryDecoderConfigurer;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -56,6 +57,7 @@ public class Avro18Adapter implements AvroAdapter {
   private Method setFieldVisibilityMethod;
   private Object charSequenceStringTypeEnumInstance;
   private Method setStringTypeMethod;
+  private Avro18BinaryDecoderConfigurer configurer;
 
   public Avro18Adapter() {
     tryInitializeCompilerFields();
@@ -90,6 +92,7 @@ public class Avro18Adapter implements AvroAdapter {
       compilerSupported = false;
       //ignore
     }
+    configurer = new Avro18BinaryDecoderConfigurer();
   }
 
   @Override
@@ -115,6 +118,11 @@ public class Avro18Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return configurer.configureBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-18/src/main/java/org/apache/avro/io/Avro18BinaryDecoderConfigurer.java
+++ b/helper/impls/helper-impl-18/src/main/java/org/apache/avro/io/Avro18BinaryDecoderConfigurer.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import org.apache.avro.io.BinaryDecoder;
+
+
+public class Avro18BinaryDecoderConfigurer {
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    return reuse.configure(bytes, offset, length);
+  }
+}

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro19BinaryDecoderConfigurer;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -56,6 +57,7 @@ public class Avro19Adapter implements AvroAdapter {
   private Method setFieldVisibilityMethod;
   private Object charSequenceStringTypeEnumInstance;
   private Method setStringTypeMethod;
+  private Avro19BinaryDecoderConfigurer configurer;
 
   public Avro19Adapter() {
     tryInitializeCompilerFields();
@@ -90,6 +92,7 @@ public class Avro19Adapter implements AvroAdapter {
       compilerSupported = false;
       //ignore
     }
+    configurer = new Avro19BinaryDecoderConfigurer();
   }
 
   @Override
@@ -115,6 +118,11 @@ public class Avro19Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return configurer.configureBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-19/src/main/java/org/apache/avro/io/Avro19BinaryDecoderConfigurer.java
+++ b/helper/impls/helper-impl-19/src/main/java/org/apache/avro/io/Avro19BinaryDecoderConfigurer.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+public class Avro19BinaryDecoderConfigurer {
+  public BinaryDecoder configureBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    return reuse.configure(bytes, offset, length);
+  }
+}


### PR DESCRIPTION
Venice has a local optimization requires re-initialize a BinaryDecoder, but the method signature is different in avro 1.4 and versions after 1.4. In order to be compatible with all avro versions, we need to add this method in AvroCompatibilityHelper.