### PR TITLE
add newBinaryDecoder which re-configures a BinaryDecoder in AvroCompatibilityHelper

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -37,6 +37,9 @@ public interface AvroAdapter {
 
   BinaryDecoder newBinaryDecoder(ObjectInput in);
 
+  BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse);
+
   JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException;
 
   JsonDecoder newJsonDecoder(Schema schema, InputStream in) throws IOException;

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -134,6 +134,22 @@ public class AvroCompatibilityHelper {
   }
 
   /**
+   * constructs or reinitializes a {@link BinaryDecoder} with the byte array
+   * provided as the source of data.
+   * @param bytes The byte array to initialize to
+   * @param offset The offset to start reading from
+   * @param length The maximum number of bytes to read from the byte array
+   * @param reuse The BinaryDecoder to attempt to reinitialize.
+   * @return A BinaryDecoder that uses <i>bytes</i> as its source of data. If
+   * <i>reuse</i> is null, this will be a new instance.
+   */
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    assertAvroAvailable();
+    return ADAPTER.newBinaryDecoder(bytes, offset, length, reuse);
+  }
+
+  /**
    * convenience method for getting a {@link BinaryDecoder} for a given byte[]
    * @param in byte array with data
    * @return a {@link BinaryDecoder} for decoding the given array

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -36,6 +36,7 @@ import org.apache.avro.Avro14SchemaAccessUtil;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro14BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -104,6 +105,11 @@ public class Avro14Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro14BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-14/src/main/java/org/apache/avro/io/Avro14BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-14/src/main/java/org/apache/avro/io/Avro14BinaryDecoderAccessUtil.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+/**
+ * this class exists to allow us access to package-private classes and methods on class {@link BinaryDecoder}
+ *
+ * the difference between this method and {@link DecoderFactory#createBinaryDecoder(byte[], int, int, BinaryDecoder)}
+ * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
+ */
+public class Avro14BinaryDecoderAccessUtil {
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    if (null != reuse) {
+      reuse.init(bytes, offset, length);
+      return reuse;
+    } else {
+      return new BinaryDecoder(bytes, offset, length);
+    }
+  }
+}

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro15BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -107,6 +108,11 @@ public class Avro15Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro15BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/org/apache/avro/io/Avro15BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-15/src/main/java/org/apache/avro/io/Avro15BinaryDecoderAccessUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+/**
+ * this class exists to allow us access to package-private classes and methods on class {@link BinaryDecoder}
+ *
+ * the difference between this method and {@link DecoderFactory#binaryDecoder(byte[], int, int, BinaryDecoder)}
+ * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
+ */
+public class Avro15BinaryDecoderAccessUtil {
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    if (null == reuse) {
+      return new BinaryDecoder(bytes, offset, length);
+    } else {
+      return reuse.configure(bytes, offset, length);
+    }
+  }
+}

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro16BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -113,6 +114,11 @@ public class Avro16Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro16BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-16/src/main/java/org/apache/avro/io/Avro16BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-16/src/main/java/org/apache/avro/io/Avro16BinaryDecoderAccessUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+/**
+ * this class exists to allow us access to package-private classes and methods on class {@link BinaryDecoder}
+ *
+ * the difference between this method and {@link DecoderFactory#binaryDecoder(byte[], int, int, BinaryDecoder)}
+ * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
+ */
+public class Avro16BinaryDecoderAccessUtil {
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    if (null == reuse) {
+      return new BinaryDecoder(bytes, offset, length);
+    } else {
+      return reuse.configure(bytes, offset, length);
+    }
+  }
+}

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro17BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -156,6 +157,11 @@ public class Avro17Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro17BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/org/apache/avro/io/Avro17BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-17/src/main/java/org/apache/avro/io/Avro17BinaryDecoderAccessUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+/**
+ * this class exists to allow us access to package-private classes and methods on class {@link BinaryDecoder}
+ *
+ * the difference between this method and {@link DecoderFactory#binaryDecoder(byte[], int, int, BinaryDecoder)}
+ * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
+ */
+public class Avro17BinaryDecoderAccessUtil {
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    if (null == reuse) {
+      return new BinaryDecoder(bytes, offset, length);
+    } else {
+      return reuse.configure(bytes, offset, length);
+    }
+  }
+}

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro18BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -115,6 +116,11 @@ public class Avro18Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro18BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-18/src/main/java/org/apache/avro/io/Avro18BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-18/src/main/java/org/apache/avro/io/Avro18BinaryDecoderAccessUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+/**
+ * this class exists to allow us access to package-private classes and methods on class {@link BinaryDecoder}
+ *
+ * the difference between this method and {@link DecoderFactory#binaryDecoder(byte[], int, int, BinaryDecoder)}
+ * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
+ */
+public class Avro18BinaryDecoderAccessUtil {
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    if (null == reuse) {
+      return new BinaryDecoder(bytes, offset, length);
+    } else {
+      return reuse.configure(bytes, offset, length);
+    }
+  }
+}

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Avro19BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DecoderFactory;
@@ -115,6 +116,11 @@ public class Avro19Adapter implements AvroAdapter {
   @Override
   public BinaryDecoder newBinaryDecoder(ObjectInput in) {
     return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro19BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
   }
 
   @Override

--- a/helper/impls/helper-impl-19/src/main/java/org/apache/avro/io/Avro19BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-19/src/main/java/org/apache/avro/io/Avro19BinaryDecoderAccessUtil.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+/**
+ * this class exists to allow us access to package-private classes and methods on class {@link BinaryDecoder}
+ *
+ * the difference between this method and {@link DecoderFactory#binaryDecoder(byte[], int, int, BinaryDecoder)}
+ * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
+ */
+public class Avro19BinaryDecoderAccessUtil {
+  public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
+      int length, BinaryDecoder reuse) {
+    if (null == reuse) {
+      return new BinaryDecoder(bytes, offset, length);
+    } else {
+      return reuse.configure(bytes, offset, length);
+    }
+  }
+}


### PR DESCRIPTION
Venice has a local optimization requires re-initialize a BinaryDecoder, but the method signature is different in avro 1.4 and versions after 1.4. In order to be compatible with all avro versions, we need to add this method in AvroCompatibilityHelper. Created several classes of AvroXXBinaryDecoderConfigurer since init/configure method in BinaryDecoder is package-private.