### PR TITLE
Improved fast serializer code generation logic for Enum type

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -3,10 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -15,7 +12,6 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
     implements FastSerializer<List<IndexedRecord>>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(List<IndexedRecord> data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -3,10 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -15,7 +12,6 @@ public class Array_of_record_GenericSerializer_1629046702287533603
     implements FastSerializer<List<IndexedRecord>>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(List<IndexedRecord> data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173.java
@@ -3,8 +3,6 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -14,7 +12,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+    private final Schema testEnumEnumSchema69 = Schema.parse("{\"type\":\"enum\",\"name\":\"testEnum\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"symbols\":[\"A\",\"B\"]}");
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
@@ -26,11 +24,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
     public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Schema testEnumEnumSchema69 = enumSchemaMap.get(-3346156575824446940L);
-        if (null == testEnumEnumSchema69) {
-            testEnumEnumSchema69 = Schema.parse("{\"type\":\"enum\",\"name\":\"testEnum\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"symbols\":[\"A\",\"B\"]}");
-            enumSchemaMap.put(-3346156575824446940L, testEnumEnumSchema69);
-        }
         (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
         org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion70 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
         if (testEnumUnion70 == null) {
@@ -39,7 +32,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
         } else {
             if (testEnumUnion70 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
                 (encoder).writeIndex(1);
-                (encoder).writeEnum(enumSchemaMap.get(-3346156575824446940L).getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion70).toString()));
+                (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion70).toString()));
             }
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray71 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
@@ -50,7 +43,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
             (encoder).setItemCount(testEnumArray71 .size());
             for (int counter72 = 0; (counter72 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray71).size()); counter72 ++) {
                 (encoder).startItem();
-                (encoder).writeEnum(enumSchemaMap.get(-3346156575824446940L).getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray71 .get(counter72)).toString()));
+                (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray71 .get(counter72)).toString()));
             }
         }
         (encoder).writeArrayEnd();
@@ -70,7 +63,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
                 } else {
                     if (union75 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
                         (encoder).writeIndex(1);
-                        (encoder).writeEnum(enumSchemaMap.get(-3346156575824446940L).getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union75).toString()));
+                        (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union75).toString()));
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201.java
@@ -3,10 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 
@@ -14,7 +11,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializ
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159.java
@@ -2,10 +2,7 @@
 package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,7 +11,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849.java
@@ -3,10 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -15,7 +12,6 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903.java
@@ -2,10 +2,7 @@
 package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,7 +11,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381.java
@@ -4,9 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -15,7 +13,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871.java
@@ -4,9 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -15,7 +13,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747.java
@@ -2,10 +2,7 @@
 package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,7 +11,6 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
     implements FastSerializer<IndexedRecord>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -3,9 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,7 +12,6 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
     implements FastSerializer<Map<CharSequence, IndexedRecord>>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
         throws IOException

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -3,9 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import com.linkedin.avro.fastserde.FastSerializer;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,7 +12,6 @@ public class Map_of_record_GenericSerializer_2141121767969292399
     implements FastSerializer<Map<CharSequence, IndexedRecord>>
 {
 
-    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
 
     public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
         throws IOException


### PR DESCRIPTION
Improved fast serialization speed by avoiding the cost of storing and retrieving Enum schemas
in a Hashmap in Avro 1.4. We have seen ~44% improvement of serialization latency for Enum array.

This PR helps to resolve issue #50 

JMH benchmark results of fast serialization time of an 200 elements EnumArray under Avro 1.4

**Before** 
```
FastAvroSerdesBenchmark.testFastAvroSerialization                                   avgt   10  12054.915 ± 1852.177   ns/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.alloc.rate                    avgt   10    255.063 ±   42.062  MB/sec
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.alloc.rate.norm               avgt   10   3352.001 ±    0.001    B/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Eden_Space           avgt   10    272.156 ±  362.710  MB/sec
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Eden_Space.norm      avgt   10   3489.396 ± 4814.784    B/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Survivor_Space       avgt   10      0.103 ±    0.477  MB/sec
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Survivor_Space.norm  avgt   10      1.505 ±    6.959    B/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.count                         avgt   10      6.000             counts
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.time                          avgt   10     46.000                 ms
```

**After**
```
FastAvroSerdesBenchmark.testFastAvroSerialization                                   avgt   10  6709.067 ±  225.951   ns/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.alloc.rate                    avgt   10   453.950 ±   14.888  MB/sec
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.alloc.rate.norm               avgt   10  3352.000 ±    0.001    B/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Eden_Space           avgt   10   452.412 ±  247.752  MB/sec
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Eden_Space.norm      avgt   10  3337.223 ± 1836.797    B/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Survivor_Space       avgt   10     0.104 ±    0.480  MB/sec
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.churn.PS_Survivor_Space.norm  avgt   10     0.802 ±    3.719    B/op
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.count                         avgt   10     9.000             counts
FastAvroSerdesBenchmark.testFastAvroSerialization:·gc.time                          avgt   10    37.000                 ms
```