### PR TITLE
Checking in samples of fast-avro code gen, to ease future reviews.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ build/
 
 #temp artifacts
 avro_tools/
-generated/
+avro-fastserde/src/test/java/com/linkedin/avro/fastserde/generated/
+*.class
 
 #IDEA artifacts
 out/

--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -46,6 +46,10 @@ jmh {
   }
 }
 
+sourceSets {
+  codegen
+}
+
 dependencies {
   compile project(":helper:helper")
 
@@ -83,6 +87,11 @@ dependencies {
   avro18 ("org.apache.avro:avro-compiler:1.8.2") {
     exclude group: "org.slf4j"
   }
+
+  codegenCompile ("org.apache.avro:avro-compiler:1.8.2") {
+    exclude group: "org.slf4j"
+  }
+  codegenCompile project(":avro-fastserde")
 }
 
 compileJmhJava {
@@ -120,7 +129,16 @@ test {
   testLogging.showStandardStreams = true
 }
 
-build.dependsOn testAvro14, testAvro17, testAvro18
+task cleanGeneratedClassFiles(type: Delete) {
+  delete fileTree(dir: 'src/codegen', include: '**/*.class')
+}
+
+task cleanAllGeneratedFiles(type: Delete) {
+  delete fileTree(dir: 'src/codegen', include: '**/*.java')
+}
+
+build.dependsOn cleanAllGeneratedFiles, testAvro14, testAvro17, testAvro18
+build.finalizedBy cleanGeneratedClassFiles
 
 task generateAvroClasses14(type:Exec) {
   commandLine "./regenerate_avro.sh"

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388
+    implements FastDeserializer<List<Boolean>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Boolean> array738 = null;
+        long chunkLen739 = (decoder.readArrayStart());
+        if (chunkLen739 > 0) {
+            List<Boolean> arrayReuse740 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse740 = ((List)(reuse));
+            }
+            if (arrayReuse740 != (null)) {
+                arrayReuse740 .clear();
+                array738 = arrayReuse740;
+            } else {
+                array738 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen739), readerSchema);
+            }
+            do {
+                for (int counter741 = 0; (counter741 <chunkLen739); counter741 ++) {
+                    Object arrayArrayElementReuseVar742 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar742 = ((GenericArray)(reuse)).peek();
+                    }
+                    array738 .add((decoder.readBoolean()));
+                }
+                chunkLen739 = (decoder.arrayNext());
+            } while (chunkLen739 > 0);
+        } else {
+            array738 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
+        }
+        return array738;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740
+    implements FastDeserializer<List<Double>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Double> deserialize(List<Double> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Double> array743 = null;
+        long chunkLen744 = (decoder.readArrayStart());
+        if (chunkLen744 > 0) {
+            List<Double> arrayReuse745 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse745 = ((List)(reuse));
+            }
+            if (arrayReuse745 != (null)) {
+                arrayReuse745 .clear();
+                array743 = arrayReuse745;
+            } else {
+                array743 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen744), readerSchema);
+            }
+            do {
+                for (int counter746 = 0; (counter746 <chunkLen744); counter746 ++) {
+                    Object arrayArrayElementReuseVar747 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar747 = ((GenericArray)(reuse)).peek();
+                    }
+                    array743 .add((decoder.readDouble()));
+                }
+                chunkLen744 = (decoder.arrayNext());
+            } while (chunkLen744 > 0);
+        } else {
+            array743 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
+        }
+        return array743;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -1,0 +1,29 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583
+    implements FastDeserializer<List<Float>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Float> deserialize(List<Float> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Float> array748 = null;
+        array748 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        return array748;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685
+    implements FastDeserializer<List<Integer>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Integer> array749 = null;
+        long chunkLen750 = (decoder.readArrayStart());
+        if (chunkLen750 > 0) {
+            List<Integer> arrayReuse751 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse751 = ((List)(reuse));
+            }
+            if (arrayReuse751 != (null)) {
+                arrayReuse751 .clear();
+                array749 = arrayReuse751;
+            } else {
+                array749 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen750), readerSchema);
+            }
+            do {
+                for (int counter752 = 0; (counter752 <chunkLen750); counter752 ++) {
+                    Object arrayArrayElementReuseVar753 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar753 = ((GenericArray)(reuse)).peek();
+                    }
+                    array749 .add((decoder.readInt()));
+                }
+                chunkLen750 = (decoder.arrayNext());
+            } while (chunkLen750 > 0);
+        } else {
+            array749 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
+        }
+        return array749;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358
+    implements FastDeserializer<List<Long>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Long> deserialize(List<Long> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Long> array754 = null;
+        long chunkLen755 = (decoder.readArrayStart());
+        if (chunkLen755 > 0) {
+            List<Long> arrayReuse756 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse756 = ((List)(reuse));
+            }
+            if (arrayReuse756 != (null)) {
+                arrayReuse756 .clear();
+                array754 = arrayReuse756;
+            } else {
+                array754 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen755), readerSchema);
+            }
+            do {
+                for (int counter757 = 0; (counter757 <chunkLen755); counter757 ++) {
+                    Object arrayArrayElementReuseVar758 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar758 = ((GenericArray)(reuse)).peek();
+                    }
+                    array754 .add((decoder.readLong()));
+                }
+                chunkLen755 = (decoder.arrayNext());
+            } while (chunkLen755 > 0);
+        } else {
+            array754 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
+        }
+        return array754;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -1,0 +1,90 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArrayElemSchema772;
+    private final Schema arrayElemOptionSchema775;
+    private final Schema field777;
+
+    public Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArrayElemSchema772 = readerSchema.getElementType();
+        this.arrayElemOptionSchema775 = arrayArrayElemSchema772 .getTypes().get(1);
+        this.field777 = arrayElemOptionSchema775 .getField("field").schema();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array768 = null;
+        long chunkLen769 = (decoder.readArrayStart());
+        if (chunkLen769 > 0) {
+            List<IndexedRecord> arrayReuse770 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse770 = ((List)(reuse));
+            }
+            if (arrayReuse770 != (null)) {
+                arrayReuse770 .clear();
+                array768 = arrayReuse770;
+            } else {
+                array768 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen769), readerSchema);
+            }
+            do {
+                for (int counter771 = 0; (counter771 <chunkLen769); counter771 ++) {
+                    Object arrayArrayElementReuseVar773 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar773 = ((GenericArray)(reuse)).peek();
+                    }
+                    int unionIndex774 = (decoder.readIndex());
+                    if (unionIndex774 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex774 == 1) {
+                        array768 .add(deserializerecord776(arrayArrayElementReuseVar773, (decoder)));
+                    }
+                }
+                chunkLen769 = (decoder.arrayNext());
+            } while (chunkLen769 > 0);
+        } else {
+            array768 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+        }
+        return array768;
+    }
+
+    public IndexedRecord deserializerecord776(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema775)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema775);
+        }
+        int unionIndex778 = (decoder.readIndex());
+        if (unionIndex778 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex778 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArrayElemSchema763;
+    private final Schema field766;
+
+    public Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArrayElemSchema763 = readerSchema.getElementType();
+        this.field766 = arrayArrayElemSchema763 .getField("field").schema();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array759 = null;
+        long chunkLen760 = (decoder.readArrayStart());
+        if (chunkLen760 > 0) {
+            List<IndexedRecord> arrayReuse761 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse761 = ((List)(reuse));
+            }
+            if (arrayReuse761 != (null)) {
+                arrayReuse761 .clear();
+                array759 = arrayReuse761;
+            } else {
+                array759 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen760), readerSchema);
+            }
+            do {
+                for (int counter762 = 0; (counter762 <chunkLen760); counter762 ++) {
+                    Object arrayArrayElementReuseVar764 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar764 = ((GenericArray)(reuse)).peek();
+                    }
+                    array759 .add(deserializerecord765(arrayArrayElementReuseVar764, (decoder)));
+                }
+                chunkLen760 = (decoder.arrayNext());
+            } while (chunkLen760 > 0);
+        } else {
+            array759 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+        }
+        return array759;
+    }
+
+    public IndexedRecord deserializerecord765(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema763)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema763);
+        }
+        int unionIndex767 = (decoder.readIndex());
+        if (unionIndex767 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex767 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782.java
@@ -1,0 +1,118 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum780;
+    private final Schema testEnumUnion781;
+    private final Schema testEnumArray783;
+    private final Schema testEnumUnionArray789;
+    private final Schema testEnumUnionArrayArrayElemSchema794;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum780 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion781 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray783 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray789 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema794 = testEnumUnionArray789 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum779((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum779(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+        int unionIndex782 = (decoder.readIndex());
+        if (unionIndex782 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex782 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray784 = null;
+        long chunkLen785 = (decoder.readArrayStart());
+        if (chunkLen785 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse786 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
+                testEnumArrayReuse786 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+            }
+            if (testEnumArrayReuse786 != (null)) {
+                testEnumArrayReuse786 .clear();
+                testEnumArray784 = testEnumArrayReuse786;
+            } else {
+                testEnumArray784 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen785), testEnumArray783);
+            }
+            do {
+                for (int counter787 = 0; (counter787 <chunkLen785); counter787 ++) {
+                    Object testEnumArrayArrayElementReuseVar788 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof GenericArray) {
+                        testEnumArrayArrayElementReuseVar788 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
+                    }
+                    testEnumArray784 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+                }
+                chunkLen785 = (decoder.arrayNext());
+            } while (chunkLen785 > 0);
+        } else {
+            testEnumArray784 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray783);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray784);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray790 = null;
+        long chunkLen791 = (decoder.readArrayStart());
+        if (chunkLen791 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse792 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
+                testEnumUnionArrayReuse792 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+            }
+            if (testEnumUnionArrayReuse792 != (null)) {
+                testEnumUnionArrayReuse792 .clear();
+                testEnumUnionArray790 = testEnumUnionArrayReuse792;
+            } else {
+                testEnumUnionArray790 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen791), testEnumUnionArray789);
+            }
+            do {
+                for (int counter793 = 0; (counter793 <chunkLen791); counter793 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar795 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
+                        testEnumUnionArrayArrayElementReuseVar795 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                    }
+                    int unionIndex796 = (decoder.readIndex());
+                    if (unionIndex796 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex796 == 1) {
+                        testEnumUnionArray790 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+                    }
+                }
+                chunkLen791 = (decoder.arrayNext());
+            } while (chunkLen791 > 0);
+        } else {
+            testEnumUnionArray790 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray789);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray790);
+        return FastGenericDeserializerGeneratorTest_shouldReadEnum;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292.java
@@ -1,0 +1,145 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testFixedUnion799;
+    private final Schema testFixedArray802;
+    private final Schema testFixedUnionArray809;
+    private final Schema testFixedUnionArrayArrayElemSchema814;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testFixedUnion799 = readerSchema.getField("testFixedUnion").schema();
+        this.testFixedArray802 = readerSchema.getField("testFixedArray").schema();
+        this.testFixedUnionArray809 = readerSchema.getField("testFixedUnionArray").schema();
+        this.testFixedUnionArrayArrayElemSchema814 = testFixedUnionArray809 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed797((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed797(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadFixed = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadFixed = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        byte[] testFixed798;
+        if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes().length == (2))) {
+            testFixed798 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
+        } else {
+            testFixed798 = ( new byte[2]);
+        }
+        decoder.readFixed(testFixed798);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(testFixed798));
+        int unionIndex800 = (decoder.readIndex());
+        if (unionIndex800 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex800 == 1) {
+            byte[] testFixed801;
+            if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes().length == (2))) {
+                testFixed801 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
+            } else {
+                testFixed801 = ( new byte[2]);
+            }
+            decoder.readFixed(testFixed801);
+            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(testFixed801));
+        }
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray803 = null;
+        long chunkLen804 = (decoder.readArrayStart());
+        if (chunkLen804 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse805 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
+                testFixedArrayReuse805 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+            }
+            if (testFixedArrayReuse805 != (null)) {
+                testFixedArrayReuse805 .clear();
+                testFixedArray803 = testFixedArrayReuse805;
+            } else {
+                testFixedArray803 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen804), testFixedArray802);
+            }
+            do {
+                for (int counter806 = 0; (counter806 <chunkLen804); counter806 ++) {
+                    Object testFixedArrayArrayElementReuseVar807 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
+                        testFixedArrayArrayElementReuseVar807 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                    }
+                    byte[] testFixed808;
+                    if ((testFixedArrayArrayElementReuseVar807 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar807).bytes().length == (2))) {
+                        testFixed808 = ((GenericFixed) testFixedArrayArrayElementReuseVar807).bytes();
+                    } else {
+                        testFixed808 = ( new byte[2]);
+                    }
+                    decoder.readFixed(testFixed808);
+                    testFixedArray803 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed808));
+                }
+                chunkLen804 = (decoder.arrayNext());
+            } while (chunkLen804 > 0);
+        } else {
+            testFixedArray803 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray802);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray803);
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray810 = null;
+        long chunkLen811 = (decoder.readArrayStart());
+        if (chunkLen811 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse812 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
+                testFixedUnionArrayReuse812 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+            }
+            if (testFixedUnionArrayReuse812 != (null)) {
+                testFixedUnionArrayReuse812 .clear();
+                testFixedUnionArray810 = testFixedUnionArrayReuse812;
+            } else {
+                testFixedUnionArray810 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen811), testFixedUnionArray809);
+            }
+            do {
+                for (int counter813 = 0; (counter813 <chunkLen811); counter813 ++) {
+                    Object testFixedUnionArrayArrayElementReuseVar815 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
+                        testFixedUnionArrayArrayElementReuseVar815 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                    }
+                    int unionIndex816 = (decoder.readIndex());
+                    if (unionIndex816 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex816 == 1) {
+                        byte[] testFixed817;
+                        if ((testFixedUnionArrayArrayElementReuseVar815 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar815).bytes().length == (2))) {
+                            testFixed817 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar815).bytes();
+                        } else {
+                            testFixed817 = ( new byte[2]);
+                        }
+                        decoder.readFixed(testFixed817);
+                        testFixedUnionArray810 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed817));
+                    }
+                }
+                chunkLen811 = (decoder.arrayNext());
+            } while (chunkLen811 > 0);
+        } else {
+            testFixedUnionArray810 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray809);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray810);
+        return FastGenericDeserializerGeneratorTest_shouldReadFixed;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema union875;
+    private final Schema unionOptionSchema877;
+    private final Schema subField879;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.union875 = readerSchema.getField("union").schema();
+        this.unionOptionSchema877 = union875 .getTypes().get(1);
+        this.subField879 = unionOptionSchema877 .getField("subField").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion874((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion874(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex876 = (decoder.readIndex());
+        if (unionIndex876 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex876 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord878(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+        } else {
+            if (unionIndex876 == 2) {
+                if (FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex876 == 3) {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
+    }
+
+    public IndexedRecord deserializesubRecord878(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema877)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema877);
+        }
+        int unionIndex880 = (decoder.readIndex());
+        if (unionIndex880 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex880 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
@@ -1,0 +1,123 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapField882;
+    private final Schema mapFieldMapValueSchema888;
+    private final Schema mapFieldValueMapValueSchema894;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapField882 = readerSchema.getField("mapField").schema();
+        this.mapFieldMapValueSchema888 = mapField882 .getValueType();
+        this.mapFieldValueMapValueSchema894 = mapFieldMapValueSchema888 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap881((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap881(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadNestedMap = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadNestedMap = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Map<Utf8, List<Integer>>> mapField883 = null;
+        long chunkLen884 = (decoder.readMapStart());
+        if (chunkLen884 > 0) {
+            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse885 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0) instanceof Map) {
+                mapFieldReuse885 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
+            }
+            if (mapFieldReuse885 != (null)) {
+                mapFieldReuse885 .clear();
+                mapField883 = mapFieldReuse885;
+            } else {
+                mapField883 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
+            }
+            do {
+                for (int counter886 = 0; (counter886 <chunkLen884); counter886 ++) {
+                    Utf8 key887 = (decoder.readString(null));
+                    Map<Utf8, List<Integer>> mapFieldValue889 = null;
+                    long chunkLen890 = (decoder.readMapStart());
+                    if (chunkLen890 > 0) {
+                        Map<Utf8, List<Integer>> mapFieldValueReuse891 = null;
+                        if (null instanceof Map) {
+                            mapFieldValueReuse891 = ((Map) null);
+                        }
+                        if (mapFieldValueReuse891 != (null)) {
+                            mapFieldValueReuse891 .clear();
+                            mapFieldValue889 = mapFieldValueReuse891;
+                        } else {
+                            mapFieldValue889 = new HashMap<Utf8, List<Integer>>();
+                        }
+                        do {
+                            for (int counter892 = 0; (counter892 <chunkLen890); counter892 ++) {
+                                Utf8 key893 = (decoder.readString(null));
+                                List<Integer> mapFieldValueValue895 = null;
+                                long chunkLen896 = (decoder.readArrayStart());
+                                if (chunkLen896 > 0) {
+                                    List<Integer> mapFieldValueValueReuse897 = null;
+                                    if (null instanceof List) {
+                                        mapFieldValueValueReuse897 = ((List) null);
+                                    }
+                                    if (mapFieldValueValueReuse897 != (null)) {
+                                        mapFieldValueValueReuse897 .clear();
+                                        mapFieldValueValue895 = mapFieldValueValueReuse897;
+                                    } else {
+                                        mapFieldValueValue895 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen896), mapFieldValueMapValueSchema894);
+                                    }
+                                    do {
+                                        for (int counter898 = 0; (counter898 <chunkLen896); counter898 ++) {
+                                            Object mapFieldValueValueArrayElementReuseVar899 = null;
+                                            if (null instanceof GenericArray) {
+                                                mapFieldValueValueArrayElementReuseVar899 = ((GenericArray) null).peek();
+                                            }
+                                            mapFieldValueValue895 .add((decoder.readInt()));
+                                        }
+                                        chunkLen896 = (decoder.arrayNext());
+                                    } while (chunkLen896 > 0);
+                                } else {
+                                    mapFieldValueValue895 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema894);
+                                }
+                                mapFieldValue889 .put(key893, mapFieldValueValue895);
+                            }
+                            chunkLen890 = (decoder.mapNext());
+                        } while (chunkLen890 > 0);
+                    } else {
+                        mapFieldValue889 = Collections.emptyMap();
+                    }
+                    mapField883 .put(key887, mapFieldValue889);
+                }
+                chunkLen884 = (decoder.mapNext());
+            } while (chunkLen884 > 0);
+        } else {
+            mapField883 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField883);
+        return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
@@ -1,0 +1,186 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum901;
+    private final Schema testEnumUnion904;
+    private final Schema testEnumArray908;
+    private final Schema testEnumUnionArray916;
+    private final Schema testEnumUnionArrayArrayElemSchema921;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum901 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion904 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray908 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray916 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema921 = testEnumUnionArray916 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum900((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum900(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex902 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue903 = null;
+        if (enumIndex902 == 0) {
+            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+        }
+        if (enumIndex902 == 1) {
+            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+        }
+        if (enumIndex902 == 2) {
+            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+        }
+        if (enumIndex902 == 3) {
+            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+        }
+        if (enumIndex902 == 4) {
+            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue903);
+        int unionIndex905 = (decoder.readIndex());
+        if (unionIndex905 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex905 == 1) {
+            int enumIndex906 = (decoder.readEnum());
+            org.apache.avro.generic.GenericData.EnumSymbol enumValue907 = null;
+            if (enumIndex906 == 0) {
+                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+            }
+            if (enumIndex906 == 1) {
+                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+            }
+            if (enumIndex906 == 2) {
+                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+            }
+            if (enumIndex906 == 3) {
+                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+            }
+            if (enumIndex906 == 4) {
+                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue907);
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray909 = null;
+        long chunkLen910 = (decoder.readArrayStart());
+        if (chunkLen910 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse911 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
+                testEnumArrayReuse911 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+            }
+            if (testEnumArrayReuse911 != (null)) {
+                testEnumArrayReuse911 .clear();
+                testEnumArray909 = testEnumArrayReuse911;
+            } else {
+                testEnumArray909 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen910), testEnumArray908);
+            }
+            do {
+                for (int counter912 = 0; (counter912 <chunkLen910); counter912 ++) {
+                    Object testEnumArrayArrayElementReuseVar913 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof GenericArray) {
+                        testEnumArrayArrayElementReuseVar913 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
+                    }
+                    int enumIndex914 = (decoder.readEnum());
+                    org.apache.avro.generic.GenericData.EnumSymbol enumValue915 = null;
+                    if (enumIndex914 == 0) {
+                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+                    }
+                    if (enumIndex914 == 1) {
+                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+                    }
+                    if (enumIndex914 == 2) {
+                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+                    }
+                    if (enumIndex914 == 3) {
+                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+                    }
+                    if (enumIndex914 == 4) {
+                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+                    }
+                    testEnumArray909 .add(enumValue915);
+                }
+                chunkLen910 = (decoder.arrayNext());
+            } while (chunkLen910 > 0);
+        } else {
+            testEnumArray909 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray908);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray909);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray917 = null;
+        long chunkLen918 = (decoder.readArrayStart());
+        if (chunkLen918 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse919 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
+                testEnumUnionArrayReuse919 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+            }
+            if (testEnumUnionArrayReuse919 != (null)) {
+                testEnumUnionArrayReuse919 .clear();
+                testEnumUnionArray917 = testEnumUnionArrayReuse919;
+            } else {
+                testEnumUnionArray917 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen918), testEnumUnionArray916);
+            }
+            do {
+                for (int counter920 = 0; (counter920 <chunkLen918); counter920 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar922 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
+                        testEnumUnionArrayArrayElementReuseVar922 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                    }
+                    int unionIndex923 = (decoder.readIndex());
+                    if (unionIndex923 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex923 == 1) {
+                        int enumIndex924 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue925 = null;
+                        if (enumIndex924 == 0) {
+                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+                        }
+                        if (enumIndex924 == 1) {
+                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+                        }
+                        if (enumIndex924 == 2) {
+                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+                        }
+                        if (enumIndex924 == 3) {
+                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+                        }
+                        if (enumIndex924 == 4) {
+                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+                        }
+                        testEnumUnionArray917 .add(enumValue925);
+                    }
+                }
+                chunkLen918 = (decoder.arrayNext());
+            } while (chunkLen918 > 0);
+        } else {
+            testEnumUnionArray917 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray916);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray917);
+        return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957.java
@@ -1,0 +1,126 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testIntUnion927;
+    private final Schema testStringUnion929;
+    private final Schema testLongUnion931;
+    private final Schema testDoubleUnion933;
+    private final Schema testFloatUnion935;
+    private final Schema testBooleanUnion937;
+    private final Schema testBytesUnion939;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testIntUnion927 = readerSchema.getField("testIntUnion").schema();
+        this.testStringUnion929 = readerSchema.getField("testStringUnion").schema();
+        this.testLongUnion931 = readerSchema.getField("testLongUnion").schema();
+        this.testDoubleUnion933 = readerSchema.getField("testDoubleUnion").schema();
+        this.testFloatUnion935 = readerSchema.getField("testFloatUnion").schema();
+        this.testBooleanUnion937 = readerSchema.getField("testBooleanUnion").schema();
+        this.testBytesUnion939 = readerSchema.getField("testBytesUnion").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives926((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives926(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
+        int unionIndex928 = (decoder.readIndex());
+        if (unionIndex928 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex928 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
+        }
+        if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2) instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2))));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(null));
+        }
+        int unionIndex930 = (decoder.readIndex());
+        if (unionIndex930 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex930 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(null));
+            }
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
+        int unionIndex932 = (decoder.readIndex());
+        if (unionIndex932 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex932 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
+        int unionIndex934 = (decoder.readIndex());
+        if (unionIndex934 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex934 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
+        int unionIndex936 = (decoder.readIndex());
+        if (unionIndex936 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex936 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
+        int unionIndex938 = (decoder.readIndex());
+        if (unionIndex938 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex938 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
+        }
+        if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12) instanceof ByteBuffer) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12))));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes((null)));
+        }
+        int unionIndex940 = (decoder.readIndex());
+        if (unionIndex940 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex940 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13) instanceof ByteBuffer) {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes((null)));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123.java
@@ -1,0 +1,213 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordsArray945;
+    private final Schema recordsArrayArrayElemSchema950;
+    private final Schema subField953;
+    private final Schema recordsMap955;
+    private final Schema recordsArrayUnion961;
+    private final Schema recordsArrayUnionOptionSchema963;
+    private final Schema recordsArrayUnionOptionArrayElemSchema968;
+    private final Schema recordsMapUnion971;
+    private final Schema recordsMapUnionOptionSchema973;
+    private final Schema recordsMapUnionOptionMapValueSchema979;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordsArray945 = readerSchema.getField("recordsArray").schema();
+        this.recordsArrayArrayElemSchema950 = recordsArray945 .getElementType();
+        this.subField953 = recordsArrayArrayElemSchema950 .getField("subField").schema();
+        this.recordsMap955 = readerSchema.getField("recordsMap").schema();
+        this.recordsArrayUnion961 = readerSchema.getField("recordsArrayUnion").schema();
+        this.recordsArrayUnionOptionSchema963 = recordsArrayUnion961 .getTypes().get(1);
+        this.recordsArrayUnionOptionArrayElemSchema968 = recordsArrayUnionOptionSchema963 .getElementType();
+        this.recordsMapUnion971 = readerSchema.getField("recordsMapUnion").schema();
+        this.recordsMapUnionOptionSchema973 = recordsMapUnion971 .getTypes().get(1);
+        this.recordsMapUnionOptionMapValueSchema979 = recordsMapUnionOptionSchema973 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField944((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField944(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<IndexedRecord> recordsArray946 = null;
+        long chunkLen947 = (decoder.readArrayStart());
+        if (chunkLen947 > 0) {
+            List<IndexedRecord> recordsArrayReuse948 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
+                recordsArrayReuse948 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+            }
+            if (recordsArrayReuse948 != (null)) {
+                recordsArrayReuse948 .clear();
+                recordsArray946 = recordsArrayReuse948;
+            } else {
+                recordsArray946 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen947), recordsArray945);
+            }
+            do {
+                for (int counter949 = 0; (counter949 <chunkLen947); counter949 ++) {
+                    Object recordsArrayArrayElementReuseVar951 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
+                        recordsArrayArrayElementReuseVar951 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                    }
+                    recordsArray946 .add(deserializesubRecord952(recordsArrayArrayElementReuseVar951, (decoder)));
+                }
+                chunkLen947 = (decoder.arrayNext());
+            } while (chunkLen947 > 0);
+        } else {
+            recordsArray946 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray945);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray946);
+        Map<Utf8, IndexedRecord> recordsMap956 = null;
+        long chunkLen957 = (decoder.readMapStart());
+        if (chunkLen957 > 0) {
+            Map<Utf8, IndexedRecord> recordsMapReuse958 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1) instanceof Map) {
+                recordsMapReuse958 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
+            }
+            if (recordsMapReuse958 != (null)) {
+                recordsMapReuse958 .clear();
+                recordsMap956 = recordsMapReuse958;
+            } else {
+                recordsMap956 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter959 = 0; (counter959 <chunkLen957); counter959 ++) {
+                    Utf8 key960 = (decoder.readString(null));
+                    recordsMap956 .put(key960, deserializesubRecord952(null, (decoder)));
+                }
+                chunkLen957 = (decoder.mapNext());
+            } while (chunkLen957 > 0);
+        } else {
+            recordsMap956 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap956);
+        int unionIndex962 = (decoder.readIndex());
+        if (unionIndex962 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex962 == 1) {
+            List<IndexedRecord> recordsArrayUnionOption964 = null;
+            long chunkLen965 = (decoder.readArrayStart());
+            if (chunkLen965 > 0) {
+                List<IndexedRecord> recordsArrayUnionOptionReuse966 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
+                    recordsArrayUnionOptionReuse966 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                }
+                if (recordsArrayUnionOptionReuse966 != (null)) {
+                    recordsArrayUnionOptionReuse966 .clear();
+                    recordsArrayUnionOption964 = recordsArrayUnionOptionReuse966;
+                } else {
+                    recordsArrayUnionOption964 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen965), recordsArrayUnionOptionSchema963);
+                }
+                do {
+                    for (int counter967 = 0; (counter967 <chunkLen965); counter967 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar969 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayUnionOptionArrayElementReuseVar969 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                        }
+                        int unionIndex970 = (decoder.readIndex());
+                        if (unionIndex970 == 0) {
+                            decoder.readNull();
+                        }
+                        if (unionIndex970 == 1) {
+                            recordsArrayUnionOption964 .add(deserializesubRecord952(recordsArrayUnionOptionArrayElementReuseVar969, (decoder)));
+                        }
+                    }
+                    chunkLen965 = (decoder.arrayNext());
+                } while (chunkLen965 > 0);
+            } else {
+                recordsArrayUnionOption964 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema963);
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption964);
+        }
+        int unionIndex972 = (decoder.readIndex());
+        if (unionIndex972 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex972 == 1) {
+            Map<Utf8, IndexedRecord> recordsMapUnionOption974 = null;
+            long chunkLen975 = (decoder.readMapStart());
+            if (chunkLen975 > 0) {
+                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse976 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3) instanceof Map) {
+                    recordsMapUnionOptionReuse976 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
+                }
+                if (recordsMapUnionOptionReuse976 != (null)) {
+                    recordsMapUnionOptionReuse976 .clear();
+                    recordsMapUnionOption974 = recordsMapUnionOptionReuse976;
+                } else {
+                    recordsMapUnionOption974 = new HashMap<Utf8, IndexedRecord>();
+                }
+                do {
+                    for (int counter977 = 0; (counter977 <chunkLen975); counter977 ++) {
+                        Utf8 key978 = (decoder.readString(null));
+                        int unionIndex980 = (decoder.readIndex());
+                        if (unionIndex980 == 0) {
+                            decoder.readNull();
+                        }
+                        if (unionIndex980 == 1) {
+                            recordsMapUnionOption974 .put(key978, deserializesubRecord952(null, (decoder)));
+                        }
+                    }
+                    chunkLen975 = (decoder.mapNext());
+                } while (chunkLen975 > 0);
+            } else {
+                recordsMapUnionOption974 = Collections.emptyMap();
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption974);
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
+    }
+
+    public IndexedRecord deserializesubRecord952(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema950)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema950);
+        }
+        int unionIndex954 = (decoder.readIndex());
+        if (unionIndex954 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex954 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709.java
@@ -1,0 +1,331 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordsArrayMap982;
+    private final Schema recordsArrayMapArrayElemSchema987;
+    private final Schema recordsArrayMapElemMapValueSchema994;
+    private final Schema recordsArrayMapElemValueOptionSchema996;
+    private final Schema subField998;
+    private final Schema recordsMapArray1000;
+    private final Schema recordsMapArrayMapValueSchema1006;
+    private final Schema recordsMapArrayValueArrayElemSchema1011;
+    private final Schema recordsArrayMapUnion1014;
+    private final Schema recordsArrayMapUnionOptionArrayElemSchema1020;
+    private final Schema recordsArrayMapUnionOptionElemMapValueSchema1027;
+    private final Schema recordsMapArrayUnion1029;
+    private final Schema recordsMapArrayUnionOptionSchema1031;
+    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema1041;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordsArrayMap982 = readerSchema.getField("recordsArrayMap").schema();
+        this.recordsArrayMapArrayElemSchema987 = recordsArrayMap982 .getElementType();
+        this.recordsArrayMapElemMapValueSchema994 = recordsArrayMapArrayElemSchema987 .getValueType();
+        this.recordsArrayMapElemValueOptionSchema996 = recordsArrayMapElemMapValueSchema994 .getTypes().get(1);
+        this.subField998 = recordsArrayMapElemValueOptionSchema996 .getField("subField").schema();
+        this.recordsMapArray1000 = readerSchema.getField("recordsMapArray").schema();
+        this.recordsMapArrayMapValueSchema1006 = recordsMapArray1000 .getValueType();
+        this.recordsMapArrayValueArrayElemSchema1011 = recordsMapArrayMapValueSchema1006 .getElementType();
+        this.recordsArrayMapUnion1014 = readerSchema.getField("recordsArrayMapUnion").schema();
+        this.recordsArrayMapUnionOptionArrayElemSchema1020 = recordsArrayMap982 .getElementType();
+        this.recordsArrayMapUnionOptionElemMapValueSchema1027 = recordsArrayMapUnionOptionArrayElemSchema1020 .getValueType();
+        this.recordsMapArrayUnion1029 = readerSchema.getField("recordsMapArrayUnion").schema();
+        this.recordsMapArrayUnionOptionSchema1031 = recordsMapArrayUnion1029 .getTypes().get(1);
+        this.recordsMapArrayUnionOptionValueArrayElemSchema1041 = recordsMapArrayMapValueSchema1006 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField981((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField981(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Map<Utf8, IndexedRecord>> recordsArrayMap983 = null;
+        long chunkLen984 = (decoder.readArrayStart());
+        if (chunkLen984 > 0) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse985 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
+                recordsArrayMapReuse985 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+            }
+            if (recordsArrayMapReuse985 != (null)) {
+                recordsArrayMapReuse985 .clear();
+                recordsArrayMap983 = recordsArrayMapReuse985;
+            } else {
+                recordsArrayMap983 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen984), recordsArrayMap982);
+            }
+            do {
+                for (int counter986 = 0; (counter986 <chunkLen984); counter986 ++) {
+                    Object recordsArrayMapArrayElementReuseVar988 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
+                        recordsArrayMapArrayElementReuseVar988 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                    }
+                    Map<Utf8, IndexedRecord> recordsArrayMapElem989 = null;
+                    long chunkLen990 = (decoder.readMapStart());
+                    if (chunkLen990 > 0) {
+                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse991 = null;
+                        if (recordsArrayMapArrayElementReuseVar988 instanceof Map) {
+                            recordsArrayMapElemReuse991 = ((Map) recordsArrayMapArrayElementReuseVar988);
+                        }
+                        if (recordsArrayMapElemReuse991 != (null)) {
+                            recordsArrayMapElemReuse991 .clear();
+                            recordsArrayMapElem989 = recordsArrayMapElemReuse991;
+                        } else {
+                            recordsArrayMapElem989 = new HashMap<Utf8, IndexedRecord>();
+                        }
+                        do {
+                            for (int counter992 = 0; (counter992 <chunkLen990); counter992 ++) {
+                                Utf8 key993 = (decoder.readString(null));
+                                int unionIndex995 = (decoder.readIndex());
+                                if (unionIndex995 == 0) {
+                                    decoder.readNull();
+                                }
+                                if (unionIndex995 == 1) {
+                                    recordsArrayMapElem989 .put(key993, deserializesubRecord997(null, (decoder)));
+                                }
+                            }
+                            chunkLen990 = (decoder.mapNext());
+                        } while (chunkLen990 > 0);
+                    } else {
+                        recordsArrayMapElem989 = Collections.emptyMap();
+                    }
+                    recordsArrayMap983 .add(recordsArrayMapElem989);
+                }
+                chunkLen984 = (decoder.arrayNext());
+            } while (chunkLen984 > 0);
+        } else {
+            recordsArrayMap983 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap982);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap983);
+        Map<Utf8, List<IndexedRecord>> recordsMapArray1001 = null;
+        long chunkLen1002 = (decoder.readMapStart());
+        if (chunkLen1002 > 0) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse1003 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1) instanceof Map) {
+                recordsMapArrayReuse1003 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
+            }
+            if (recordsMapArrayReuse1003 != (null)) {
+                recordsMapArrayReuse1003 .clear();
+                recordsMapArray1001 = recordsMapArrayReuse1003;
+            } else {
+                recordsMapArray1001 = new HashMap<Utf8, List<IndexedRecord>>();
+            }
+            do {
+                for (int counter1004 = 0; (counter1004 <chunkLen1002); counter1004 ++) {
+                    Utf8 key1005 = (decoder.readString(null));
+                    List<IndexedRecord> recordsMapArrayValue1007 = null;
+                    long chunkLen1008 = (decoder.readArrayStart());
+                    if (chunkLen1008 > 0) {
+                        List<IndexedRecord> recordsMapArrayValueReuse1009 = null;
+                        if (null instanceof List) {
+                            recordsMapArrayValueReuse1009 = ((List) null);
+                        }
+                        if (recordsMapArrayValueReuse1009 != (null)) {
+                            recordsMapArrayValueReuse1009 .clear();
+                            recordsMapArrayValue1007 = recordsMapArrayValueReuse1009;
+                        } else {
+                            recordsMapArrayValue1007 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1008), recordsMapArrayMapValueSchema1006);
+                        }
+                        do {
+                            for (int counter1010 = 0; (counter1010 <chunkLen1008); counter1010 ++) {
+                                Object recordsMapArrayValueArrayElementReuseVar1012 = null;
+                                if (null instanceof GenericArray) {
+                                    recordsMapArrayValueArrayElementReuseVar1012 = ((GenericArray) null).peek();
+                                }
+                                int unionIndex1013 = (decoder.readIndex());
+                                if (unionIndex1013 == 0) {
+                                    decoder.readNull();
+                                }
+                                if (unionIndex1013 == 1) {
+                                    recordsMapArrayValue1007 .add(deserializesubRecord997(recordsMapArrayValueArrayElementReuseVar1012, (decoder)));
+                                }
+                            }
+                            chunkLen1008 = (decoder.arrayNext());
+                        } while (chunkLen1008 > 0);
+                    } else {
+                        recordsMapArrayValue1007 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema1006);
+                    }
+                    recordsMapArray1001 .put(key1005, recordsMapArrayValue1007);
+                }
+                chunkLen1002 = (decoder.mapNext());
+            } while (chunkLen1002 > 0);
+        } else {
+            recordsMapArray1001 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray1001);
+        int unionIndex1015 = (decoder.readIndex());
+        if (unionIndex1015 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1015 == 1) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption1016 = null;
+            long chunkLen1017 = (decoder.readArrayStart());
+            if (chunkLen1017 > 0) {
+                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse1018 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
+                    recordsArrayMapUnionOptionReuse1018 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                }
+                if (recordsArrayMapUnionOptionReuse1018 != (null)) {
+                    recordsArrayMapUnionOptionReuse1018 .clear();
+                    recordsArrayMapUnionOption1016 = recordsArrayMapUnionOptionReuse1018;
+                } else {
+                    recordsArrayMapUnionOption1016 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen1017), recordsArrayMap982);
+                }
+                do {
+                    for (int counter1019 = 0; (counter1019 <chunkLen1017); counter1019 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar1021 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayMapUnionOptionArrayElementReuseVar1021 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                        }
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem1022 = null;
+                        long chunkLen1023 = (decoder.readMapStart());
+                        if (chunkLen1023 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse1024 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar1021 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse1024 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar1021);
+                            }
+                            if (recordsArrayMapUnionOptionElemReuse1024 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse1024 .clear();
+                                recordsArrayMapUnionOptionElem1022 = recordsArrayMapUnionOptionElemReuse1024;
+                            } else {
+                                recordsArrayMapUnionOptionElem1022 = new HashMap<Utf8, IndexedRecord>();
+                            }
+                            do {
+                                for (int counter1025 = 0; (counter1025 <chunkLen1023); counter1025 ++) {
+                                    Utf8 key1026 = (decoder.readString(null));
+                                    int unionIndex1028 = (decoder.readIndex());
+                                    if (unionIndex1028 == 0) {
+                                        decoder.readNull();
+                                    }
+                                    if (unionIndex1028 == 1) {
+                                        recordsArrayMapUnionOptionElem1022 .put(key1026, deserializesubRecord997(null, (decoder)));
+                                    }
+                                }
+                                chunkLen1023 = (decoder.mapNext());
+                            } while (chunkLen1023 > 0);
+                        } else {
+                            recordsArrayMapUnionOptionElem1022 = Collections.emptyMap();
+                        }
+                        recordsArrayMapUnionOption1016 .add(recordsArrayMapUnionOptionElem1022);
+                    }
+                    chunkLen1017 = (decoder.arrayNext());
+                } while (chunkLen1017 > 0);
+            } else {
+                recordsArrayMapUnionOption1016 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap982);
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption1016);
+        }
+        int unionIndex1030 = (decoder.readIndex());
+        if (unionIndex1030 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1030 == 1) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption1032 = null;
+            long chunkLen1033 = (decoder.readMapStart());
+            if (chunkLen1033 > 0) {
+                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse1034 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3) instanceof Map) {
+                    recordsMapArrayUnionOptionReuse1034 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
+                }
+                if (recordsMapArrayUnionOptionReuse1034 != (null)) {
+                    recordsMapArrayUnionOptionReuse1034 .clear();
+                    recordsMapArrayUnionOption1032 = recordsMapArrayUnionOptionReuse1034;
+                } else {
+                    recordsMapArrayUnionOption1032 = new HashMap<Utf8, List<IndexedRecord>>();
+                }
+                do {
+                    for (int counter1035 = 0; (counter1035 <chunkLen1033); counter1035 ++) {
+                        Utf8 key1036 = (decoder.readString(null));
+                        List<IndexedRecord> recordsMapArrayUnionOptionValue1037 = null;
+                        long chunkLen1038 = (decoder.readArrayStart());
+                        if (chunkLen1038 > 0) {
+                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse1039 = null;
+                            if (null instanceof List) {
+                                recordsMapArrayUnionOptionValueReuse1039 = ((List) null);
+                            }
+                            if (recordsMapArrayUnionOptionValueReuse1039 != (null)) {
+                                recordsMapArrayUnionOptionValueReuse1039 .clear();
+                                recordsMapArrayUnionOptionValue1037 = recordsMapArrayUnionOptionValueReuse1039;
+                            } else {
+                                recordsMapArrayUnionOptionValue1037 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1038), recordsMapArrayMapValueSchema1006);
+                            }
+                            do {
+                                for (int counter1040 = 0; (counter1040 <chunkLen1038); counter1040 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar1042 = null;
+                                    if (null instanceof GenericArray) {
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar1042 = ((GenericArray) null).peek();
+                                    }
+                                    int unionIndex1043 = (decoder.readIndex());
+                                    if (unionIndex1043 == 0) {
+                                        decoder.readNull();
+                                    }
+                                    if (unionIndex1043 == 1) {
+                                        recordsMapArrayUnionOptionValue1037 .add(deserializesubRecord997(recordsMapArrayUnionOptionValueArrayElementReuseVar1042, (decoder)));
+                                    }
+                                }
+                                chunkLen1038 = (decoder.arrayNext());
+                            } while (chunkLen1038 > 0);
+                        } else {
+                            recordsMapArrayUnionOptionValue1037 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema1006);
+                        }
+                        recordsMapArrayUnionOption1032 .put(key1036, recordsMapArrayUnionOptionValue1037);
+                    }
+                    chunkLen1033 = (decoder.mapNext());
+                } while (chunkLen1033 > 0);
+            } else {
+                recordsMapArrayUnionOption1032 = Collections.emptyMap();
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption1032);
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
+    }
+
+    public IndexedRecord deserializesubRecord997(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema996)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema996);
+        }
+        int unionIndex999 = (decoder.readIndex());
+        if (unionIndex999 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex999 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531.java
@@ -1,0 +1,89 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record1045;
+    private final Schema recordOptionSchema1047;
+    private final Schema subField1049;
+    private final Schema field1051;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record1045 = readerSchema.getField("record").schema();
+        this.recordOptionSchema1047 = record1045 .getTypes().get(1);
+        this.subField1049 = recordOptionSchema1047 .getField("subField").schema();
+        this.field1051 = readerSchema.getField("field").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField1044((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField1044(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex1046 = (decoder.readIndex());
+        if (unionIndex1046 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1046 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord1048(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord1048(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        int unionIndex1052 = (decoder.readIndex());
+        if (unionIndex1052 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1052 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(null));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
+    }
+
+    public IndexedRecord deserializesubRecord1048(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema1047)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema1047);
+        }
+        int unionIndex1050 = (decoder.readIndex());
+        if (unionIndex1050 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1050 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106.java
@@ -1,0 +1,188 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testNotRemoved1054;
+    private final Schema testNotRemoved21057;
+    private final Schema subRecord1059;
+    private final Schema subRecordOptionSchema1061;
+    private final Schema testNotRemoved1063;
+    private final Schema testNotRemoved21066;
+    private final Schema subRecordMap1068;
+    private final Schema subRecordArray1074;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testNotRemoved1054 = readerSchema.getField("testNotRemoved").schema();
+        this.testNotRemoved21057 = readerSchema.getField("testNotRemoved2").schema();
+        this.subRecord1059 = readerSchema.getField("subRecord").schema();
+        this.subRecordOptionSchema1061 = subRecord1059 .getTypes().get(1);
+        this.testNotRemoved1063 = subRecordOptionSchema1061 .getField("testNotRemoved").schema();
+        this.testNotRemoved21066 = subRecordOptionSchema1061 .getField("testNotRemoved2").schema();
+        this.subRecordMap1068 = readerSchema.getField("subRecordMap").schema();
+        this.subRecordArray1074 = readerSchema.getField("subRecordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField1053((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField1053(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex1055 = (decoder.readIndex());
+        if (unionIndex1055 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1055 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex1056 = (decoder.readIndex());
+        if (unionIndex1056 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1056 == 1) {
+            decoder.skipString();
+        }
+        int unionIndex1058 = (decoder.readIndex());
+        if (unionIndex1058 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1058 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(null));
+            }
+        }
+        int unionIndex1060 = (decoder.readIndex());
+        if (unionIndex1060 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1060 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord1062(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+        }
+        Map<Utf8, IndexedRecord> subRecordMap1069 = null;
+        long chunkLen1070 = (decoder.readMapStart());
+        if (chunkLen1070 > 0) {
+            Map<Utf8, IndexedRecord> subRecordMapReuse1071 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3) instanceof Map) {
+                subRecordMapReuse1071 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
+            }
+            if (subRecordMapReuse1071 != (null)) {
+                subRecordMapReuse1071 .clear();
+                subRecordMap1069 = subRecordMapReuse1071;
+            } else {
+                subRecordMap1069 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter1072 = 0; (counter1072 <chunkLen1070); counter1072 ++) {
+                    Utf8 key1073 = (decoder.readString(null));
+                    subRecordMap1069 .put(key1073, deserializesubRecord1062(null, (decoder)));
+                }
+                chunkLen1070 = (decoder.mapNext());
+            } while (chunkLen1070 > 0);
+        } else {
+            subRecordMap1069 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1069);
+        List<IndexedRecord> subRecordArray1075 = null;
+        long chunkLen1076 = (decoder.readArrayStart());
+        if (chunkLen1076 > 0) {
+            List<IndexedRecord> subRecordArrayReuse1077 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
+                subRecordArrayReuse1077 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+            }
+            if (subRecordArrayReuse1077 != (null)) {
+                subRecordArrayReuse1077 .clear();
+                subRecordArray1075 = subRecordArrayReuse1077;
+            } else {
+                subRecordArray1075 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1076), subRecordArray1074);
+            }
+            do {
+                for (int counter1078 = 0; (counter1078 <chunkLen1076); counter1078 ++) {
+                    Object subRecordArrayArrayElementReuseVar1079 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
+                        subRecordArrayArrayElementReuseVar1079 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                    }
+                    subRecordArray1075 .add(deserializesubRecord1062(subRecordArrayArrayElementReuseVar1079, (decoder)));
+                }
+                chunkLen1076 = (decoder.arrayNext());
+            } while (chunkLen1076 > 0);
+        } else {
+            subRecordArray1075 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray1074);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1075);
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
+    }
+
+    public IndexedRecord deserializesubRecord1062(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema1061)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema1061);
+        }
+        int unionIndex1064 = (decoder.readIndex());
+        if (unionIndex1064 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1064 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex1065 = (decoder.readIndex());
+        if (unionIndex1065 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1065 == 1) {
+            decoder.skipString();
+        }
+        int unionIndex1067 = (decoder.readIndex());
+        if (unionIndex1067 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1067 == 1) {
+            if (subRecord.get(1) instanceof Utf8) {
+                subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+            } else {
+                subRecord.put(1, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565.java
@@ -1,0 +1,79 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord1081;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord1081 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord1080((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord1080(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord1082(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1082(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord1081)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord1081);
+        }
+        if (subRecord.get(0) instanceof Utf8) {
+            subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+        } else {
+            subRecord.put(0, (decoder).readString(null));
+        }
+        deserializesubSubRecord1083(null, (decoder));
+        int unionIndex1084 = (decoder.readIndex());
+        if (unionIndex1084 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1084 == 1) {
+            deserializesubSubRecord1083(null, (decoder));
+        }
+        if (subRecord.get(1) instanceof Utf8) {
+            subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+        } else {
+            subRecord.put(1, (decoder).readString(null));
+        }
+        return subRecord;
+    }
+
+    public void deserializesubSubRecord1083(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        decoder.skipString();
+        decoder.skipString();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899.java
@@ -1,0 +1,80 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord11086;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord11086 = readerSchema.getField("subRecord1").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1085((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1085(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord1087(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
+        deserializesubRecord21088(null, (decoder));
+        int unionIndex1089 = (decoder.readIndex());
+        if (unionIndex1089 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex1089 == 1) {
+            deserializesubRecord21088(null, (decoder));
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord1087(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1087(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord11086)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord11086);
+        }
+        if (subRecord.get(0) instanceof Utf8) {
+            subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+        } else {
+            subRecord.put(0, (decoder).readString(null));
+        }
+        if (subRecord.get(1) instanceof Utf8) {
+            subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+        } else {
+            subRecord.put(1, (decoder).readString(null));
+        }
+        return subRecord;
+    }
+
+    public void deserializesubRecord21088(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        decoder.skipString();
+        decoder.skipString();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -1,0 +1,88 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapValueSchema854;
+    private final Schema mapValueOptionSchema856;
+    private final Schema field858;
+
+    public Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapValueSchema854 = readerSchema.getValueType();
+        this.mapValueOptionSchema856 = mapMapValueSchema854 .getTypes().get(1);
+        this.field858 = mapValueOptionSchema856 .getField("field").schema();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map849 = null;
+        long chunkLen850 = (decoder.readMapStart());
+        if (chunkLen850 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse851 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse851 = ((Map)(reuse));
+            }
+            if (mapReuse851 != (null)) {
+                mapReuse851 .clear();
+                map849 = mapReuse851;
+            } else {
+                map849 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter852 = 0; (counter852 <chunkLen850); counter852 ++) {
+                    Utf8 key853 = (decoder.readString(null));
+                    int unionIndex855 = (decoder.readIndex());
+                    if (unionIndex855 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex855 == 1) {
+                        map849 .put(key853, deserializerecord857(null, (decoder)));
+                    }
+                }
+                chunkLen850 = (decoder.mapNext());
+            } while (chunkLen850 > 0);
+        } else {
+            map849 = Collections.emptyMap();
+        }
+        return map849;
+    }
+
+    public IndexedRecord deserializerecord857(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema856)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema856);
+        }
+        int unionIndex859 = (decoder.readIndex());
+        if (unionIndex859 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex859 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -1,0 +1,80 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapValueSchema845;
+    private final Schema field847;
+
+    public Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapValueSchema845 = readerSchema.getValueType();
+        this.field847 = mapMapValueSchema845 .getField("field").schema();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map840 = null;
+        long chunkLen841 = (decoder.readMapStart());
+        if (chunkLen841 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse842 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse842 = ((Map)(reuse));
+            }
+            if (mapReuse842 != (null)) {
+                mapReuse842 .clear();
+                map840 = mapReuse842;
+            } else {
+                map840 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter843 = 0; (counter843 <chunkLen841); counter843 ++) {
+                    Utf8 key844 = (decoder.readString(null));
+                    map840 .put(key844, deserializerecord846(null, (decoder)));
+                }
+                chunkLen841 = (decoder.mapNext());
+            } while (chunkLen841 > 0);
+        } else {
+            map840 = Collections.emptyMap();
+        }
+        return map840;
+    }
+
+    public IndexedRecord deserializerecord846(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema845)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema845);
+        }
+        int unionIndex848 = (decoder.readIndex());
+        if (unionIndex848 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex848 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class recordName_GenericDeserializer_6897301803194779359_6897301803194779359
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionField942;
+
+    public recordName_GenericDeserializer_6897301803194779359_6897301803194779359(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionField942 = readerSchema.getField("unionField").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecordName941((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecordName941(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord recordName;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            recordName = ((IndexedRecord)(reuse));
+        } else {
+            recordName = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        if (recordName.get(0) instanceof Utf8) {
+            recordName.put(0, (decoder).readString(((Utf8) recordName.get(0))));
+        } else {
+            recordName.put(0, (decoder).readString(null));
+        }
+        int unionIndex943 = (decoder.readIndex());
+        if (unionIndex943 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex943 == 1) {
+            recordName.put(1, deserializerecordName941(recordName.get(1), (decoder)));
+        }
+        return recordName;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388
+    implements FastDeserializer<List<Boolean>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Boolean> array592 = null;
+        long chunkLen593 = (decoder.readArrayStart());
+        if (chunkLen593 > 0) {
+            List<Boolean> arrayReuse594 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse594 = ((List)(reuse));
+            }
+            if (arrayReuse594 != (null)) {
+                arrayReuse594 .clear();
+                array592 = arrayReuse594;
+            } else {
+                array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen593), readerSchema);
+            }
+            do {
+                for (int counter595 = 0; (counter595 <chunkLen593); counter595 ++) {
+                    Object arrayArrayElementReuseVar596 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar596 = ((GenericArray)(reuse)).peek();
+                    }
+                    array592 .add((decoder.readBoolean()));
+                }
+                chunkLen593 = (decoder.arrayNext());
+            } while (chunkLen593 > 0);
+        } else {
+            array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
+        }
+        return array592;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740
+    implements FastDeserializer<List<Double>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Double> deserialize(List<Double> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Double> array597 = null;
+        long chunkLen598 = (decoder.readArrayStart());
+        if (chunkLen598 > 0) {
+            List<Double> arrayReuse599 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse599 = ((List)(reuse));
+            }
+            if (arrayReuse599 != (null)) {
+                arrayReuse599 .clear();
+                array597 = arrayReuse599;
+            } else {
+                array597 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen598), readerSchema);
+            }
+            do {
+                for (int counter600 = 0; (counter600 <chunkLen598); counter600 ++) {
+                    Object arrayArrayElementReuseVar601 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar601 = ((GenericArray)(reuse)).peek();
+                    }
+                    array597 .add((decoder.readDouble()));
+                }
+                chunkLen598 = (decoder.arrayNext());
+            } while (chunkLen598 > 0);
+        } else {
+            array597 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
+        }
+        return array597;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -1,0 +1,29 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583
+    implements FastDeserializer<List<Float>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Float> deserialize(List<Float> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Float> array602 = null;
+        array602 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        return array602;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685
+    implements FastDeserializer<List<Integer>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Integer> array603 = null;
+        long chunkLen604 = (decoder.readArrayStart());
+        if (chunkLen604 > 0) {
+            List<Integer> arrayReuse605 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse605 = ((List)(reuse));
+            }
+            if (arrayReuse605 != (null)) {
+                arrayReuse605 .clear();
+                array603 = arrayReuse605;
+            } else {
+                array603 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen604), readerSchema);
+            }
+            do {
+                for (int counter606 = 0; (counter606 <chunkLen604); counter606 ++) {
+                    Object arrayArrayElementReuseVar607 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar607 = ((GenericArray)(reuse)).peek();
+                    }
+                    array603 .add((decoder.readInt()));
+                }
+                chunkLen604 = (decoder.arrayNext());
+            } while (chunkLen604 > 0);
+        } else {
+            array603 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
+        }
+        return array603;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358
+    implements FastDeserializer<List<Long>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Long> deserialize(List<Long> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Long> array608 = null;
+        long chunkLen609 = (decoder.readArrayStart());
+        if (chunkLen609 > 0) {
+            List<Long> arrayReuse610 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse610 = ((List)(reuse));
+            }
+            if (arrayReuse610 != (null)) {
+                arrayReuse610 .clear();
+                array608 = arrayReuse610;
+            } else {
+                array608 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen609), readerSchema);
+            }
+            do {
+                for (int counter611 = 0; (counter611 <chunkLen609); counter611 ++) {
+                    Object arrayArrayElementReuseVar612 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar612 = ((GenericArray)(reuse)).peek();
+                    }
+                    array608 .add((decoder.readLong()));
+                }
+                chunkLen609 = (decoder.arrayNext());
+            } while (chunkLen609 > 0);
+        } else {
+            array608 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
+        }
+        return array608;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -1,0 +1,90 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArrayElemSchema626;
+    private final Schema arrayElemOptionSchema629;
+    private final Schema field631;
+
+    public Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArrayElemSchema626 = readerSchema.getElementType();
+        this.arrayElemOptionSchema629 = arrayArrayElemSchema626 .getTypes().get(1);
+        this.field631 = arrayElemOptionSchema629 .getField("field").schema();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array622 = null;
+        long chunkLen623 = (decoder.readArrayStart());
+        if (chunkLen623 > 0) {
+            List<IndexedRecord> arrayReuse624 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse624 = ((List)(reuse));
+            }
+            if (arrayReuse624 != (null)) {
+                arrayReuse624 .clear();
+                array622 = arrayReuse624;
+            } else {
+                array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen623), readerSchema);
+            }
+            do {
+                for (int counter625 = 0; (counter625 <chunkLen623); counter625 ++) {
+                    Object arrayArrayElementReuseVar627 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar627 = ((GenericArray)(reuse)).peek();
+                    }
+                    int unionIndex628 = (decoder.readIndex());
+                    if (unionIndex628 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex628 == 1) {
+                        array622 .add(deserializerecord630(arrayArrayElementReuseVar627, (decoder)));
+                    }
+                }
+                chunkLen623 = (decoder.arrayNext());
+            } while (chunkLen623 > 0);
+        } else {
+            array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+        }
+        return array622;
+    }
+
+    public IndexedRecord deserializerecord630(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema629)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema629);
+        }
+        int unionIndex632 = (decoder.readIndex());
+        if (unionIndex632 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex632 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArrayElemSchema617;
+    private final Schema field620;
+
+    public Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArrayElemSchema617 = readerSchema.getElementType();
+        this.field620 = arrayArrayElemSchema617 .getField("field").schema();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array613 = null;
+        long chunkLen614 = (decoder.readArrayStart());
+        if (chunkLen614 > 0) {
+            List<IndexedRecord> arrayReuse615 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse615 = ((List)(reuse));
+            }
+            if (arrayReuse615 != (null)) {
+                arrayReuse615 .clear();
+                array613 = arrayReuse615;
+            } else {
+                array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen614), readerSchema);
+            }
+            do {
+                for (int counter616 = 0; (counter616 <chunkLen614); counter616 ++) {
+                    Object arrayArrayElementReuseVar618 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar618 = ((GenericArray)(reuse)).peek();
+                    }
+                    array613 .add(deserializerecord619(arrayArrayElementReuseVar618, (decoder)));
+                }
+                chunkLen614 = (decoder.arrayNext());
+            } while (chunkLen614 > 0);
+        } else {
+            array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+        }
+        return array613;
+    }
+
+    public IndexedRecord deserializerecord619(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema617)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema617);
+        }
+        int unionIndex621 = (decoder.readIndex());
+        if (unionIndex621 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex621 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
@@ -1,0 +1,65 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testString588;
+    private final Schema testStringUnionAlias590;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testString588 = readerSchema.getField("testString").schema();
+        this.testStringUnionAlias590 = readerSchema.getField("testStringUnionAlias").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadAliasedField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadAliasedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex589 = (decoder.readIndex());
+        if (unionIndex589 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex589 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex591 = (decoder.readIndex());
+        if (unionIndex591 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex591 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(1, (decoder).readString(null));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -1,0 +1,118 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum634;
+    private final Schema testEnumUnion635;
+    private final Schema testEnumArray637;
+    private final Schema testEnumUnionArray643;
+    private final Schema testEnumUnionArrayArrayElemSchema648;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum634 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion635 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray637 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray643 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema648 = testEnumUnionArray643 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+        int unionIndex636 = (decoder.readIndex());
+        if (unionIndex636 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex636 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray638 = null;
+        long chunkLen639 = (decoder.readArrayStart());
+        if (chunkLen639 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse640 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
+                testEnumArrayReuse640 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+            }
+            if (testEnumArrayReuse640 != (null)) {
+                testEnumArrayReuse640 .clear();
+                testEnumArray638 = testEnumArrayReuse640;
+            } else {
+                testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen639), testEnumArray637);
+            }
+            do {
+                for (int counter641 = 0; (counter641 <chunkLen639); counter641 ++) {
+                    Object testEnumArrayArrayElementReuseVar642 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof GenericArray) {
+                        testEnumArrayArrayElementReuseVar642 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
+                    }
+                    testEnumArray638 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                }
+                chunkLen639 = (decoder.arrayNext());
+            } while (chunkLen639 > 0);
+        } else {
+            testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray637);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray638);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray644 = null;
+        long chunkLen645 = (decoder.readArrayStart());
+        if (chunkLen645 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse646 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
+                testEnumUnionArrayReuse646 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+            }
+            if (testEnumUnionArrayReuse646 != (null)) {
+                testEnumUnionArrayReuse646 .clear();
+                testEnumUnionArray644 = testEnumUnionArrayReuse646;
+            } else {
+                testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen645), testEnumUnionArray643);
+            }
+            do {
+                for (int counter647 = 0; (counter647 <chunkLen645); counter647 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar649 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
+                        testEnumUnionArrayArrayElementReuseVar649 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                    }
+                    int unionIndex650 = (decoder.readIndex());
+                    if (unionIndex650 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex650 == 1) {
+                        testEnumUnionArray644 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                    }
+                }
+                chunkLen645 = (decoder.arrayNext());
+            } while (chunkLen645 > 0);
+        } else {
+            testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray643);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray644);
+        return FastGenericDeserializerGeneratorTest_shouldReadEnum;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -1,0 +1,145 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testFixedUnion653;
+    private final Schema testFixedArray656;
+    private final Schema testFixedUnionArray663;
+    private final Schema testFixedUnionArrayArrayElemSchema668;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testFixedUnion653 = readerSchema.getField("testFixedUnion").schema();
+        this.testFixedArray656 = readerSchema.getField("testFixedArray").schema();
+        this.testFixedUnionArray663 = readerSchema.getField("testFixedUnionArray").schema();
+        this.testFixedUnionArrayArrayElemSchema668 = testFixedUnionArray663 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadFixed = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadFixed = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        byte[] testFixed652;
+        if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes().length == (2))) {
+            testFixed652 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
+        } else {
+            testFixed652 = ( new byte[2]);
+        }
+        decoder.readFixed(testFixed652);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(null, testFixed652));
+        int unionIndex654 = (decoder.readIndex());
+        if (unionIndex654 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex654 == 1) {
+            byte[] testFixed655;
+            if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes().length == (2))) {
+                testFixed655 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
+            } else {
+                testFixed655 = ( new byte[2]);
+            }
+            decoder.readFixed(testFixed655);
+            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(null, testFixed655));
+        }
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray657 = null;
+        long chunkLen658 = (decoder.readArrayStart());
+        if (chunkLen658 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse659 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
+                testFixedArrayReuse659 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+            }
+            if (testFixedArrayReuse659 != (null)) {
+                testFixedArrayReuse659 .clear();
+                testFixedArray657 = testFixedArrayReuse659;
+            } else {
+                testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen658), testFixedArray656);
+            }
+            do {
+                for (int counter660 = 0; (counter660 <chunkLen658); counter660 ++) {
+                    Object testFixedArrayArrayElementReuseVar661 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
+                        testFixedArrayArrayElementReuseVar661 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                    }
+                    byte[] testFixed662;
+                    if ((testFixedArrayArrayElementReuseVar661 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes().length == (2))) {
+                        testFixed662 = ((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes();
+                    } else {
+                        testFixed662 = ( new byte[2]);
+                    }
+                    decoder.readFixed(testFixed662);
+                    testFixedArray657 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed662));
+                }
+                chunkLen658 = (decoder.arrayNext());
+            } while (chunkLen658 > 0);
+        } else {
+            testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray656);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray657);
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray664 = null;
+        long chunkLen665 = (decoder.readArrayStart());
+        if (chunkLen665 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse666 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
+                testFixedUnionArrayReuse666 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+            }
+            if (testFixedUnionArrayReuse666 != (null)) {
+                testFixedUnionArrayReuse666 .clear();
+                testFixedUnionArray664 = testFixedUnionArrayReuse666;
+            } else {
+                testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen665), testFixedUnionArray663);
+            }
+            do {
+                for (int counter667 = 0; (counter667 <chunkLen665); counter667 ++) {
+                    Object testFixedUnionArrayArrayElementReuseVar669 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
+                        testFixedUnionArrayArrayElementReuseVar669 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                    }
+                    int unionIndex670 = (decoder.readIndex());
+                    if (unionIndex670 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex670 == 1) {
+                        byte[] testFixed671;
+                        if ((testFixedUnionArrayArrayElementReuseVar669 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes().length == (2))) {
+                            testFixed671 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes();
+                        } else {
+                            testFixed671 = ( new byte[2]);
+                        }
+                        decoder.readFixed(testFixed671);
+                        testFixedUnionArray664 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed671));
+                    }
+                }
+                chunkLen665 = (decoder.arrayNext());
+            } while (chunkLen665 > 0);
+        } else {
+            testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray663);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray664);
+        return FastGenericDeserializerGeneratorTest_shouldReadFixed;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema union729;
+    private final Schema unionOptionSchema731;
+    private final Schema subField733;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.union729 = readerSchema.getField("union").schema();
+        this.unionOptionSchema731 = union729 .getTypes().get(1);
+        this.subField733 = unionOptionSchema731 .getField("subField").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex730 = (decoder.readIndex());
+        if (unionIndex730 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex730 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord732(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+        } else {
+            if (unionIndex730 == 2) {
+                if (FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex730 == 3) {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
+    }
+
+    public IndexedRecord deserializesubRecord732(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema731)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema731);
+        }
+        int unionIndex734 = (decoder.readIndex());
+        if (unionIndex734 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex734 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -1,0 +1,123 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapField736;
+    private final Schema mapFieldMapValueSchema742;
+    private final Schema mapFieldValueMapValueSchema748;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapField736 = readerSchema.getField("mapField").schema();
+        this.mapFieldMapValueSchema742 = mapField736 .getValueType();
+        this.mapFieldValueMapValueSchema748 = mapFieldMapValueSchema742 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadNestedMap = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadNestedMap = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Map<Utf8, List<Integer>>> mapField737 = null;
+        long chunkLen738 = (decoder.readMapStart());
+        if (chunkLen738 > 0) {
+            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse739 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0) instanceof Map) {
+                mapFieldReuse739 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
+            }
+            if (mapFieldReuse739 != (null)) {
+                mapFieldReuse739 .clear();
+                mapField737 = mapFieldReuse739;
+            } else {
+                mapField737 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
+            }
+            do {
+                for (int counter740 = 0; (counter740 <chunkLen738); counter740 ++) {
+                    Utf8 key741 = (decoder.readString(null));
+                    Map<Utf8, List<Integer>> mapFieldValue743 = null;
+                    long chunkLen744 = (decoder.readMapStart());
+                    if (chunkLen744 > 0) {
+                        Map<Utf8, List<Integer>> mapFieldValueReuse745 = null;
+                        if (null instanceof Map) {
+                            mapFieldValueReuse745 = ((Map) null);
+                        }
+                        if (mapFieldValueReuse745 != (null)) {
+                            mapFieldValueReuse745 .clear();
+                            mapFieldValue743 = mapFieldValueReuse745;
+                        } else {
+                            mapFieldValue743 = new HashMap<Utf8, List<Integer>>();
+                        }
+                        do {
+                            for (int counter746 = 0; (counter746 <chunkLen744); counter746 ++) {
+                                Utf8 key747 = (decoder.readString(null));
+                                List<Integer> mapFieldValueValue749 = null;
+                                long chunkLen750 = (decoder.readArrayStart());
+                                if (chunkLen750 > 0) {
+                                    List<Integer> mapFieldValueValueReuse751 = null;
+                                    if (null instanceof List) {
+                                        mapFieldValueValueReuse751 = ((List) null);
+                                    }
+                                    if (mapFieldValueValueReuse751 != (null)) {
+                                        mapFieldValueValueReuse751 .clear();
+                                        mapFieldValueValue749 = mapFieldValueValueReuse751;
+                                    } else {
+                                        mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen750), mapFieldValueMapValueSchema748);
+                                    }
+                                    do {
+                                        for (int counter752 = 0; (counter752 <chunkLen750); counter752 ++) {
+                                            Object mapFieldValueValueArrayElementReuseVar753 = null;
+                                            if (null instanceof GenericArray) {
+                                                mapFieldValueValueArrayElementReuseVar753 = ((GenericArray) null).peek();
+                                            }
+                                            mapFieldValueValue749 .add((decoder.readInt()));
+                                        }
+                                        chunkLen750 = (decoder.arrayNext());
+                                    } while (chunkLen750 > 0);
+                                } else {
+                                    mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema748);
+                                }
+                                mapFieldValue743 .put(key747, mapFieldValueValue749);
+                            }
+                            chunkLen744 = (decoder.mapNext());
+                        } while (chunkLen744 > 0);
+                    } else {
+                        mapFieldValue743 = Collections.emptyMap();
+                    }
+                    mapField737 .put(key741, mapFieldValue743);
+                }
+                chunkLen738 = (decoder.mapNext());
+            } while (chunkLen738 > 0);
+        } else {
+            mapField737 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField737);
+        return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -1,0 +1,186 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum755;
+    private final Schema testEnumUnion758;
+    private final Schema testEnumArray762;
+    private final Schema testEnumUnionArray770;
+    private final Schema testEnumUnionArrayArrayElemSchema775;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum755 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion758 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray762 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray770 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema775 = testEnumUnionArray770 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex756 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue757 = null;
+        if (enumIndex756 == 0) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+        }
+        if (enumIndex756 == 1) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+        }
+        if (enumIndex756 == 2) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+        }
+        if (enumIndex756 == 3) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+        }
+        if (enumIndex756 == 4) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue757);
+        int unionIndex759 = (decoder.readIndex());
+        if (unionIndex759 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex759 == 1) {
+            int enumIndex760 = (decoder.readEnum());
+            org.apache.avro.generic.GenericData.EnumSymbol enumValue761 = null;
+            if (enumIndex760 == 0) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+            }
+            if (enumIndex760 == 1) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+            }
+            if (enumIndex760 == 2) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+            }
+            if (enumIndex760 == 3) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+            }
+            if (enumIndex760 == 4) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue761);
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray763 = null;
+        long chunkLen764 = (decoder.readArrayStart());
+        if (chunkLen764 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse765 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
+                testEnumArrayReuse765 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+            }
+            if (testEnumArrayReuse765 != (null)) {
+                testEnumArrayReuse765 .clear();
+                testEnumArray763 = testEnumArrayReuse765;
+            } else {
+                testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen764), testEnumArray762);
+            }
+            do {
+                for (int counter766 = 0; (counter766 <chunkLen764); counter766 ++) {
+                    Object testEnumArrayArrayElementReuseVar767 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof GenericArray) {
+                        testEnumArrayArrayElementReuseVar767 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
+                    }
+                    int enumIndex768 = (decoder.readEnum());
+                    org.apache.avro.generic.GenericData.EnumSymbol enumValue769 = null;
+                    if (enumIndex768 == 0) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                    }
+                    if (enumIndex768 == 1) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                    }
+                    if (enumIndex768 == 2) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                    }
+                    if (enumIndex768 == 3) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                    }
+                    if (enumIndex768 == 4) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                    }
+                    testEnumArray763 .add(enumValue769);
+                }
+                chunkLen764 = (decoder.arrayNext());
+            } while (chunkLen764 > 0);
+        } else {
+            testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray762);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray763);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray771 = null;
+        long chunkLen772 = (decoder.readArrayStart());
+        if (chunkLen772 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse773 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
+                testEnumUnionArrayReuse773 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+            }
+            if (testEnumUnionArrayReuse773 != (null)) {
+                testEnumUnionArrayReuse773 .clear();
+                testEnumUnionArray771 = testEnumUnionArrayReuse773;
+            } else {
+                testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen772), testEnumUnionArray770);
+            }
+            do {
+                for (int counter774 = 0; (counter774 <chunkLen772); counter774 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar776 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
+                        testEnumUnionArrayArrayElementReuseVar776 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                    }
+                    int unionIndex777 = (decoder.readIndex());
+                    if (unionIndex777 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex777 == 1) {
+                        int enumIndex778 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue779 = null;
+                        if (enumIndex778 == 0) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                        }
+                        if (enumIndex778 == 1) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                        }
+                        if (enumIndex778 == 2) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                        }
+                        if (enumIndex778 == 3) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                        }
+                        if (enumIndex778 == 4) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                        }
+                        testEnumUnionArray771 .add(enumValue779);
+                    }
+                }
+                chunkLen772 = (decoder.arrayNext());
+            } while (chunkLen772 > 0);
+        } else {
+            testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray770);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray771);
+        return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
@@ -1,0 +1,126 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testIntUnion781;
+    private final Schema testStringUnion783;
+    private final Schema testLongUnion785;
+    private final Schema testDoubleUnion787;
+    private final Schema testFloatUnion789;
+    private final Schema testBooleanUnion791;
+    private final Schema testBytesUnion793;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testIntUnion781 = readerSchema.getField("testIntUnion").schema();
+        this.testStringUnion783 = readerSchema.getField("testStringUnion").schema();
+        this.testLongUnion785 = readerSchema.getField("testLongUnion").schema();
+        this.testDoubleUnion787 = readerSchema.getField("testDoubleUnion").schema();
+        this.testFloatUnion789 = readerSchema.getField("testFloatUnion").schema();
+        this.testBooleanUnion791 = readerSchema.getField("testBooleanUnion").schema();
+        this.testBytesUnion793 = readerSchema.getField("testBytesUnion").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
+        int unionIndex782 = (decoder.readIndex());
+        if (unionIndex782 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex782 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
+        }
+        if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2) instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2))));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(null));
+        }
+        int unionIndex784 = (decoder.readIndex());
+        if (unionIndex784 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex784 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(null));
+            }
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
+        int unionIndex786 = (decoder.readIndex());
+        if (unionIndex786 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex786 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
+        int unionIndex788 = (decoder.readIndex());
+        if (unionIndex788 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex788 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
+        int unionIndex790 = (decoder.readIndex());
+        if (unionIndex790 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex790 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
+        int unionIndex792 = (decoder.readIndex());
+        if (unionIndex792 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex792 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
+        }
+        if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12) instanceof ByteBuffer) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12))));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes((null)));
+        }
+        int unionIndex794 = (decoder.readIndex());
+        if (unionIndex794 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex794 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13) instanceof ByteBuffer) {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes((null)));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -1,0 +1,213 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordsArray799;
+    private final Schema recordsArrayArrayElemSchema804;
+    private final Schema subField807;
+    private final Schema recordsMap809;
+    private final Schema recordsArrayUnion815;
+    private final Schema recordsArrayUnionOptionSchema817;
+    private final Schema recordsArrayUnionOptionArrayElemSchema822;
+    private final Schema recordsMapUnion825;
+    private final Schema recordsMapUnionOptionSchema827;
+    private final Schema recordsMapUnionOptionMapValueSchema833;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordsArray799 = readerSchema.getField("recordsArray").schema();
+        this.recordsArrayArrayElemSchema804 = recordsArray799 .getElementType();
+        this.subField807 = recordsArrayArrayElemSchema804 .getField("subField").schema();
+        this.recordsMap809 = readerSchema.getField("recordsMap").schema();
+        this.recordsArrayUnion815 = readerSchema.getField("recordsArrayUnion").schema();
+        this.recordsArrayUnionOptionSchema817 = recordsArrayUnion815 .getTypes().get(1);
+        this.recordsArrayUnionOptionArrayElemSchema822 = recordsArrayUnionOptionSchema817 .getElementType();
+        this.recordsMapUnion825 = readerSchema.getField("recordsMapUnion").schema();
+        this.recordsMapUnionOptionSchema827 = recordsMapUnion825 .getTypes().get(1);
+        this.recordsMapUnionOptionMapValueSchema833 = recordsMapUnionOptionSchema827 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<IndexedRecord> recordsArray800 = null;
+        long chunkLen801 = (decoder.readArrayStart());
+        if (chunkLen801 > 0) {
+            List<IndexedRecord> recordsArrayReuse802 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
+                recordsArrayReuse802 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+            }
+            if (recordsArrayReuse802 != (null)) {
+                recordsArrayReuse802 .clear();
+                recordsArray800 = recordsArrayReuse802;
+            } else {
+                recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen801), recordsArray799);
+            }
+            do {
+                for (int counter803 = 0; (counter803 <chunkLen801); counter803 ++) {
+                    Object recordsArrayArrayElementReuseVar805 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
+                        recordsArrayArrayElementReuseVar805 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                    }
+                    recordsArray800 .add(deserializesubRecord806(recordsArrayArrayElementReuseVar805, (decoder)));
+                }
+                chunkLen801 = (decoder.arrayNext());
+            } while (chunkLen801 > 0);
+        } else {
+            recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray799);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray800);
+        Map<Utf8, IndexedRecord> recordsMap810 = null;
+        long chunkLen811 = (decoder.readMapStart());
+        if (chunkLen811 > 0) {
+            Map<Utf8, IndexedRecord> recordsMapReuse812 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1) instanceof Map) {
+                recordsMapReuse812 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
+            }
+            if (recordsMapReuse812 != (null)) {
+                recordsMapReuse812 .clear();
+                recordsMap810 = recordsMapReuse812;
+            } else {
+                recordsMap810 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter813 = 0; (counter813 <chunkLen811); counter813 ++) {
+                    Utf8 key814 = (decoder.readString(null));
+                    recordsMap810 .put(key814, deserializesubRecord806(null, (decoder)));
+                }
+                chunkLen811 = (decoder.mapNext());
+            } while (chunkLen811 > 0);
+        } else {
+            recordsMap810 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap810);
+        int unionIndex816 = (decoder.readIndex());
+        if (unionIndex816 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex816 == 1) {
+            List<IndexedRecord> recordsArrayUnionOption818 = null;
+            long chunkLen819 = (decoder.readArrayStart());
+            if (chunkLen819 > 0) {
+                List<IndexedRecord> recordsArrayUnionOptionReuse820 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
+                    recordsArrayUnionOptionReuse820 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                }
+                if (recordsArrayUnionOptionReuse820 != (null)) {
+                    recordsArrayUnionOptionReuse820 .clear();
+                    recordsArrayUnionOption818 = recordsArrayUnionOptionReuse820;
+                } else {
+                    recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen819), recordsArrayUnionOptionSchema817);
+                }
+                do {
+                    for (int counter821 = 0; (counter821 <chunkLen819); counter821 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar823 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayUnionOptionArrayElementReuseVar823 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                        }
+                        int unionIndex824 = (decoder.readIndex());
+                        if (unionIndex824 == 0) {
+                            decoder.readNull();
+                        }
+                        if (unionIndex824 == 1) {
+                            recordsArrayUnionOption818 .add(deserializesubRecord806(recordsArrayUnionOptionArrayElementReuseVar823, (decoder)));
+                        }
+                    }
+                    chunkLen819 = (decoder.arrayNext());
+                } while (chunkLen819 > 0);
+            } else {
+                recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema817);
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption818);
+        }
+        int unionIndex826 = (decoder.readIndex());
+        if (unionIndex826 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex826 == 1) {
+            Map<Utf8, IndexedRecord> recordsMapUnionOption828 = null;
+            long chunkLen829 = (decoder.readMapStart());
+            if (chunkLen829 > 0) {
+                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse830 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3) instanceof Map) {
+                    recordsMapUnionOptionReuse830 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
+                }
+                if (recordsMapUnionOptionReuse830 != (null)) {
+                    recordsMapUnionOptionReuse830 .clear();
+                    recordsMapUnionOption828 = recordsMapUnionOptionReuse830;
+                } else {
+                    recordsMapUnionOption828 = new HashMap<Utf8, IndexedRecord>();
+                }
+                do {
+                    for (int counter831 = 0; (counter831 <chunkLen829); counter831 ++) {
+                        Utf8 key832 = (decoder.readString(null));
+                        int unionIndex834 = (decoder.readIndex());
+                        if (unionIndex834 == 0) {
+                            decoder.readNull();
+                        }
+                        if (unionIndex834 == 1) {
+                            recordsMapUnionOption828 .put(key832, deserializesubRecord806(null, (decoder)));
+                        }
+                    }
+                    chunkLen829 = (decoder.mapNext());
+                } while (chunkLen829 > 0);
+            } else {
+                recordsMapUnionOption828 = Collections.emptyMap();
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption828);
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
+    }
+
+    public IndexedRecord deserializesubRecord806(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema804)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema804);
+        }
+        int unionIndex808 = (decoder.readIndex());
+        if (unionIndex808 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex808 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -1,0 +1,331 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordsArrayMap836;
+    private final Schema recordsArrayMapArrayElemSchema841;
+    private final Schema recordsArrayMapElemMapValueSchema848;
+    private final Schema recordsArrayMapElemValueOptionSchema850;
+    private final Schema subField852;
+    private final Schema recordsMapArray854;
+    private final Schema recordsMapArrayMapValueSchema860;
+    private final Schema recordsMapArrayValueArrayElemSchema865;
+    private final Schema recordsArrayMapUnion868;
+    private final Schema recordsArrayMapUnionOptionArrayElemSchema874;
+    private final Schema recordsArrayMapUnionOptionElemMapValueSchema881;
+    private final Schema recordsMapArrayUnion883;
+    private final Schema recordsMapArrayUnionOptionSchema885;
+    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema895;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordsArrayMap836 = readerSchema.getField("recordsArrayMap").schema();
+        this.recordsArrayMapArrayElemSchema841 = recordsArrayMap836 .getElementType();
+        this.recordsArrayMapElemMapValueSchema848 = recordsArrayMapArrayElemSchema841 .getValueType();
+        this.recordsArrayMapElemValueOptionSchema850 = recordsArrayMapElemMapValueSchema848 .getTypes().get(1);
+        this.subField852 = recordsArrayMapElemValueOptionSchema850 .getField("subField").schema();
+        this.recordsMapArray854 = readerSchema.getField("recordsMapArray").schema();
+        this.recordsMapArrayMapValueSchema860 = recordsMapArray854 .getValueType();
+        this.recordsMapArrayValueArrayElemSchema865 = recordsMapArrayMapValueSchema860 .getElementType();
+        this.recordsArrayMapUnion868 = readerSchema.getField("recordsArrayMapUnion").schema();
+        this.recordsArrayMapUnionOptionArrayElemSchema874 = recordsArrayMap836 .getElementType();
+        this.recordsArrayMapUnionOptionElemMapValueSchema881 = recordsArrayMapUnionOptionArrayElemSchema874 .getValueType();
+        this.recordsMapArrayUnion883 = readerSchema.getField("recordsMapArrayUnion").schema();
+        this.recordsMapArrayUnionOptionSchema885 = recordsMapArrayUnion883 .getTypes().get(1);
+        this.recordsMapArrayUnionOptionValueArrayElemSchema895 = recordsMapArrayMapValueSchema860 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Map<Utf8, IndexedRecord>> recordsArrayMap837 = null;
+        long chunkLen838 = (decoder.readArrayStart());
+        if (chunkLen838 > 0) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse839 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
+                recordsArrayMapReuse839 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+            }
+            if (recordsArrayMapReuse839 != (null)) {
+                recordsArrayMapReuse839 .clear();
+                recordsArrayMap837 = recordsArrayMapReuse839;
+            } else {
+                recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen838), recordsArrayMap836);
+            }
+            do {
+                for (int counter840 = 0; (counter840 <chunkLen838); counter840 ++) {
+                    Object recordsArrayMapArrayElementReuseVar842 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
+                        recordsArrayMapArrayElementReuseVar842 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                    }
+                    Map<Utf8, IndexedRecord> recordsArrayMapElem843 = null;
+                    long chunkLen844 = (decoder.readMapStart());
+                    if (chunkLen844 > 0) {
+                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse845 = null;
+                        if (recordsArrayMapArrayElementReuseVar842 instanceof Map) {
+                            recordsArrayMapElemReuse845 = ((Map) recordsArrayMapArrayElementReuseVar842);
+                        }
+                        if (recordsArrayMapElemReuse845 != (null)) {
+                            recordsArrayMapElemReuse845 .clear();
+                            recordsArrayMapElem843 = recordsArrayMapElemReuse845;
+                        } else {
+                            recordsArrayMapElem843 = new HashMap<Utf8, IndexedRecord>();
+                        }
+                        do {
+                            for (int counter846 = 0; (counter846 <chunkLen844); counter846 ++) {
+                                Utf8 key847 = (decoder.readString(null));
+                                int unionIndex849 = (decoder.readIndex());
+                                if (unionIndex849 == 0) {
+                                    decoder.readNull();
+                                }
+                                if (unionIndex849 == 1) {
+                                    recordsArrayMapElem843 .put(key847, deserializesubRecord851(null, (decoder)));
+                                }
+                            }
+                            chunkLen844 = (decoder.mapNext());
+                        } while (chunkLen844 > 0);
+                    } else {
+                        recordsArrayMapElem843 = Collections.emptyMap();
+                    }
+                    recordsArrayMap837 .add(recordsArrayMapElem843);
+                }
+                chunkLen838 = (decoder.arrayNext());
+            } while (chunkLen838 > 0);
+        } else {
+            recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap837);
+        Map<Utf8, List<IndexedRecord>> recordsMapArray855 = null;
+        long chunkLen856 = (decoder.readMapStart());
+        if (chunkLen856 > 0) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse857 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1) instanceof Map) {
+                recordsMapArrayReuse857 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
+            }
+            if (recordsMapArrayReuse857 != (null)) {
+                recordsMapArrayReuse857 .clear();
+                recordsMapArray855 = recordsMapArrayReuse857;
+            } else {
+                recordsMapArray855 = new HashMap<Utf8, List<IndexedRecord>>();
+            }
+            do {
+                for (int counter858 = 0; (counter858 <chunkLen856); counter858 ++) {
+                    Utf8 key859 = (decoder.readString(null));
+                    List<IndexedRecord> recordsMapArrayValue861 = null;
+                    long chunkLen862 = (decoder.readArrayStart());
+                    if (chunkLen862 > 0) {
+                        List<IndexedRecord> recordsMapArrayValueReuse863 = null;
+                        if (null instanceof List) {
+                            recordsMapArrayValueReuse863 = ((List) null);
+                        }
+                        if (recordsMapArrayValueReuse863 != (null)) {
+                            recordsMapArrayValueReuse863 .clear();
+                            recordsMapArrayValue861 = recordsMapArrayValueReuse863;
+                        } else {
+                            recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen862), recordsMapArrayMapValueSchema860);
+                        }
+                        do {
+                            for (int counter864 = 0; (counter864 <chunkLen862); counter864 ++) {
+                                Object recordsMapArrayValueArrayElementReuseVar866 = null;
+                                if (null instanceof GenericArray) {
+                                    recordsMapArrayValueArrayElementReuseVar866 = ((GenericArray) null).peek();
+                                }
+                                int unionIndex867 = (decoder.readIndex());
+                                if (unionIndex867 == 0) {
+                                    decoder.readNull();
+                                }
+                                if (unionIndex867 == 1) {
+                                    recordsMapArrayValue861 .add(deserializesubRecord851(recordsMapArrayValueArrayElementReuseVar866, (decoder)));
+                                }
+                            }
+                            chunkLen862 = (decoder.arrayNext());
+                        } while (chunkLen862 > 0);
+                    } else {
+                        recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                    }
+                    recordsMapArray855 .put(key859, recordsMapArrayValue861);
+                }
+                chunkLen856 = (decoder.mapNext());
+            } while (chunkLen856 > 0);
+        } else {
+            recordsMapArray855 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray855);
+        int unionIndex869 = (decoder.readIndex());
+        if (unionIndex869 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex869 == 1) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption870 = null;
+            long chunkLen871 = (decoder.readArrayStart());
+            if (chunkLen871 > 0) {
+                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse872 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
+                    recordsArrayMapUnionOptionReuse872 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                }
+                if (recordsArrayMapUnionOptionReuse872 != (null)) {
+                    recordsArrayMapUnionOptionReuse872 .clear();
+                    recordsArrayMapUnionOption870 = recordsArrayMapUnionOptionReuse872;
+                } else {
+                    recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen871), recordsArrayMap836);
+                }
+                do {
+                    for (int counter873 = 0; (counter873 <chunkLen871); counter873 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar875 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayMapUnionOptionArrayElementReuseVar875 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                        }
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem876 = null;
+                        long chunkLen877 = (decoder.readMapStart());
+                        if (chunkLen877 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse878 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar875 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse878 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar875);
+                            }
+                            if (recordsArrayMapUnionOptionElemReuse878 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse878 .clear();
+                                recordsArrayMapUnionOptionElem876 = recordsArrayMapUnionOptionElemReuse878;
+                            } else {
+                                recordsArrayMapUnionOptionElem876 = new HashMap<Utf8, IndexedRecord>();
+                            }
+                            do {
+                                for (int counter879 = 0; (counter879 <chunkLen877); counter879 ++) {
+                                    Utf8 key880 = (decoder.readString(null));
+                                    int unionIndex882 = (decoder.readIndex());
+                                    if (unionIndex882 == 0) {
+                                        decoder.readNull();
+                                    }
+                                    if (unionIndex882 == 1) {
+                                        recordsArrayMapUnionOptionElem876 .put(key880, deserializesubRecord851(null, (decoder)));
+                                    }
+                                }
+                                chunkLen877 = (decoder.mapNext());
+                            } while (chunkLen877 > 0);
+                        } else {
+                            recordsArrayMapUnionOptionElem876 = Collections.emptyMap();
+                        }
+                        recordsArrayMapUnionOption870 .add(recordsArrayMapUnionOptionElem876);
+                    }
+                    chunkLen871 = (decoder.arrayNext());
+                } while (chunkLen871 > 0);
+            } else {
+                recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption870);
+        }
+        int unionIndex884 = (decoder.readIndex());
+        if (unionIndex884 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex884 == 1) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption886 = null;
+            long chunkLen887 = (decoder.readMapStart());
+            if (chunkLen887 > 0) {
+                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse888 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3) instanceof Map) {
+                    recordsMapArrayUnionOptionReuse888 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
+                }
+                if (recordsMapArrayUnionOptionReuse888 != (null)) {
+                    recordsMapArrayUnionOptionReuse888 .clear();
+                    recordsMapArrayUnionOption886 = recordsMapArrayUnionOptionReuse888;
+                } else {
+                    recordsMapArrayUnionOption886 = new HashMap<Utf8, List<IndexedRecord>>();
+                }
+                do {
+                    for (int counter889 = 0; (counter889 <chunkLen887); counter889 ++) {
+                        Utf8 key890 = (decoder.readString(null));
+                        List<IndexedRecord> recordsMapArrayUnionOptionValue891 = null;
+                        long chunkLen892 = (decoder.readArrayStart());
+                        if (chunkLen892 > 0) {
+                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse893 = null;
+                            if (null instanceof List) {
+                                recordsMapArrayUnionOptionValueReuse893 = ((List) null);
+                            }
+                            if (recordsMapArrayUnionOptionValueReuse893 != (null)) {
+                                recordsMapArrayUnionOptionValueReuse893 .clear();
+                                recordsMapArrayUnionOptionValue891 = recordsMapArrayUnionOptionValueReuse893;
+                            } else {
+                                recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen892), recordsMapArrayMapValueSchema860);
+                            }
+                            do {
+                                for (int counter894 = 0; (counter894 <chunkLen892); counter894 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar896 = null;
+                                    if (null instanceof GenericArray) {
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar896 = ((GenericArray) null).peek();
+                                    }
+                                    int unionIndex897 = (decoder.readIndex());
+                                    if (unionIndex897 == 0) {
+                                        decoder.readNull();
+                                    }
+                                    if (unionIndex897 == 1) {
+                                        recordsMapArrayUnionOptionValue891 .add(deserializesubRecord851(recordsMapArrayUnionOptionValueArrayElementReuseVar896, (decoder)));
+                                    }
+                                }
+                                chunkLen892 = (decoder.arrayNext());
+                            } while (chunkLen892 > 0);
+                        } else {
+                            recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                        }
+                        recordsMapArrayUnionOption886 .put(key890, recordsMapArrayUnionOptionValue891);
+                    }
+                    chunkLen887 = (decoder.mapNext());
+                } while (chunkLen887 > 0);
+            } else {
+                recordsMapArrayUnionOption886 = Collections.emptyMap();
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption886);
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
+    }
+
+    public IndexedRecord deserializesubRecord851(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema850)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema850);
+        }
+        int unionIndex853 = (decoder.readIndex());
+        if (unionIndex853 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex853 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
@@ -1,0 +1,89 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record899;
+    private final Schema recordOptionSchema901;
+    private final Schema subField903;
+    private final Schema field905;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record899 = readerSchema.getField("record").schema();
+        this.recordOptionSchema901 = record899 .getTypes().get(1);
+        this.subField903 = recordOptionSchema901 .getField("subField").schema();
+        this.field905 = readerSchema.getField("field").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex900 = (decoder.readIndex());
+        if (unionIndex900 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex900 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        int unionIndex906 = (decoder.readIndex());
+        if (unionIndex906 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex906 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(null));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
+    }
+
+    public IndexedRecord deserializesubRecord902(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema901)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema901);
+        }
+        int unionIndex904 = (decoder.readIndex());
+        if (unionIndex904 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex904 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -1,0 +1,188 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testNotRemoved908;
+    private final Schema testNotRemoved2911;
+    private final Schema subRecord913;
+    private final Schema subRecordOptionSchema915;
+    private final Schema testNotRemoved917;
+    private final Schema testNotRemoved2920;
+    private final Schema subRecordMap922;
+    private final Schema subRecordArray928;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testNotRemoved908 = readerSchema.getField("testNotRemoved").schema();
+        this.testNotRemoved2911 = readerSchema.getField("testNotRemoved2").schema();
+        this.subRecord913 = readerSchema.getField("subRecord").schema();
+        this.subRecordOptionSchema915 = subRecord913 .getTypes().get(1);
+        this.testNotRemoved917 = subRecordOptionSchema915 .getField("testNotRemoved").schema();
+        this.testNotRemoved2920 = subRecordOptionSchema915 .getField("testNotRemoved2").schema();
+        this.subRecordMap922 = readerSchema.getField("subRecordMap").schema();
+        this.subRecordArray928 = readerSchema.getField("subRecordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex909 = (decoder.readIndex());
+        if (unionIndex909 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex909 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex910 = (decoder.readIndex());
+        if (unionIndex910 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex910 == 1) {
+            decoder.skipString();
+        }
+        int unionIndex912 = (decoder.readIndex());
+        if (unionIndex912 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex912 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(null));
+            }
+        }
+        int unionIndex914 = (decoder.readIndex());
+        if (unionIndex914 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex914 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord916(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+        }
+        Map<Utf8, IndexedRecord> subRecordMap923 = null;
+        long chunkLen924 = (decoder.readMapStart());
+        if (chunkLen924 > 0) {
+            Map<Utf8, IndexedRecord> subRecordMapReuse925 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3) instanceof Map) {
+                subRecordMapReuse925 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
+            }
+            if (subRecordMapReuse925 != (null)) {
+                subRecordMapReuse925 .clear();
+                subRecordMap923 = subRecordMapReuse925;
+            } else {
+                subRecordMap923 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter926 = 0; (counter926 <chunkLen924); counter926 ++) {
+                    Utf8 key927 = (decoder.readString(null));
+                    subRecordMap923 .put(key927, deserializesubRecord916(null, (decoder)));
+                }
+                chunkLen924 = (decoder.mapNext());
+            } while (chunkLen924 > 0);
+        } else {
+            subRecordMap923 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap923);
+        List<IndexedRecord> subRecordArray929 = null;
+        long chunkLen930 = (decoder.readArrayStart());
+        if (chunkLen930 > 0) {
+            List<IndexedRecord> subRecordArrayReuse931 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
+                subRecordArrayReuse931 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+            }
+            if (subRecordArrayReuse931 != (null)) {
+                subRecordArrayReuse931 .clear();
+                subRecordArray929 = subRecordArrayReuse931;
+            } else {
+                subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen930), subRecordArray928);
+            }
+            do {
+                for (int counter932 = 0; (counter932 <chunkLen930); counter932 ++) {
+                    Object subRecordArrayArrayElementReuseVar933 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
+                        subRecordArrayArrayElementReuseVar933 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                    }
+                    subRecordArray929 .add(deserializesubRecord916(subRecordArrayArrayElementReuseVar933, (decoder)));
+                }
+                chunkLen930 = (decoder.arrayNext());
+            } while (chunkLen930 > 0);
+        } else {
+            subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray928);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray929);
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
+    }
+
+    public IndexedRecord deserializesubRecord916(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema915)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema915);
+        }
+        int unionIndex918 = (decoder.readIndex());
+        if (unionIndex918 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex918 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex919 = (decoder.readIndex());
+        if (unionIndex919 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex919 == 1) {
+            decoder.skipString();
+        }
+        int unionIndex921 = (decoder.readIndex());
+        if (unionIndex921 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex921 == 1) {
+            if (subRecord.get(1) instanceof Utf8) {
+                subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+            } else {
+                subRecord.put(1, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
@@ -1,0 +1,79 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord935;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord935 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord936(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
+    }
+
+    public IndexedRecord deserializesubRecord936(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord935)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord935);
+        }
+        if (subRecord.get(0) instanceof Utf8) {
+            subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+        } else {
+            subRecord.put(0, (decoder).readString(null));
+        }
+        deserializesubSubRecord937(null, (decoder));
+        int unionIndex938 = (decoder.readIndex());
+        if (unionIndex938 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex938 == 1) {
+            deserializesubSubRecord937(null, (decoder));
+        }
+        if (subRecord.get(1) instanceof Utf8) {
+            subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+        } else {
+            subRecord.put(1, (decoder).readString(null));
+        }
+        return subRecord;
+    }
+
+    public void deserializesubSubRecord937(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        decoder.skipString();
+        decoder.skipString();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
@@ -1,0 +1,80 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord1940;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord1940 = readerSchema.getField("subRecord1").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
+        deserializesubRecord2942(null, (decoder));
+        int unionIndex943 = (decoder.readIndex());
+        if (unionIndex943 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex943 == 1) {
+            deserializesubRecord2942(null, (decoder));
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
+    }
+
+    public IndexedRecord deserializesubRecord941(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord1940)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord1940);
+        }
+        if (subRecord.get(0) instanceof Utf8) {
+            subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+        } else {
+            subRecord.put(0, (decoder).readString(null));
+        }
+        if (subRecord.get(1) instanceof Utf8) {
+            subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+        } else {
+            subRecord.put(1, (decoder).readString(null));
+        }
+        return subRecord;
+    }
+
+    public void deserializesubRecord2942(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        decoder.skipString();
+        decoder.skipString();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -1,0 +1,88 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapValueSchema708;
+    private final Schema mapValueOptionSchema710;
+    private final Schema field712;
+
+    public Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapValueSchema708 = readerSchema.getValueType();
+        this.mapValueOptionSchema710 = mapMapValueSchema708 .getTypes().get(1);
+        this.field712 = mapValueOptionSchema710 .getField("field").schema();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map703 = null;
+        long chunkLen704 = (decoder.readMapStart());
+        if (chunkLen704 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse705 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse705 = ((Map)(reuse));
+            }
+            if (mapReuse705 != (null)) {
+                mapReuse705 .clear();
+                map703 = mapReuse705;
+            } else {
+                map703 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter706 = 0; (counter706 <chunkLen704); counter706 ++) {
+                    Utf8 key707 = (decoder.readString(null));
+                    int unionIndex709 = (decoder.readIndex());
+                    if (unionIndex709 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex709 == 1) {
+                        map703 .put(key707, deserializerecord711(null, (decoder)));
+                    }
+                }
+                chunkLen704 = (decoder.mapNext());
+            } while (chunkLen704 > 0);
+        } else {
+            map703 = Collections.emptyMap();
+        }
+        return map703;
+    }
+
+    public IndexedRecord deserializerecord711(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema710)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema710);
+        }
+        int unionIndex713 = (decoder.readIndex());
+        if (unionIndex713 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex713 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -1,0 +1,80 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapValueSchema699;
+    private final Schema field701;
+
+    public Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapValueSchema699 = readerSchema.getValueType();
+        this.field701 = mapMapValueSchema699 .getField("field").schema();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map694 = null;
+        long chunkLen695 = (decoder.readMapStart());
+        if (chunkLen695 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse696 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse696 = ((Map)(reuse));
+            }
+            if (mapReuse696 != (null)) {
+                mapReuse696 .clear();
+                map694 = mapReuse696;
+            } else {
+                map694 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter697 = 0; (counter697 <chunkLen695); counter697 ++) {
+                    Utf8 key698 = (decoder.readString(null));
+                    map694 .put(key698, deserializerecord700(null, (decoder)));
+                }
+                chunkLen695 = (decoder.mapNext());
+            } while (chunkLen695 > 0);
+        } else {
+            map694 = Collections.emptyMap();
+        }
+        return map694;
+    }
+
+    public IndexedRecord deserializerecord700(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema699)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema699);
+        }
+        int unionIndex702 = (decoder.readIndex());
+        if (unionIndex702 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex702 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class recordName_GenericDeserializer_6897301803194779359_6897301803194779359
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionField796;
+
+    public recordName_GenericDeserializer_6897301803194779359_6897301803194779359(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionField796 = readerSchema.getField("unionField").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecordName795((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecordName795(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord recordName;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            recordName = ((IndexedRecord)(reuse));
+        } else {
+            recordName = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        if (recordName.get(0) instanceof Utf8) {
+            recordName.put(0, (decoder).readString(((Utf8) recordName.get(0))));
+        } else {
+            recordName.put(0, (decoder).readString(null));
+        }
+        int unionIndex797 = (decoder.readIndex());
+        if (unionIndex797 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex797 == 1) {
+            recordName.put(1, deserializerecordName795(recordName.get(1), (decoder)));
+        }
+        return recordName;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388
+    implements FastDeserializer<List<Boolean>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Boolean> array592 = null;
+        long chunkLen593 = (decoder.readArrayStart());
+        if (chunkLen593 > 0) {
+            List<Boolean> arrayReuse594 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse594 = ((List)(reuse));
+            }
+            if (arrayReuse594 != (null)) {
+                arrayReuse594 .clear();
+                array592 = arrayReuse594;
+            } else {
+                array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen593), readerSchema);
+            }
+            do {
+                for (int counter595 = 0; (counter595 <chunkLen593); counter595 ++) {
+                    Object arrayArrayElementReuseVar596 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar596 = ((GenericArray)(reuse)).peek();
+                    }
+                    array592 .add((decoder.readBoolean()));
+                }
+                chunkLen593 = (decoder.arrayNext());
+            } while (chunkLen593 > 0);
+        } else {
+            array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
+        }
+        return array592;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740
+    implements FastDeserializer<List<Double>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Double> deserialize(List<Double> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Double> array597 = null;
+        long chunkLen598 = (decoder.readArrayStart());
+        if (chunkLen598 > 0) {
+            List<Double> arrayReuse599 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse599 = ((List)(reuse));
+            }
+            if (arrayReuse599 != (null)) {
+                arrayReuse599 .clear();
+                array597 = arrayReuse599;
+            } else {
+                array597 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen598), readerSchema);
+            }
+            do {
+                for (int counter600 = 0; (counter600 <chunkLen598); counter600 ++) {
+                    Object arrayArrayElementReuseVar601 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar601 = ((GenericArray)(reuse)).peek();
+                    }
+                    array597 .add((decoder.readDouble()));
+                }
+                chunkLen598 = (decoder.arrayNext());
+            } while (chunkLen598 > 0);
+        } else {
+            array597 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
+        }
+        return array597;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -1,0 +1,29 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583
+    implements FastDeserializer<List<Float>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Float> deserialize(List<Float> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Float> array602 = null;
+        array602 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        return array602;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685
+    implements FastDeserializer<List<Integer>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Integer> array603 = null;
+        long chunkLen604 = (decoder.readArrayStart());
+        if (chunkLen604 > 0) {
+            List<Integer> arrayReuse605 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse605 = ((List)(reuse));
+            }
+            if (arrayReuse605 != (null)) {
+                arrayReuse605 .clear();
+                array603 = arrayReuse605;
+            } else {
+                array603 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen604), readerSchema);
+            }
+            do {
+                for (int counter606 = 0; (counter606 <chunkLen604); counter606 ++) {
+                    Object arrayArrayElementReuseVar607 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar607 = ((GenericArray)(reuse)).peek();
+                    }
+                    array603 .add((decoder.readInt()));
+                }
+                chunkLen604 = (decoder.arrayNext());
+            } while (chunkLen604 > 0);
+        } else {
+            array603 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
+        }
+        return array603;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358
+    implements FastDeserializer<List<Long>>
+{
+
+    private final Schema readerSchema;
+
+    public Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public List<Long> deserialize(List<Long> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<Long> array608 = null;
+        long chunkLen609 = (decoder.readArrayStart());
+        if (chunkLen609 > 0) {
+            List<Long> arrayReuse610 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse610 = ((List)(reuse));
+            }
+            if (arrayReuse610 != (null)) {
+                arrayReuse610 .clear();
+                array608 = arrayReuse610;
+            } else {
+                array608 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen609), readerSchema);
+            }
+            do {
+                for (int counter611 = 0; (counter611 <chunkLen609); counter611 ++) {
+                    Object arrayArrayElementReuseVar612 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar612 = ((GenericArray)(reuse)).peek();
+                    }
+                    array608 .add((decoder.readLong()));
+                }
+                chunkLen609 = (decoder.arrayNext());
+            } while (chunkLen609 > 0);
+        } else {
+            array608 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
+        }
+        return array608;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -1,0 +1,90 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArrayElemSchema626;
+    private final Schema arrayElemOptionSchema629;
+    private final Schema field631;
+
+    public Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArrayElemSchema626 = readerSchema.getElementType();
+        this.arrayElemOptionSchema629 = arrayArrayElemSchema626 .getTypes().get(1);
+        this.field631 = arrayElemOptionSchema629 .getField("field").schema();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array622 = null;
+        long chunkLen623 = (decoder.readArrayStart());
+        if (chunkLen623 > 0) {
+            List<IndexedRecord> arrayReuse624 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse624 = ((List)(reuse));
+            }
+            if (arrayReuse624 != (null)) {
+                arrayReuse624 .clear();
+                array622 = arrayReuse624;
+            } else {
+                array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen623), readerSchema);
+            }
+            do {
+                for (int counter625 = 0; (counter625 <chunkLen623); counter625 ++) {
+                    Object arrayArrayElementReuseVar627 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar627 = ((GenericArray)(reuse)).peek();
+                    }
+                    int unionIndex628 = (decoder.readIndex());
+                    if (unionIndex628 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex628 == 1) {
+                        array622 .add(deserializerecord630(arrayArrayElementReuseVar627, (decoder)));
+                    }
+                }
+                chunkLen623 = (decoder.arrayNext());
+            } while (chunkLen623 > 0);
+        } else {
+            array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+        }
+        return array622;
+    }
+
+    public IndexedRecord deserializerecord630(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema629)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema629);
+        }
+        int unionIndex632 = (decoder.readIndex());
+        if (unionIndex632 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex632 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArrayElemSchema617;
+    private final Schema field620;
+
+    public Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArrayElemSchema617 = readerSchema.getElementType();
+        this.field620 = arrayArrayElemSchema617 .getField("field").schema();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array613 = null;
+        long chunkLen614 = (decoder.readArrayStart());
+        if (chunkLen614 > 0) {
+            List<IndexedRecord> arrayReuse615 = null;
+            if ((reuse) instanceof List) {
+                arrayReuse615 = ((List)(reuse));
+            }
+            if (arrayReuse615 != (null)) {
+                arrayReuse615 .clear();
+                array613 = arrayReuse615;
+            } else {
+                array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen614), readerSchema);
+            }
+            do {
+                for (int counter616 = 0; (counter616 <chunkLen614); counter616 ++) {
+                    Object arrayArrayElementReuseVar618 = null;
+                    if ((reuse) instanceof GenericArray) {
+                        arrayArrayElementReuseVar618 = ((GenericArray)(reuse)).peek();
+                    }
+                    array613 .add(deserializerecord619(arrayArrayElementReuseVar618, (decoder)));
+                }
+                chunkLen614 = (decoder.arrayNext());
+            } while (chunkLen614 > 0);
+        } else {
+            array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+        }
+        return array613;
+    }
+
+    public IndexedRecord deserializerecord619(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema617)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema617);
+        }
+        int unionIndex621 = (decoder.readIndex());
+        if (unionIndex621 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex621 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
@@ -1,0 +1,65 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testString588;
+    private final Schema testStringUnionAlias590;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testString588 = readerSchema.getField("testString").schema();
+        this.testStringUnionAlias590 = readerSchema.getField("testStringUnionAlias").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadAliasedField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadAliasedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex589 = (decoder.readIndex());
+        if (unionIndex589 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex589 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex591 = (decoder.readIndex());
+        if (unionIndex591 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex591 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(1, (decoder).readString(null));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -1,0 +1,118 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum634;
+    private final Schema testEnumUnion635;
+    private final Schema testEnumArray637;
+    private final Schema testEnumUnionArray643;
+    private final Schema testEnumUnionArrayArrayElemSchema648;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum634 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion635 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray637 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray643 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema648 = testEnumUnionArray643 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+        int unionIndex636 = (decoder.readIndex());
+        if (unionIndex636 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex636 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray638 = null;
+        long chunkLen639 = (decoder.readArrayStart());
+        if (chunkLen639 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse640 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
+                testEnumArrayReuse640 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+            }
+            if (testEnumArrayReuse640 != (null)) {
+                testEnumArrayReuse640 .clear();
+                testEnumArray638 = testEnumArrayReuse640;
+            } else {
+                testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen639), testEnumArray637);
+            }
+            do {
+                for (int counter641 = 0; (counter641 <chunkLen639); counter641 ++) {
+                    Object testEnumArrayArrayElementReuseVar642 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof GenericArray) {
+                        testEnumArrayArrayElementReuseVar642 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
+                    }
+                    testEnumArray638 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                }
+                chunkLen639 = (decoder.arrayNext());
+            } while (chunkLen639 > 0);
+        } else {
+            testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray637);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray638);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray644 = null;
+        long chunkLen645 = (decoder.readArrayStart());
+        if (chunkLen645 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse646 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
+                testEnumUnionArrayReuse646 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+            }
+            if (testEnumUnionArrayReuse646 != (null)) {
+                testEnumUnionArrayReuse646 .clear();
+                testEnumUnionArray644 = testEnumUnionArrayReuse646;
+            } else {
+                testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen645), testEnumUnionArray643);
+            }
+            do {
+                for (int counter647 = 0; (counter647 <chunkLen645); counter647 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar649 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
+                        testEnumUnionArrayArrayElementReuseVar649 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                    }
+                    int unionIndex650 = (decoder.readIndex());
+                    if (unionIndex650 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex650 == 1) {
+                        testEnumUnionArray644 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                    }
+                }
+                chunkLen645 = (decoder.arrayNext());
+            } while (chunkLen645 > 0);
+        } else {
+            testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray643);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray644);
+        return FastGenericDeserializerGeneratorTest_shouldReadEnum;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -1,0 +1,145 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testFixedUnion653;
+    private final Schema testFixedArray656;
+    private final Schema testFixedUnionArray663;
+    private final Schema testFixedUnionArrayArrayElemSchema668;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testFixedUnion653 = readerSchema.getField("testFixedUnion").schema();
+        this.testFixedArray656 = readerSchema.getField("testFixedArray").schema();
+        this.testFixedUnionArray663 = readerSchema.getField("testFixedUnionArray").schema();
+        this.testFixedUnionArrayArrayElemSchema668 = testFixedUnionArray663 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadFixed = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadFixed = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        byte[] testFixed652;
+        if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes().length == (2))) {
+            testFixed652 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
+        } else {
+            testFixed652 = ( new byte[2]);
+        }
+        decoder.readFixed(testFixed652);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(null, testFixed652));
+        int unionIndex654 = (decoder.readIndex());
+        if (unionIndex654 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex654 == 1) {
+            byte[] testFixed655;
+            if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes().length == (2))) {
+                testFixed655 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
+            } else {
+                testFixed655 = ( new byte[2]);
+            }
+            decoder.readFixed(testFixed655);
+            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(null, testFixed655));
+        }
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray657 = null;
+        long chunkLen658 = (decoder.readArrayStart());
+        if (chunkLen658 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse659 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
+                testFixedArrayReuse659 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+            }
+            if (testFixedArrayReuse659 != (null)) {
+                testFixedArrayReuse659 .clear();
+                testFixedArray657 = testFixedArrayReuse659;
+            } else {
+                testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen658), testFixedArray656);
+            }
+            do {
+                for (int counter660 = 0; (counter660 <chunkLen658); counter660 ++) {
+                    Object testFixedArrayArrayElementReuseVar661 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
+                        testFixedArrayArrayElementReuseVar661 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                    }
+                    byte[] testFixed662;
+                    if ((testFixedArrayArrayElementReuseVar661 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes().length == (2))) {
+                        testFixed662 = ((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes();
+                    } else {
+                        testFixed662 = ( new byte[2]);
+                    }
+                    decoder.readFixed(testFixed662);
+                    testFixedArray657 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed662));
+                }
+                chunkLen658 = (decoder.arrayNext());
+            } while (chunkLen658 > 0);
+        } else {
+            testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray656);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray657);
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray664 = null;
+        long chunkLen665 = (decoder.readArrayStart());
+        if (chunkLen665 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse666 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
+                testFixedUnionArrayReuse666 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+            }
+            if (testFixedUnionArrayReuse666 != (null)) {
+                testFixedUnionArrayReuse666 .clear();
+                testFixedUnionArray664 = testFixedUnionArrayReuse666;
+            } else {
+                testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen665), testFixedUnionArray663);
+            }
+            do {
+                for (int counter667 = 0; (counter667 <chunkLen665); counter667 ++) {
+                    Object testFixedUnionArrayArrayElementReuseVar669 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
+                        testFixedUnionArrayArrayElementReuseVar669 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                    }
+                    int unionIndex670 = (decoder.readIndex());
+                    if (unionIndex670 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex670 == 1) {
+                        byte[] testFixed671;
+                        if ((testFixedUnionArrayArrayElementReuseVar669 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes().length == (2))) {
+                            testFixed671 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes();
+                        } else {
+                            testFixed671 = ( new byte[2]);
+                        }
+                        decoder.readFixed(testFixed671);
+                        testFixedUnionArray664 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed671));
+                    }
+                }
+                chunkLen665 = (decoder.arrayNext());
+            } while (chunkLen665 > 0);
+        } else {
+            testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray663);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray664);
+        return FastGenericDeserializerGeneratorTest_shouldReadFixed;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema union729;
+    private final Schema unionOptionSchema731;
+    private final Schema subField733;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.union729 = readerSchema.getField("union").schema();
+        this.unionOptionSchema731 = union729 .getTypes().get(1);
+        this.subField733 = unionOptionSchema731 .getField("subField").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex730 = (decoder.readIndex());
+        if (unionIndex730 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex730 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord732(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+        } else {
+            if (unionIndex730 == 2) {
+                if (FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex730 == 3) {
+                    FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
+    }
+
+    public IndexedRecord deserializesubRecord732(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema731)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema731);
+        }
+        int unionIndex734 = (decoder.readIndex());
+        if (unionIndex734 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex734 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -1,0 +1,123 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapField736;
+    private final Schema mapFieldMapValueSchema742;
+    private final Schema mapFieldValueMapValueSchema748;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapField736 = readerSchema.getField("mapField").schema();
+        this.mapFieldMapValueSchema742 = mapField736 .getValueType();
+        this.mapFieldValueMapValueSchema748 = mapFieldMapValueSchema742 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadNestedMap = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadNestedMap = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Map<Utf8, List<Integer>>> mapField737 = null;
+        long chunkLen738 = (decoder.readMapStart());
+        if (chunkLen738 > 0) {
+            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse739 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0) instanceof Map) {
+                mapFieldReuse739 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
+            }
+            if (mapFieldReuse739 != (null)) {
+                mapFieldReuse739 .clear();
+                mapField737 = mapFieldReuse739;
+            } else {
+                mapField737 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
+            }
+            do {
+                for (int counter740 = 0; (counter740 <chunkLen738); counter740 ++) {
+                    Utf8 key741 = (decoder.readString(null));
+                    Map<Utf8, List<Integer>> mapFieldValue743 = null;
+                    long chunkLen744 = (decoder.readMapStart());
+                    if (chunkLen744 > 0) {
+                        Map<Utf8, List<Integer>> mapFieldValueReuse745 = null;
+                        if (null instanceof Map) {
+                            mapFieldValueReuse745 = ((Map) null);
+                        }
+                        if (mapFieldValueReuse745 != (null)) {
+                            mapFieldValueReuse745 .clear();
+                            mapFieldValue743 = mapFieldValueReuse745;
+                        } else {
+                            mapFieldValue743 = new HashMap<Utf8, List<Integer>>();
+                        }
+                        do {
+                            for (int counter746 = 0; (counter746 <chunkLen744); counter746 ++) {
+                                Utf8 key747 = (decoder.readString(null));
+                                List<Integer> mapFieldValueValue749 = null;
+                                long chunkLen750 = (decoder.readArrayStart());
+                                if (chunkLen750 > 0) {
+                                    List<Integer> mapFieldValueValueReuse751 = null;
+                                    if (null instanceof List) {
+                                        mapFieldValueValueReuse751 = ((List) null);
+                                    }
+                                    if (mapFieldValueValueReuse751 != (null)) {
+                                        mapFieldValueValueReuse751 .clear();
+                                        mapFieldValueValue749 = mapFieldValueValueReuse751;
+                                    } else {
+                                        mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen750), mapFieldValueMapValueSchema748);
+                                    }
+                                    do {
+                                        for (int counter752 = 0; (counter752 <chunkLen750); counter752 ++) {
+                                            Object mapFieldValueValueArrayElementReuseVar753 = null;
+                                            if (null instanceof GenericArray) {
+                                                mapFieldValueValueArrayElementReuseVar753 = ((GenericArray) null).peek();
+                                            }
+                                            mapFieldValueValue749 .add((decoder.readInt()));
+                                        }
+                                        chunkLen750 = (decoder.arrayNext());
+                                    } while (chunkLen750 > 0);
+                                } else {
+                                    mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema748);
+                                }
+                                mapFieldValue743 .put(key747, mapFieldValueValue749);
+                            }
+                            chunkLen744 = (decoder.mapNext());
+                        } while (chunkLen744 > 0);
+                    } else {
+                        mapFieldValue743 = Collections.emptyMap();
+                    }
+                    mapField737 .put(key741, mapFieldValue743);
+                }
+                chunkLen738 = (decoder.mapNext());
+            } while (chunkLen738 > 0);
+        } else {
+            mapField737 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField737);
+        return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -1,0 +1,186 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum755;
+    private final Schema testEnumUnion758;
+    private final Schema testEnumArray762;
+    private final Schema testEnumUnionArray770;
+    private final Schema testEnumUnionArrayArrayElemSchema775;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum755 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion758 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray762 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray770 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema775 = testEnumUnionArray770 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex756 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue757 = null;
+        if (enumIndex756 == 0) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+        }
+        if (enumIndex756 == 1) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+        }
+        if (enumIndex756 == 2) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+        }
+        if (enumIndex756 == 3) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+        }
+        if (enumIndex756 == 4) {
+            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue757);
+        int unionIndex759 = (decoder.readIndex());
+        if (unionIndex759 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex759 == 1) {
+            int enumIndex760 = (decoder.readEnum());
+            org.apache.avro.generic.GenericData.EnumSymbol enumValue761 = null;
+            if (enumIndex760 == 0) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+            }
+            if (enumIndex760 == 1) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+            }
+            if (enumIndex760 == 2) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+            }
+            if (enumIndex760 == 3) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+            }
+            if (enumIndex760 == 4) {
+                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue761);
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray763 = null;
+        long chunkLen764 = (decoder.readArrayStart());
+        if (chunkLen764 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse765 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
+                testEnumArrayReuse765 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+            }
+            if (testEnumArrayReuse765 != (null)) {
+                testEnumArrayReuse765 .clear();
+                testEnumArray763 = testEnumArrayReuse765;
+            } else {
+                testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen764), testEnumArray762);
+            }
+            do {
+                for (int counter766 = 0; (counter766 <chunkLen764); counter766 ++) {
+                    Object testEnumArrayArrayElementReuseVar767 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof GenericArray) {
+                        testEnumArrayArrayElementReuseVar767 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
+                    }
+                    int enumIndex768 = (decoder.readEnum());
+                    org.apache.avro.generic.GenericData.EnumSymbol enumValue769 = null;
+                    if (enumIndex768 == 0) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                    }
+                    if (enumIndex768 == 1) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                    }
+                    if (enumIndex768 == 2) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                    }
+                    if (enumIndex768 == 3) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                    }
+                    if (enumIndex768 == 4) {
+                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                    }
+                    testEnumArray763 .add(enumValue769);
+                }
+                chunkLen764 = (decoder.arrayNext());
+            } while (chunkLen764 > 0);
+        } else {
+            testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray762);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray763);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray771 = null;
+        long chunkLen772 = (decoder.readArrayStart());
+        if (chunkLen772 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse773 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
+                testEnumUnionArrayReuse773 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+            }
+            if (testEnumUnionArrayReuse773 != (null)) {
+                testEnumUnionArrayReuse773 .clear();
+                testEnumUnionArray771 = testEnumUnionArrayReuse773;
+            } else {
+                testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen772), testEnumUnionArray770);
+            }
+            do {
+                for (int counter774 = 0; (counter774 <chunkLen772); counter774 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar776 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
+                        testEnumUnionArrayArrayElementReuseVar776 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                    }
+                    int unionIndex777 = (decoder.readIndex());
+                    if (unionIndex777 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex777 == 1) {
+                        int enumIndex778 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue779 = null;
+                        if (enumIndex778 == 0) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                        }
+                        if (enumIndex778 == 1) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                        }
+                        if (enumIndex778 == 2) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                        }
+                        if (enumIndex778 == 3) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                        }
+                        if (enumIndex778 == 4) {
+                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                        }
+                        testEnumUnionArray771 .add(enumValue779);
+                    }
+                }
+                chunkLen772 = (decoder.arrayNext());
+            } while (chunkLen772 > 0);
+        } else {
+            testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray770);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray771);
+        return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
@@ -1,0 +1,126 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testIntUnion781;
+    private final Schema testStringUnion783;
+    private final Schema testLongUnion785;
+    private final Schema testDoubleUnion787;
+    private final Schema testFloatUnion789;
+    private final Schema testBooleanUnion791;
+    private final Schema testBytesUnion793;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testIntUnion781 = readerSchema.getField("testIntUnion").schema();
+        this.testStringUnion783 = readerSchema.getField("testStringUnion").schema();
+        this.testLongUnion785 = readerSchema.getField("testLongUnion").schema();
+        this.testDoubleUnion787 = readerSchema.getField("testDoubleUnion").schema();
+        this.testFloatUnion789 = readerSchema.getField("testFloatUnion").schema();
+        this.testBooleanUnion791 = readerSchema.getField("testBooleanUnion").schema();
+        this.testBytesUnion793 = readerSchema.getField("testBytesUnion").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
+        int unionIndex782 = (decoder.readIndex());
+        if (unionIndex782 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex782 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
+        }
+        if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2) instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2))));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(null));
+        }
+        int unionIndex784 = (decoder.readIndex());
+        if (unionIndex784 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex784 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(null));
+            }
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
+        int unionIndex786 = (decoder.readIndex());
+        if (unionIndex786 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex786 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
+        int unionIndex788 = (decoder.readIndex());
+        if (unionIndex788 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex788 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
+        int unionIndex790 = (decoder.readIndex());
+        if (unionIndex790 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex790 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
+        int unionIndex792 = (decoder.readIndex());
+        if (unionIndex792 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex792 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
+        }
+        if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12) instanceof ByteBuffer) {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12))));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes((null)));
+        }
+        int unionIndex794 = (decoder.readIndex());
+        if (unionIndex794 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex794 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13) instanceof ByteBuffer) {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes((null)));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -1,0 +1,213 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordsArray799;
+    private final Schema recordsArrayArrayElemSchema804;
+    private final Schema subField807;
+    private final Schema recordsMap809;
+    private final Schema recordsArrayUnion815;
+    private final Schema recordsArrayUnionOptionSchema817;
+    private final Schema recordsArrayUnionOptionArrayElemSchema822;
+    private final Schema recordsMapUnion825;
+    private final Schema recordsMapUnionOptionSchema827;
+    private final Schema recordsMapUnionOptionMapValueSchema833;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordsArray799 = readerSchema.getField("recordsArray").schema();
+        this.recordsArrayArrayElemSchema804 = recordsArray799 .getElementType();
+        this.subField807 = recordsArrayArrayElemSchema804 .getField("subField").schema();
+        this.recordsMap809 = readerSchema.getField("recordsMap").schema();
+        this.recordsArrayUnion815 = readerSchema.getField("recordsArrayUnion").schema();
+        this.recordsArrayUnionOptionSchema817 = recordsArrayUnion815 .getTypes().get(1);
+        this.recordsArrayUnionOptionArrayElemSchema822 = recordsArrayUnionOptionSchema817 .getElementType();
+        this.recordsMapUnion825 = readerSchema.getField("recordsMapUnion").schema();
+        this.recordsMapUnionOptionSchema827 = recordsMapUnion825 .getTypes().get(1);
+        this.recordsMapUnionOptionMapValueSchema833 = recordsMapUnionOptionSchema827 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<IndexedRecord> recordsArray800 = null;
+        long chunkLen801 = (decoder.readArrayStart());
+        if (chunkLen801 > 0) {
+            List<IndexedRecord> recordsArrayReuse802 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
+                recordsArrayReuse802 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+            }
+            if (recordsArrayReuse802 != (null)) {
+                recordsArrayReuse802 .clear();
+                recordsArray800 = recordsArrayReuse802;
+            } else {
+                recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen801), recordsArray799);
+            }
+            do {
+                for (int counter803 = 0; (counter803 <chunkLen801); counter803 ++) {
+                    Object recordsArrayArrayElementReuseVar805 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
+                        recordsArrayArrayElementReuseVar805 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                    }
+                    recordsArray800 .add(deserializesubRecord806(recordsArrayArrayElementReuseVar805, (decoder)));
+                }
+                chunkLen801 = (decoder.arrayNext());
+            } while (chunkLen801 > 0);
+        } else {
+            recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray799);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray800);
+        Map<Utf8, IndexedRecord> recordsMap810 = null;
+        long chunkLen811 = (decoder.readMapStart());
+        if (chunkLen811 > 0) {
+            Map<Utf8, IndexedRecord> recordsMapReuse812 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1) instanceof Map) {
+                recordsMapReuse812 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
+            }
+            if (recordsMapReuse812 != (null)) {
+                recordsMapReuse812 .clear();
+                recordsMap810 = recordsMapReuse812;
+            } else {
+                recordsMap810 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter813 = 0; (counter813 <chunkLen811); counter813 ++) {
+                    Utf8 key814 = (decoder.readString(null));
+                    recordsMap810 .put(key814, deserializesubRecord806(null, (decoder)));
+                }
+                chunkLen811 = (decoder.mapNext());
+            } while (chunkLen811 > 0);
+        } else {
+            recordsMap810 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap810);
+        int unionIndex816 = (decoder.readIndex());
+        if (unionIndex816 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex816 == 1) {
+            List<IndexedRecord> recordsArrayUnionOption818 = null;
+            long chunkLen819 = (decoder.readArrayStart());
+            if (chunkLen819 > 0) {
+                List<IndexedRecord> recordsArrayUnionOptionReuse820 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
+                    recordsArrayUnionOptionReuse820 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                }
+                if (recordsArrayUnionOptionReuse820 != (null)) {
+                    recordsArrayUnionOptionReuse820 .clear();
+                    recordsArrayUnionOption818 = recordsArrayUnionOptionReuse820;
+                } else {
+                    recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen819), recordsArrayUnionOptionSchema817);
+                }
+                do {
+                    for (int counter821 = 0; (counter821 <chunkLen819); counter821 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar823 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayUnionOptionArrayElementReuseVar823 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                        }
+                        int unionIndex824 = (decoder.readIndex());
+                        if (unionIndex824 == 0) {
+                            decoder.readNull();
+                        }
+                        if (unionIndex824 == 1) {
+                            recordsArrayUnionOption818 .add(deserializesubRecord806(recordsArrayUnionOptionArrayElementReuseVar823, (decoder)));
+                        }
+                    }
+                    chunkLen819 = (decoder.arrayNext());
+                } while (chunkLen819 > 0);
+            } else {
+                recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema817);
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption818);
+        }
+        int unionIndex826 = (decoder.readIndex());
+        if (unionIndex826 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex826 == 1) {
+            Map<Utf8, IndexedRecord> recordsMapUnionOption828 = null;
+            long chunkLen829 = (decoder.readMapStart());
+            if (chunkLen829 > 0) {
+                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse830 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3) instanceof Map) {
+                    recordsMapUnionOptionReuse830 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
+                }
+                if (recordsMapUnionOptionReuse830 != (null)) {
+                    recordsMapUnionOptionReuse830 .clear();
+                    recordsMapUnionOption828 = recordsMapUnionOptionReuse830;
+                } else {
+                    recordsMapUnionOption828 = new HashMap<Utf8, IndexedRecord>();
+                }
+                do {
+                    for (int counter831 = 0; (counter831 <chunkLen829); counter831 ++) {
+                        Utf8 key832 = (decoder.readString(null));
+                        int unionIndex834 = (decoder.readIndex());
+                        if (unionIndex834 == 0) {
+                            decoder.readNull();
+                        }
+                        if (unionIndex834 == 1) {
+                            recordsMapUnionOption828 .put(key832, deserializesubRecord806(null, (decoder)));
+                        }
+                    }
+                    chunkLen829 = (decoder.mapNext());
+                } while (chunkLen829 > 0);
+            } else {
+                recordsMapUnionOption828 = Collections.emptyMap();
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption828);
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
+    }
+
+    public IndexedRecord deserializesubRecord806(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema804)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema804);
+        }
+        int unionIndex808 = (decoder.readIndex());
+        if (unionIndex808 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex808 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -1,0 +1,331 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordsArrayMap836;
+    private final Schema recordsArrayMapArrayElemSchema841;
+    private final Schema recordsArrayMapElemMapValueSchema848;
+    private final Schema recordsArrayMapElemValueOptionSchema850;
+    private final Schema subField852;
+    private final Schema recordsMapArray854;
+    private final Schema recordsMapArrayMapValueSchema860;
+    private final Schema recordsMapArrayValueArrayElemSchema865;
+    private final Schema recordsArrayMapUnion868;
+    private final Schema recordsArrayMapUnionOptionArrayElemSchema874;
+    private final Schema recordsArrayMapUnionOptionElemMapValueSchema881;
+    private final Schema recordsMapArrayUnion883;
+    private final Schema recordsMapArrayUnionOptionSchema885;
+    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema895;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordsArrayMap836 = readerSchema.getField("recordsArrayMap").schema();
+        this.recordsArrayMapArrayElemSchema841 = recordsArrayMap836 .getElementType();
+        this.recordsArrayMapElemMapValueSchema848 = recordsArrayMapArrayElemSchema841 .getValueType();
+        this.recordsArrayMapElemValueOptionSchema850 = recordsArrayMapElemMapValueSchema848 .getTypes().get(1);
+        this.subField852 = recordsArrayMapElemValueOptionSchema850 .getField("subField").schema();
+        this.recordsMapArray854 = readerSchema.getField("recordsMapArray").schema();
+        this.recordsMapArrayMapValueSchema860 = recordsMapArray854 .getValueType();
+        this.recordsMapArrayValueArrayElemSchema865 = recordsMapArrayMapValueSchema860 .getElementType();
+        this.recordsArrayMapUnion868 = readerSchema.getField("recordsArrayMapUnion").schema();
+        this.recordsArrayMapUnionOptionArrayElemSchema874 = recordsArrayMap836 .getElementType();
+        this.recordsArrayMapUnionOptionElemMapValueSchema881 = recordsArrayMapUnionOptionArrayElemSchema874 .getValueType();
+        this.recordsMapArrayUnion883 = readerSchema.getField("recordsMapArrayUnion").schema();
+        this.recordsMapArrayUnionOptionSchema885 = recordsMapArrayUnion883 .getTypes().get(1);
+        this.recordsMapArrayUnionOptionValueArrayElemSchema895 = recordsMapArrayMapValueSchema860 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Map<Utf8, IndexedRecord>> recordsArrayMap837 = null;
+        long chunkLen838 = (decoder.readArrayStart());
+        if (chunkLen838 > 0) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse839 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
+                recordsArrayMapReuse839 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+            }
+            if (recordsArrayMapReuse839 != (null)) {
+                recordsArrayMapReuse839 .clear();
+                recordsArrayMap837 = recordsArrayMapReuse839;
+            } else {
+                recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen838), recordsArrayMap836);
+            }
+            do {
+                for (int counter840 = 0; (counter840 <chunkLen838); counter840 ++) {
+                    Object recordsArrayMapArrayElementReuseVar842 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
+                        recordsArrayMapArrayElementReuseVar842 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                    }
+                    Map<Utf8, IndexedRecord> recordsArrayMapElem843 = null;
+                    long chunkLen844 = (decoder.readMapStart());
+                    if (chunkLen844 > 0) {
+                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse845 = null;
+                        if (recordsArrayMapArrayElementReuseVar842 instanceof Map) {
+                            recordsArrayMapElemReuse845 = ((Map) recordsArrayMapArrayElementReuseVar842);
+                        }
+                        if (recordsArrayMapElemReuse845 != (null)) {
+                            recordsArrayMapElemReuse845 .clear();
+                            recordsArrayMapElem843 = recordsArrayMapElemReuse845;
+                        } else {
+                            recordsArrayMapElem843 = new HashMap<Utf8, IndexedRecord>();
+                        }
+                        do {
+                            for (int counter846 = 0; (counter846 <chunkLen844); counter846 ++) {
+                                Utf8 key847 = (decoder.readString(null));
+                                int unionIndex849 = (decoder.readIndex());
+                                if (unionIndex849 == 0) {
+                                    decoder.readNull();
+                                }
+                                if (unionIndex849 == 1) {
+                                    recordsArrayMapElem843 .put(key847, deserializesubRecord851(null, (decoder)));
+                                }
+                            }
+                            chunkLen844 = (decoder.mapNext());
+                        } while (chunkLen844 > 0);
+                    } else {
+                        recordsArrayMapElem843 = Collections.emptyMap();
+                    }
+                    recordsArrayMap837 .add(recordsArrayMapElem843);
+                }
+                chunkLen838 = (decoder.arrayNext());
+            } while (chunkLen838 > 0);
+        } else {
+            recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap837);
+        Map<Utf8, List<IndexedRecord>> recordsMapArray855 = null;
+        long chunkLen856 = (decoder.readMapStart());
+        if (chunkLen856 > 0) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse857 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1) instanceof Map) {
+                recordsMapArrayReuse857 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
+            }
+            if (recordsMapArrayReuse857 != (null)) {
+                recordsMapArrayReuse857 .clear();
+                recordsMapArray855 = recordsMapArrayReuse857;
+            } else {
+                recordsMapArray855 = new HashMap<Utf8, List<IndexedRecord>>();
+            }
+            do {
+                for (int counter858 = 0; (counter858 <chunkLen856); counter858 ++) {
+                    Utf8 key859 = (decoder.readString(null));
+                    List<IndexedRecord> recordsMapArrayValue861 = null;
+                    long chunkLen862 = (decoder.readArrayStart());
+                    if (chunkLen862 > 0) {
+                        List<IndexedRecord> recordsMapArrayValueReuse863 = null;
+                        if (null instanceof List) {
+                            recordsMapArrayValueReuse863 = ((List) null);
+                        }
+                        if (recordsMapArrayValueReuse863 != (null)) {
+                            recordsMapArrayValueReuse863 .clear();
+                            recordsMapArrayValue861 = recordsMapArrayValueReuse863;
+                        } else {
+                            recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen862), recordsMapArrayMapValueSchema860);
+                        }
+                        do {
+                            for (int counter864 = 0; (counter864 <chunkLen862); counter864 ++) {
+                                Object recordsMapArrayValueArrayElementReuseVar866 = null;
+                                if (null instanceof GenericArray) {
+                                    recordsMapArrayValueArrayElementReuseVar866 = ((GenericArray) null).peek();
+                                }
+                                int unionIndex867 = (decoder.readIndex());
+                                if (unionIndex867 == 0) {
+                                    decoder.readNull();
+                                }
+                                if (unionIndex867 == 1) {
+                                    recordsMapArrayValue861 .add(deserializesubRecord851(recordsMapArrayValueArrayElementReuseVar866, (decoder)));
+                                }
+                            }
+                            chunkLen862 = (decoder.arrayNext());
+                        } while (chunkLen862 > 0);
+                    } else {
+                        recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                    }
+                    recordsMapArray855 .put(key859, recordsMapArrayValue861);
+                }
+                chunkLen856 = (decoder.mapNext());
+            } while (chunkLen856 > 0);
+        } else {
+            recordsMapArray855 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray855);
+        int unionIndex869 = (decoder.readIndex());
+        if (unionIndex869 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex869 == 1) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption870 = null;
+            long chunkLen871 = (decoder.readArrayStart());
+            if (chunkLen871 > 0) {
+                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse872 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
+                    recordsArrayMapUnionOptionReuse872 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                }
+                if (recordsArrayMapUnionOptionReuse872 != (null)) {
+                    recordsArrayMapUnionOptionReuse872 .clear();
+                    recordsArrayMapUnionOption870 = recordsArrayMapUnionOptionReuse872;
+                } else {
+                    recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen871), recordsArrayMap836);
+                }
+                do {
+                    for (int counter873 = 0; (counter873 <chunkLen871); counter873 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar875 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayMapUnionOptionArrayElementReuseVar875 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                        }
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem876 = null;
+                        long chunkLen877 = (decoder.readMapStart());
+                        if (chunkLen877 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse878 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar875 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse878 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar875);
+                            }
+                            if (recordsArrayMapUnionOptionElemReuse878 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse878 .clear();
+                                recordsArrayMapUnionOptionElem876 = recordsArrayMapUnionOptionElemReuse878;
+                            } else {
+                                recordsArrayMapUnionOptionElem876 = new HashMap<Utf8, IndexedRecord>();
+                            }
+                            do {
+                                for (int counter879 = 0; (counter879 <chunkLen877); counter879 ++) {
+                                    Utf8 key880 = (decoder.readString(null));
+                                    int unionIndex882 = (decoder.readIndex());
+                                    if (unionIndex882 == 0) {
+                                        decoder.readNull();
+                                    }
+                                    if (unionIndex882 == 1) {
+                                        recordsArrayMapUnionOptionElem876 .put(key880, deserializesubRecord851(null, (decoder)));
+                                    }
+                                }
+                                chunkLen877 = (decoder.mapNext());
+                            } while (chunkLen877 > 0);
+                        } else {
+                            recordsArrayMapUnionOptionElem876 = Collections.emptyMap();
+                        }
+                        recordsArrayMapUnionOption870 .add(recordsArrayMapUnionOptionElem876);
+                    }
+                    chunkLen871 = (decoder.arrayNext());
+                } while (chunkLen871 > 0);
+            } else {
+                recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption870);
+        }
+        int unionIndex884 = (decoder.readIndex());
+        if (unionIndex884 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex884 == 1) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption886 = null;
+            long chunkLen887 = (decoder.readMapStart());
+            if (chunkLen887 > 0) {
+                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse888 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3) instanceof Map) {
+                    recordsMapArrayUnionOptionReuse888 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
+                }
+                if (recordsMapArrayUnionOptionReuse888 != (null)) {
+                    recordsMapArrayUnionOptionReuse888 .clear();
+                    recordsMapArrayUnionOption886 = recordsMapArrayUnionOptionReuse888;
+                } else {
+                    recordsMapArrayUnionOption886 = new HashMap<Utf8, List<IndexedRecord>>();
+                }
+                do {
+                    for (int counter889 = 0; (counter889 <chunkLen887); counter889 ++) {
+                        Utf8 key890 = (decoder.readString(null));
+                        List<IndexedRecord> recordsMapArrayUnionOptionValue891 = null;
+                        long chunkLen892 = (decoder.readArrayStart());
+                        if (chunkLen892 > 0) {
+                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse893 = null;
+                            if (null instanceof List) {
+                                recordsMapArrayUnionOptionValueReuse893 = ((List) null);
+                            }
+                            if (recordsMapArrayUnionOptionValueReuse893 != (null)) {
+                                recordsMapArrayUnionOptionValueReuse893 .clear();
+                                recordsMapArrayUnionOptionValue891 = recordsMapArrayUnionOptionValueReuse893;
+                            } else {
+                                recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen892), recordsMapArrayMapValueSchema860);
+                            }
+                            do {
+                                for (int counter894 = 0; (counter894 <chunkLen892); counter894 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar896 = null;
+                                    if (null instanceof GenericArray) {
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar896 = ((GenericArray) null).peek();
+                                    }
+                                    int unionIndex897 = (decoder.readIndex());
+                                    if (unionIndex897 == 0) {
+                                        decoder.readNull();
+                                    }
+                                    if (unionIndex897 == 1) {
+                                        recordsMapArrayUnionOptionValue891 .add(deserializesubRecord851(recordsMapArrayUnionOptionValueArrayElementReuseVar896, (decoder)));
+                                    }
+                                }
+                                chunkLen892 = (decoder.arrayNext());
+                            } while (chunkLen892 > 0);
+                        } else {
+                            recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                        }
+                        recordsMapArrayUnionOption886 .put(key890, recordsMapArrayUnionOptionValue891);
+                    }
+                    chunkLen887 = (decoder.mapNext());
+                } while (chunkLen887 > 0);
+            } else {
+                recordsMapArrayUnionOption886 = Collections.emptyMap();
+            }
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption886);
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
+    }
+
+    public IndexedRecord deserializesubRecord851(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema850)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema850);
+        }
+        int unionIndex853 = (decoder.readIndex());
+        if (unionIndex853 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex853 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
@@ -1,0 +1,89 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record899;
+    private final Schema recordOptionSchema901;
+    private final Schema subField903;
+    private final Schema field905;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record899 = readerSchema.getField("record").schema();
+        this.recordOptionSchema901 = record899 .getTypes().get(1);
+        this.subField903 = recordOptionSchema901 .getField("subField").schema();
+        this.field905 = readerSchema.getField("field").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex900 = (decoder.readIndex());
+        if (unionIndex900 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex900 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        int unionIndex906 = (decoder.readIndex());
+        if (unionIndex906 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex906 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(null));
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
+    }
+
+    public IndexedRecord deserializesubRecord902(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema901)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema901);
+        }
+        int unionIndex904 = (decoder.readIndex());
+        if (unionIndex904 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex904 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -1,0 +1,188 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testNotRemoved908;
+    private final Schema testNotRemoved2911;
+    private final Schema subRecord913;
+    private final Schema subRecordOptionSchema915;
+    private final Schema testNotRemoved917;
+    private final Schema testNotRemoved2920;
+    private final Schema subRecordMap922;
+    private final Schema subRecordArray928;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testNotRemoved908 = readerSchema.getField("testNotRemoved").schema();
+        this.testNotRemoved2911 = readerSchema.getField("testNotRemoved2").schema();
+        this.subRecord913 = readerSchema.getField("subRecord").schema();
+        this.subRecordOptionSchema915 = subRecord913 .getTypes().get(1);
+        this.testNotRemoved917 = subRecordOptionSchema915 .getField("testNotRemoved").schema();
+        this.testNotRemoved2920 = subRecordOptionSchema915 .getField("testNotRemoved2").schema();
+        this.subRecordMap922 = readerSchema.getField("subRecordMap").schema();
+        this.subRecordArray928 = readerSchema.getField("subRecordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex909 = (decoder.readIndex());
+        if (unionIndex909 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex909 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex910 = (decoder.readIndex());
+        if (unionIndex910 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex910 == 1) {
+            decoder.skipString();
+        }
+        int unionIndex912 = (decoder.readIndex());
+        if (unionIndex912 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex912 == 1) {
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1) instanceof Utf8) {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1))));
+            } else {
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(null));
+            }
+        }
+        int unionIndex914 = (decoder.readIndex());
+        if (unionIndex914 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex914 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord916(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+        }
+        Map<Utf8, IndexedRecord> subRecordMap923 = null;
+        long chunkLen924 = (decoder.readMapStart());
+        if (chunkLen924 > 0) {
+            Map<Utf8, IndexedRecord> subRecordMapReuse925 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3) instanceof Map) {
+                subRecordMapReuse925 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
+            }
+            if (subRecordMapReuse925 != (null)) {
+                subRecordMapReuse925 .clear();
+                subRecordMap923 = subRecordMapReuse925;
+            } else {
+                subRecordMap923 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter926 = 0; (counter926 <chunkLen924); counter926 ++) {
+                    Utf8 key927 = (decoder.readString(null));
+                    subRecordMap923 .put(key927, deserializesubRecord916(null, (decoder)));
+                }
+                chunkLen924 = (decoder.mapNext());
+            } while (chunkLen924 > 0);
+        } else {
+            subRecordMap923 = Collections.emptyMap();
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap923);
+        List<IndexedRecord> subRecordArray929 = null;
+        long chunkLen930 = (decoder.readArrayStart());
+        if (chunkLen930 > 0) {
+            List<IndexedRecord> subRecordArrayReuse931 = null;
+            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
+                subRecordArrayReuse931 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+            }
+            if (subRecordArrayReuse931 != (null)) {
+                subRecordArrayReuse931 .clear();
+                subRecordArray929 = subRecordArrayReuse931;
+            } else {
+                subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen930), subRecordArray928);
+            }
+            do {
+                for (int counter932 = 0; (counter932 <chunkLen930); counter932 ++) {
+                    Object subRecordArrayArrayElementReuseVar933 = null;
+                    if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
+                        subRecordArrayArrayElementReuseVar933 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                    }
+                    subRecordArray929 .add(deserializesubRecord916(subRecordArrayArrayElementReuseVar933, (decoder)));
+                }
+                chunkLen930 = (decoder.arrayNext());
+            } while (chunkLen930 > 0);
+        } else {
+            subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray928);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray929);
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
+    }
+
+    public IndexedRecord deserializesubRecord916(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema915)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema915);
+        }
+        int unionIndex918 = (decoder.readIndex());
+        if (unionIndex918 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex918 == 1) {
+            if (subRecord.get(0) instanceof Utf8) {
+                subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+            } else {
+                subRecord.put(0, (decoder).readString(null));
+            }
+        }
+        int unionIndex919 = (decoder.readIndex());
+        if (unionIndex919 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex919 == 1) {
+            decoder.skipString();
+        }
+        int unionIndex921 = (decoder.readIndex());
+        if (unionIndex921 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex921 == 1) {
+            if (subRecord.get(1) instanceof Utf8) {
+                subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+            } else {
+                subRecord.put(1, (decoder).readString(null));
+            }
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
@@ -1,0 +1,79 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord935;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord935 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord936(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
+    }
+
+    public IndexedRecord deserializesubRecord936(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord935)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord935);
+        }
+        if (subRecord.get(0) instanceof Utf8) {
+            subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+        } else {
+            subRecord.put(0, (decoder).readString(null));
+        }
+        deserializesubSubRecord937(null, (decoder));
+        int unionIndex938 = (decoder.readIndex());
+        if (unionIndex938 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex938 == 1) {
+            deserializesubSubRecord937(null, (decoder));
+        }
+        if (subRecord.get(1) instanceof Utf8) {
+            subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+        } else {
+            subRecord.put(1, (decoder).readString(null));
+        }
+        return subRecord;
+    }
+
+    public void deserializesubSubRecord937(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        decoder.skipString();
+        decoder.skipString();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
@@ -1,0 +1,80 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord1940;
+
+    public FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord1940 = readerSchema.getField("subRecord1").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
+        deserializesubRecord2942(null, (decoder));
+        int unionIndex943 = (decoder.readIndex());
+        if (unionIndex943 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex943 == 1) {
+            deserializesubRecord2942(null, (decoder));
+        }
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
+    }
+
+    public IndexedRecord deserializesubRecord941(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord1940)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord1940);
+        }
+        if (subRecord.get(0) instanceof Utf8) {
+            subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
+        } else {
+            subRecord.put(0, (decoder).readString(null));
+        }
+        if (subRecord.get(1) instanceof Utf8) {
+            subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
+        } else {
+            subRecord.put(1, (decoder).readString(null));
+        }
+        return subRecord;
+    }
+
+    public void deserializesubRecord2942(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        decoder.skipString();
+        decoder.skipString();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -1,0 +1,88 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapValueSchema708;
+    private final Schema mapValueOptionSchema710;
+    private final Schema field712;
+
+    public Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapValueSchema708 = readerSchema.getValueType();
+        this.mapValueOptionSchema710 = mapMapValueSchema708 .getTypes().get(1);
+        this.field712 = mapValueOptionSchema710 .getField("field").schema();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map703 = null;
+        long chunkLen704 = (decoder.readMapStart());
+        if (chunkLen704 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse705 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse705 = ((Map)(reuse));
+            }
+            if (mapReuse705 != (null)) {
+                mapReuse705 .clear();
+                map703 = mapReuse705;
+            } else {
+                map703 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter706 = 0; (counter706 <chunkLen704); counter706 ++) {
+                    Utf8 key707 = (decoder.readString(null));
+                    int unionIndex709 = (decoder.readIndex());
+                    if (unionIndex709 == 0) {
+                        decoder.readNull();
+                    }
+                    if (unionIndex709 == 1) {
+                        map703 .put(key707, deserializerecord711(null, (decoder)));
+                    }
+                }
+                chunkLen704 = (decoder.mapNext());
+            } while (chunkLen704 > 0);
+        } else {
+            map703 = Collections.emptyMap();
+        }
+        return map703;
+    }
+
+    public IndexedRecord deserializerecord711(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema710)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema710);
+        }
+        int unionIndex713 = (decoder.readIndex());
+        if (unionIndex713 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex713 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -1,0 +1,80 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapValueSchema699;
+    private final Schema field701;
+
+    public Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapValueSchema699 = readerSchema.getValueType();
+        this.field701 = mapMapValueSchema699 .getField("field").schema();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map694 = null;
+        long chunkLen695 = (decoder.readMapStart());
+        if (chunkLen695 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse696 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse696 = ((Map)(reuse));
+            }
+            if (mapReuse696 != (null)) {
+                mapReuse696 .clear();
+                map694 = mapReuse696;
+            } else {
+                map694 = new HashMap<Utf8, IndexedRecord>();
+            }
+            do {
+                for (int counter697 = 0; (counter697 <chunkLen695); counter697 ++) {
+                    Utf8 key698 = (decoder.readString(null));
+                    map694 .put(key698, deserializerecord700(null, (decoder)));
+                }
+                chunkLen695 = (decoder.mapNext());
+            } while (chunkLen695 > 0);
+        } else {
+            map694 = Collections.emptyMap();
+        }
+        return map694;
+    }
+
+    public IndexedRecord deserializerecord700(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema699)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema699);
+        }
+        int unionIndex702 = (decoder.readIndex());
+        if (unionIndex702 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex702 == 1) {
+            if (record.get(0) instanceof Utf8) {
+                record.put(0, (decoder).readString(((Utf8) record.get(0))));
+            } else {
+                record.put(0, (decoder).readString(null));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class recordName_GenericDeserializer_6897301803194779359_6897301803194779359
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionField796;
+
+    public recordName_GenericDeserializer_6897301803194779359_6897301803194779359(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionField796 = readerSchema.getField("unionField").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecordName795((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecordName795(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord recordName;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            recordName = ((IndexedRecord)(reuse));
+        } else {
+            recordName = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        if (recordName.get(0) instanceof Utf8) {
+            recordName.put(0, (decoder).readString(((Utf8) recordName.get(0))));
+        } else {
+            recordName.put(0, (decoder).readString(null));
+        }
+        int unionIndex797 = (decoder.readIndex());
+        if (unionIndex797 == 0) {
+            decoder.readNull();
+        }
+        if (unionIndex797 == 1) {
+            recordName.put(1, deserializerecordName795(recordName.get(1), (decoder)));
+        }
+        return recordName;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -1,0 +1,66 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_UNION_GenericSerializer_585074122056792963
+    implements FastSerializer<List<IndexedRecord>>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(List<IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter64 = 0; (counter64 <((List<IndexedRecord> ) data).size()); counter64 ++) {
+                (encoder).startItem();
+                IndexedRecord union65 = null;
+                union65 = ((List<IndexedRecord> ) data).get(counter64);
+                if (union65 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union65 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union65).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        serializerecord66(((IndexedRecord) union65), (encoder));
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord66(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field67 = ((CharSequence) data.get(0));
+        if (field67 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field67 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field67 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field67));
+                } else {
+                    (encoder).writeString(field67 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -1,0 +1,58 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_record_GenericSerializer_1629046702287533603
+    implements FastSerializer<List<IndexedRecord>>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(List<IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter60 = 0; (counter60 <((List<IndexedRecord> ) data).size()); counter60 ++) {
+                (encoder).startItem();
+                IndexedRecord record61 = null;
+                record61 = ((List<IndexedRecord> ) data).get(counter60);
+                serializerecord62(record61, (encoder));
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord62(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field63 = ((CharSequence) data.get(0));
+        if (field63 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field63 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field63 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field63));
+                } else {
+                    (encoder).writeString(field63 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173.java
@@ -1,0 +1,81 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Schema testEnumEnumSchema69 = enumSchemaMap.get(-3346156575824446940L);
+        if (null == testEnumEnumSchema69) {
+            testEnumEnumSchema69 = Schema.parse("{\"type\":\"enum\",\"name\":\"testEnum\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"symbols\":[\"A\",\"B\"]}");
+            enumSchemaMap.put(-3346156575824446940L, testEnumEnumSchema69);
+        }
+        (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
+        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion70 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
+        if (testEnumUnion70 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testEnumUnion70 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
+                (encoder).writeIndex(1);
+                (encoder).writeEnum(enumSchemaMap.get(-3346156575824446940L).getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion70).toString()));
+            }
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray71 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
+        (encoder).writeArrayStart();
+        if ((testEnumArray71 == null)||testEnumArray71 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testEnumArray71 .size());
+            for (int counter72 = 0; (counter72 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray71).size()); counter72 ++) {
+                (encoder).startItem();
+                (encoder).writeEnum(enumSchemaMap.get(-3346156575824446940L).getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray71 .get(counter72)).toString()));
+            }
+        }
+        (encoder).writeArrayEnd();
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray73 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
+        (encoder).writeArrayStart();
+        if ((testEnumUnionArray73 == null)||testEnumUnionArray73 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testEnumUnionArray73 .size());
+            for (int counter74 = 0; (counter74 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray73).size()); counter74 ++) {
+                (encoder).startItem();
+                org.apache.avro.generic.GenericData.EnumSymbol union75 = null;
+                union75 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray73).get(counter74);
+                if (union75 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if (union75 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
+                        (encoder).writeIndex(1);
+                        (encoder).writeEnum(enumSchemaMap.get(-3346156575824446940L).getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union75).toString()));
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201.java
@@ -1,0 +1,76 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed76(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed76(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) data.get(0)).bytes());
+        org.apache.avro.generic.GenericData.Fixed testFixedUnion77 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
+        if (testFixedUnion77 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testFixedUnion77 instanceof org.apache.avro.generic.GenericData.Fixed) {
+                (encoder).writeIndex(1);
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion77).bytes());
+            }
+        }
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray78 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
+        (encoder).writeArrayStart();
+        if ((testFixedArray78 == null)||testFixedArray78 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testFixedArray78 .size());
+            for (int counter79 = 0; (counter79 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray78).size()); counter79 ++) {
+                (encoder).startItem();
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray78 .get(counter79)).bytes());
+            }
+        }
+        (encoder).writeArrayEnd();
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray80 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
+        (encoder).writeArrayStart();
+        if ((testFixedUnionArray80 == null)||testFixedUnionArray80 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testFixedUnionArray80 .size());
+            for (int counter81 = 0; (counter81 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray80).size()); counter81 ++) {
+                (encoder).startItem();
+                org.apache.avro.generic.GenericData.Fixed union82 = null;
+                union82 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray80).get(counter81);
+                if (union82 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if (union82 instanceof org.apache.avro.generic.GenericData.Fixed) {
+                        (encoder).writeIndex(1);
+                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union82).bytes());
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion99(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion99(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Object union100 = ((Object) data.get(0));
+        if (union100 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((union100 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union100).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializesubRecord101(((IndexedRecord) union100), (encoder));
+            } else {
+                if (union100 instanceof CharSequence) {
+                    (encoder).writeIndex(2);
+                    if (union100 instanceof Utf8) {
+                        (encoder).writeString(((Utf8) union100));
+                    } else {
+                        (encoder).writeString(union100 .toString());
+                    }
+                } else {
+                    if (union100 instanceof Integer) {
+                        (encoder).writeIndex(3);
+                        (encoder).writeInt(((Integer) union100));
+                    }
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord101(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField102 = ((CharSequence) data.get(0));
+        if (subField102 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField102 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField102 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField102));
+                } else {
+                    (encoder).writeString(subField102 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849.java
@@ -1,0 +1,117 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives103(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives103(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeInt(((Integer) data.get(0)));
+        Integer testIntUnion104 = ((Integer) data.get(1));
+        if (testIntUnion104 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testIntUnion104 instanceof Integer) {
+                (encoder).writeIndex(1);
+                (encoder).writeInt(((Integer) testIntUnion104));
+            }
+        }
+        if (data.get(2) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(2)));
+        } else {
+            (encoder).writeString(data.get(2).toString());
+        }
+        CharSequence testStringUnion105 = ((CharSequence) data.get(3));
+        if (testStringUnion105 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testStringUnion105 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (testStringUnion105 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) testStringUnion105));
+                } else {
+                    (encoder).writeString(testStringUnion105 .toString());
+                }
+            }
+        }
+        (encoder).writeLong(((Long) data.get(4)));
+        Long testLongUnion106 = ((Long) data.get(5));
+        if (testLongUnion106 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testLongUnion106 instanceof Long) {
+                (encoder).writeIndex(1);
+                (encoder).writeLong(((Long) testLongUnion106));
+            }
+        }
+        (encoder).writeDouble(((Double) data.get(6)));
+        Double testDoubleUnion107 = ((Double) data.get(7));
+        if (testDoubleUnion107 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testDoubleUnion107 instanceof Double) {
+                (encoder).writeIndex(1);
+                (encoder).writeDouble(((Double) testDoubleUnion107));
+            }
+        }
+        (encoder).writeFloat(((Float) data.get(8)));
+        Float testFloatUnion108 = ((Float) data.get(9));
+        if (testFloatUnion108 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testFloatUnion108 instanceof Float) {
+                (encoder).writeIndex(1);
+                (encoder).writeFloat(((Float) testFloatUnion108));
+            }
+        }
+        (encoder).writeBoolean(((Boolean) data.get(10)));
+        Boolean testBooleanUnion109 = ((Boolean) data.get(11));
+        if (testBooleanUnion109 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testBooleanUnion109 instanceof Boolean) {
+                (encoder).writeIndex(1);
+                (encoder).writeBoolean(((Boolean) testBooleanUnion109));
+            }
+        }
+        (encoder).writeBytes(((ByteBuffer) data.get(12)));
+        ByteBuffer testBytesUnion110 = ((ByteBuffer) data.get(13));
+        if (testBytesUnion110 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testBytesUnion110 instanceof ByteBuffer) {
+                (encoder).writeIndex(1);
+                (encoder).writeBytes(((ByteBuffer) testBytesUnion110));
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex111(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex111(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Object union_field112 = ((Object) data.get(0));
+        if (union_field112 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((union_field112 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field112).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializerecord1113(((IndexedRecord) union_field112), (encoder));
+            } else {
+                if ((union_field112 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field112).getSchema().getFullName())) {
+                    (encoder).writeIndex(2);
+                    serializerecord2114(((IndexedRecord) union_field112), (encoder));
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord1113(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        if (data.get(0) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(0)));
+        } else {
+            (encoder).writeString(data.get(0).toString());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord2114(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        if (data.get(0) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(0)));
+        } else {
+            (encoder).writeString(data.get(0).toString());
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381.java
@@ -1,0 +1,142 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField115(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField115(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        List<IndexedRecord> recordsArray116 = ((List<IndexedRecord> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((recordsArray116 == null)||recordsArray116 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsArray116 .size());
+            for (int counter117 = 0; (counter117 <((List<IndexedRecord> ) recordsArray116).size()); counter117 ++) {
+                (encoder).startItem();
+                IndexedRecord subRecord118 = null;
+                subRecord118 = ((List<IndexedRecord> ) recordsArray116).get(counter117);
+                serializesubRecord119(subRecord118, (encoder));
+            }
+        }
+        (encoder).writeArrayEnd();
+        Map<CharSequence, IndexedRecord> recordsMap121 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        (encoder).writeMapStart();
+        if ((recordsMap121 == null)||recordsMap121 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsMap121 .size());
+            for (CharSequence key122 : ((Map<CharSequence, IndexedRecord> ) recordsMap121).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key122);
+                IndexedRecord subRecord123 = null;
+                subRecord123 = ((Map<CharSequence, IndexedRecord> ) recordsMap121).get(key122);
+                serializesubRecord119(subRecord123, (encoder));
+            }
+        }
+        (encoder).writeMapEnd();
+        List<IndexedRecord> recordsArrayUnion124 = ((List<IndexedRecord> ) data.get(2));
+        if (recordsArrayUnion124 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsArrayUnion124 instanceof List) {
+                (encoder).writeIndex(1);
+                (encoder).writeArrayStart();
+                if ((((List<IndexedRecord> ) recordsArrayUnion124) == null)||((List<IndexedRecord> ) recordsArrayUnion124).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion124).size());
+                    for (int counter125 = 0; (counter125 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion124)).size()); counter125 ++) {
+                        (encoder).startItem();
+                        IndexedRecord union126 = null;
+                        union126 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion124)).get(counter125);
+                        if (union126 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union126 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union126).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord119(((IndexedRecord) union126), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        Map<CharSequence, IndexedRecord> recordsMapUnion127 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
+        if (recordsMapUnion127 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsMapUnion127 instanceof Map) {
+                (encoder).writeIndex(1);
+                (encoder).writeMapStart();
+                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion127) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion127).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion127).size());
+                    for (CharSequence key128 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion127)).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key128);
+                        IndexedRecord union129 = null;
+                        union129 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion127)).get(key128);
+                        if (union129 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union129 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union129).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord119(((IndexedRecord) union129), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord119(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField120 = ((CharSequence) data.get(0));
+        if (subField120 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField120 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField120 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField120));
+                } else {
+                    (encoder).writeString(subField120 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871.java
@@ -1,0 +1,208 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField130(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField130(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMap131 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((recordsArrayMap131 == null)||recordsArrayMap131 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsArrayMap131 .size());
+            for (int counter132 = 0; (counter132 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap131).size()); counter132 ++) {
+                (encoder).startItem();
+                Map<CharSequence, IndexedRecord> map133 = null;
+                map133 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap131).get(counter132);
+                (encoder).writeMapStart();
+                if ((map133 == null)||map133 .isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(map133 .size());
+                    for (CharSequence key134 : ((Map<CharSequence, IndexedRecord> ) map133).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key134);
+                        IndexedRecord union135 = null;
+                        union135 = ((Map<CharSequence, IndexedRecord> ) map133).get(key134);
+                        if (union135 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union135 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union135).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord136(((IndexedRecord) union135), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+        (encoder).writeArrayEnd();
+        Map<CharSequence, List<IndexedRecord>> recordsMapArray138 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        (encoder).writeMapStart();
+        if ((recordsMapArray138 == null)||recordsMapArray138 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsMapArray138 .size());
+            for (CharSequence key139 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray138).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key139);
+                List<IndexedRecord> array140 = null;
+                array140 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray138).get(key139);
+                (encoder).writeArrayStart();
+                if ((array140 == null)||array140 .isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(array140 .size());
+                    for (int counter141 = 0; (counter141 <((List<IndexedRecord> ) array140).size()); counter141 ++) {
+                        (encoder).startItem();
+                        IndexedRecord union142 = null;
+                        union142 = ((List<IndexedRecord> ) array140).get(counter141);
+                        if (union142 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union142 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union142).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord136(((IndexedRecord) union142), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        (encoder).writeMapEnd();
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion143 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
+        if (recordsArrayMapUnion143 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsArrayMapUnion143 instanceof List) {
+                (encoder).writeIndex(1);
+                (encoder).writeArrayStart();
+                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143).size());
+                    for (int counter144 = 0; (counter144 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143)).size()); counter144 ++) {
+                        (encoder).startItem();
+                        Map<CharSequence, IndexedRecord> map145 = null;
+                        map145 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143)).get(counter144);
+                        (encoder).writeMapStart();
+                        if ((map145 == null)||map145 .isEmpty()) {
+                            (encoder).setItemCount(0);
+                        } else {
+                            (encoder).setItemCount(map145 .size());
+                            for (CharSequence key146 : ((Map<CharSequence, IndexedRecord> ) map145).keySet()) {
+                                (encoder).startItem();
+                                (encoder).writeString(key146);
+                                IndexedRecord union147 = null;
+                                union147 = ((Map<CharSequence, IndexedRecord> ) map145).get(key146);
+                                if (union147 == null) {
+                                    (encoder).writeIndex(0);
+                                    (encoder).writeNull();
+                                } else {
+                                    if ((union147 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union147).getSchema().getFullName())) {
+                                        (encoder).writeIndex(1);
+                                        serializesubRecord136(((IndexedRecord) union147), (encoder));
+                                    }
+                                }
+                            }
+                        }
+                        (encoder).writeMapEnd();
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion148 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
+        if (recordsMapArrayUnion148 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsMapArrayUnion148 instanceof Map) {
+                (encoder).writeIndex(1);
+                (encoder).writeMapStart();
+                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148).size());
+                    for (CharSequence key149 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148)).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key149);
+                        List<IndexedRecord> array150 = null;
+                        array150 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148)).get(key149);
+                        (encoder).writeArrayStart();
+                        if ((array150 == null)||array150 .isEmpty()) {
+                            (encoder).setItemCount(0);
+                        } else {
+                            (encoder).setItemCount(array150 .size());
+                            for (int counter151 = 0; (counter151 <((List<IndexedRecord> ) array150).size()); counter151 ++) {
+                                (encoder).startItem();
+                                IndexedRecord union152 = null;
+                                union152 = ((List<IndexedRecord> ) array150).get(counter151);
+                                if (union152 == null) {
+                                    (encoder).writeIndex(0);
+                                    (encoder).writeNull();
+                                } else {
+                                    if ((union152 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union152).getSchema().getFullName())) {
+                                        (encoder).writeIndex(1);
+                                        serializesubRecord136(((IndexedRecord) union152), (encoder));
+                                    }
+                                }
+                            }
+                        }
+                        (encoder).writeArrayEnd();
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord136(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField137 = ((CharSequence) data.get(0));
+        if (subField137 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField137 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField137 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField137));
+                } else {
+                    (encoder).writeString(subField137 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747
+    implements FastSerializer<IndexedRecord>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField153(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField153(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        IndexedRecord record154 = ((IndexedRecord) data.get(0));
+        if (record154 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((record154 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record154).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializesubRecord155(((IndexedRecord) record154), (encoder));
+            }
+        }
+        IndexedRecord record1157 = ((IndexedRecord) data.get(1));
+        serializesubRecord155(record1157, (encoder));
+        CharSequence field158 = ((CharSequence) data.get(2));
+        if (field158 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field158 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field158 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field158));
+                } else {
+                    (encoder).writeString(field158 .toString());
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord155(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField156 = ((CharSequence) data.get(0));
+        if (subField156 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField156 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField156 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField156));
+                } else {
+                    (encoder).writeString(subField156 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -1,0 +1,66 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_UNION_GenericSerializer_2087096002965517991
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key87 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key87);
+                IndexedRecord union88 = null;
+                union88 = ((Map<CharSequence, IndexedRecord> ) data).get(key87);
+                if (union88 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union88 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union88).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        serializerecord89(((IndexedRecord) union88), (encoder));
+                    }
+                }
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord89(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field90 = ((CharSequence) data.get(0));
+        if (field90 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field90 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field90 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field90));
+                } else {
+                    (encoder).writeString(field90 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -1,0 +1,58 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericSerializer_2141121767969292399
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+{
+
+    private Map<Long, Schema> enumSchemaMap = new ConcurrentHashMap<Long, Schema>();
+
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key83 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key83);
+                IndexedRecord record84 = null;
+                record84 = ((Map<CharSequence, IndexedRecord> ) data).get(key83);
+                serializerecord85(record84, (encoder));
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord85(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field86 = ((CharSequence) data.get(0));
+        if (field86 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field86 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field86 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field86));
+                } else {
+                    (encoder).writeString(field86 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_UNION_GenericSerializer_585074122056792963
+    implements FastSerializer<List<IndexedRecord>>
+{
+
+
+    public void serialize(List<IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter64 = 0; (counter64 <((List<IndexedRecord> ) data).size()); counter64 ++) {
+                (encoder).startItem();
+                IndexedRecord union65 = null;
+                union65 = ((List<IndexedRecord> ) data).get(counter64);
+                if (union65 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union65 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union65).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        serializerecord66(((IndexedRecord) union65), (encoder));
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord66(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field67 = ((CharSequence) data.get(0));
+        if (field67 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field67 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field67 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field67));
+                } else {
+                    (encoder).writeString(field67 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -1,0 +1,54 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_record_GenericSerializer_1629046702287533603
+    implements FastSerializer<List<IndexedRecord>>
+{
+
+
+    public void serialize(List<IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter60 = 0; (counter60 <((List<IndexedRecord> ) data).size()); counter60 ++) {
+                (encoder).startItem();
+                IndexedRecord record61 = null;
+                record61 = ((List<IndexedRecord> ) data).get(counter60);
+                serializerecord62(record61, (encoder));
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord62(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field63 = ((CharSequence) data.get(0));
+        if (field63 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field63 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field63 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field63));
+                } else {
+                    (encoder).writeString(field63 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
+        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion69 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
+        if (testEnumUnion69 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((testEnumUnion69 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).toString()));
+            }
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray70 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
+        (encoder).writeArrayStart();
+        if ((testEnumArray70 == null)||testEnumArray70 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testEnumArray70 .size());
+            for (int counter71 = 0; (counter71 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray70).size()); counter71 ++) {
+                (encoder).startItem();
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).toString()));
+            }
+        }
+        (encoder).writeArrayEnd();
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray72 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
+        (encoder).writeArrayStart();
+        if ((testEnumUnionArray72 == null)||testEnumUnionArray72 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testEnumUnionArray72 .size());
+            for (int counter73 = 0; (counter73 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).size()); counter73 ++) {
+                (encoder).startItem();
+                org.apache.avro.generic.GenericData.EnumSymbol union74 = null;
+                union74 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).get(counter73);
+                if (union74 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union74 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union74).toString()));
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) data.get(0)).bytes());
+        org.apache.avro.generic.GenericData.Fixed testFixedUnion76 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
+        if (testFixedUnion76 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((testFixedUnion76 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).bytes());
+            }
+        }
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray77 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
+        (encoder).writeArrayStart();
+        if ((testFixedArray77 == null)||testFixedArray77 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testFixedArray77 .size());
+            for (int counter78 = 0; (counter78 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray77).size()); counter78 ++) {
+                (encoder).startItem();
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray77 .get(counter78)).bytes());
+            }
+        }
+        (encoder).writeArrayEnd();
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray79 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
+        (encoder).writeArrayStart();
+        if ((testFixedUnionArray79 == null)||testFixedUnionArray79 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testFixedUnionArray79 .size());
+            for (int counter80 = 0; (counter80 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).size()); counter80 ++) {
+                (encoder).startItem();
+                org.apache.avro.generic.GenericData.Fixed union81 = null;
+                union81 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).get(counter80);
+                if (union81 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union81 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) union81).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union81).bytes());
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Object union99 = ((Object) data.get(0));
+        if (union99 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((union99 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union99).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializesubRecord100(((IndexedRecord) union99), (encoder));
+            } else {
+                if (union99 instanceof CharSequence) {
+                    (encoder).writeIndex(2);
+                    if (union99 instanceof Utf8) {
+                        (encoder).writeString(((Utf8) union99));
+                    } else {
+                        (encoder).writeString(union99 .toString());
+                    }
+                } else {
+                    if (union99 instanceof Integer) {
+                        (encoder).writeIndex(3);
+                        (encoder).writeInt(((Integer) union99));
+                    }
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord100(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField101 = ((CharSequence) data.get(0));
+        if (subField101 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField101 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField101 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField101));
+                } else {
+                    (encoder).writeString(subField101 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
@@ -1,0 +1,113 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeInt(((Integer) data.get(0)));
+        Integer testIntUnion103 = ((Integer) data.get(1));
+        if (testIntUnion103 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testIntUnion103 instanceof Integer) {
+                (encoder).writeIndex(1);
+                (encoder).writeInt(((Integer) testIntUnion103));
+            }
+        }
+        if (data.get(2) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(2)));
+        } else {
+            (encoder).writeString(data.get(2).toString());
+        }
+        CharSequence testStringUnion104 = ((CharSequence) data.get(3));
+        if (testStringUnion104 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testStringUnion104 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (testStringUnion104 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) testStringUnion104));
+                } else {
+                    (encoder).writeString(testStringUnion104 .toString());
+                }
+            }
+        }
+        (encoder).writeLong(((Long) data.get(4)));
+        Long testLongUnion105 = ((Long) data.get(5));
+        if (testLongUnion105 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testLongUnion105 instanceof Long) {
+                (encoder).writeIndex(1);
+                (encoder).writeLong(((Long) testLongUnion105));
+            }
+        }
+        (encoder).writeDouble(((Double) data.get(6)));
+        Double testDoubleUnion106 = ((Double) data.get(7));
+        if (testDoubleUnion106 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testDoubleUnion106 instanceof Double) {
+                (encoder).writeIndex(1);
+                (encoder).writeDouble(((Double) testDoubleUnion106));
+            }
+        }
+        (encoder).writeFloat(((Float) data.get(8)));
+        Float testFloatUnion107 = ((Float) data.get(9));
+        if (testFloatUnion107 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testFloatUnion107 instanceof Float) {
+                (encoder).writeIndex(1);
+                (encoder).writeFloat(((Float) testFloatUnion107));
+            }
+        }
+        (encoder).writeBoolean(((Boolean) data.get(10)));
+        Boolean testBooleanUnion108 = ((Boolean) data.get(11));
+        if (testBooleanUnion108 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testBooleanUnion108 instanceof Boolean) {
+                (encoder).writeIndex(1);
+                (encoder).writeBoolean(((Boolean) testBooleanUnion108));
+            }
+        }
+        (encoder).writeBytes(((ByteBuffer) data.get(12)));
+        ByteBuffer testBytesUnion109 = ((ByteBuffer) data.get(13));
+        if (testBytesUnion109 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testBytesUnion109 instanceof ByteBuffer) {
+                (encoder).writeIndex(1);
+                (encoder).writeBytes(((ByteBuffer) testBytesUnion109));
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
@@ -1,0 +1,64 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Object union_field111 = ((Object) data.get(0));
+        if (union_field111 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializerecord1112(((IndexedRecord) union_field111), (encoder));
+            } else {
+                if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+                    (encoder).writeIndex(2);
+                    serializerecord2113(((IndexedRecord) union_field111), (encoder));
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord1112(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        if (data.get(0) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(0)));
+        } else {
+            (encoder).writeString(data.get(0).toString());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord2113(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        if (data.get(0) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(0)));
+        } else {
+            (encoder).writeString(data.get(0).toString());
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
@@ -1,0 +1,139 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        List<IndexedRecord> recordsArray115 = ((List<IndexedRecord> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((recordsArray115 == null)||recordsArray115 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsArray115 .size());
+            for (int counter116 = 0; (counter116 <((List<IndexedRecord> ) recordsArray115).size()); counter116 ++) {
+                (encoder).startItem();
+                IndexedRecord subRecord117 = null;
+                subRecord117 = ((List<IndexedRecord> ) recordsArray115).get(counter116);
+                serializesubRecord118(subRecord117, (encoder));
+            }
+        }
+        (encoder).writeArrayEnd();
+        Map<CharSequence, IndexedRecord> recordsMap120 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        (encoder).writeMapStart();
+        if ((recordsMap120 == null)||recordsMap120 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsMap120 .size());
+            for (CharSequence key121 : ((Map<CharSequence, IndexedRecord> ) recordsMap120).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key121);
+                IndexedRecord subRecord122 = null;
+                subRecord122 = ((Map<CharSequence, IndexedRecord> ) recordsMap120).get(key121);
+                serializesubRecord118(subRecord122, (encoder));
+            }
+        }
+        (encoder).writeMapEnd();
+        List<IndexedRecord> recordsArrayUnion123 = ((List<IndexedRecord> ) data.get(2));
+        if (recordsArrayUnion123 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsArrayUnion123 instanceof List) {
+                (encoder).writeIndex(1);
+                (encoder).writeArrayStart();
+                if ((((List<IndexedRecord> ) recordsArrayUnion123) == null)||((List<IndexedRecord> ) recordsArrayUnion123).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion123).size());
+                    for (int counter124 = 0; (counter124 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).size()); counter124 ++) {
+                        (encoder).startItem();
+                        IndexedRecord union125 = null;
+                        union125 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).get(counter124);
+                        if (union125 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union125 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union125).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord118(((IndexedRecord) union125), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        Map<CharSequence, IndexedRecord> recordsMapUnion126 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
+        if (recordsMapUnion126 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsMapUnion126 instanceof Map) {
+                (encoder).writeIndex(1);
+                (encoder).writeMapStart();
+                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion126) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).size());
+                    for (CharSequence key127 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key127);
+                        IndexedRecord union128 = null;
+                        union128 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).get(key127);
+                        if (union128 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union128 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union128).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord118(((IndexedRecord) union128), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord118(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField119 = ((CharSequence) data.get(0));
+        if (subField119 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField119 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField119 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField119));
+                } else {
+                    (encoder).writeString(subField119 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
@@ -1,0 +1,205 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMap130 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((recordsArrayMap130 == null)||recordsArrayMap130 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsArrayMap130 .size());
+            for (int counter131 = 0; (counter131 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).size()); counter131 ++) {
+                (encoder).startItem();
+                Map<CharSequence, IndexedRecord> map132 = null;
+                map132 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).get(counter131);
+                (encoder).writeMapStart();
+                if ((map132 == null)||map132 .isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(map132 .size());
+                    for (CharSequence key133 : ((Map<CharSequence, IndexedRecord> ) map132).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key133);
+                        IndexedRecord union134 = null;
+                        union134 = ((Map<CharSequence, IndexedRecord> ) map132).get(key133);
+                        if (union134 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union134 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union134).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord135(((IndexedRecord) union134), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+        (encoder).writeArrayEnd();
+        Map<CharSequence, List<IndexedRecord>> recordsMapArray137 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        (encoder).writeMapStart();
+        if ((recordsMapArray137 == null)||recordsMapArray137 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsMapArray137 .size());
+            for (CharSequence key138 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key138);
+                List<IndexedRecord> array139 = null;
+                array139 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).get(key138);
+                (encoder).writeArrayStart();
+                if ((array139 == null)||array139 .isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(array139 .size());
+                    for (int counter140 = 0; (counter140 <((List<IndexedRecord> ) array139).size()); counter140 ++) {
+                        (encoder).startItem();
+                        IndexedRecord union141 = null;
+                        union141 = ((List<IndexedRecord> ) array139).get(counter140);
+                        if (union141 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union141 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union141).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord135(((IndexedRecord) union141), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        (encoder).writeMapEnd();
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion142 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
+        if (recordsArrayMapUnion142 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsArrayMapUnion142 instanceof List) {
+                (encoder).writeIndex(1);
+                (encoder).writeArrayStart();
+                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).size());
+                    for (int counter143 = 0; (counter143 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).size()); counter143 ++) {
+                        (encoder).startItem();
+                        Map<CharSequence, IndexedRecord> map144 = null;
+                        map144 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).get(counter143);
+                        (encoder).writeMapStart();
+                        if ((map144 == null)||map144 .isEmpty()) {
+                            (encoder).setItemCount(0);
+                        } else {
+                            (encoder).setItemCount(map144 .size());
+                            for (CharSequence key145 : ((Map<CharSequence, IndexedRecord> ) map144).keySet()) {
+                                (encoder).startItem();
+                                (encoder).writeString(key145);
+                                IndexedRecord union146 = null;
+                                union146 = ((Map<CharSequence, IndexedRecord> ) map144).get(key145);
+                                if (union146 == null) {
+                                    (encoder).writeIndex(0);
+                                    (encoder).writeNull();
+                                } else {
+                                    if ((union146 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union146).getSchema().getFullName())) {
+                                        (encoder).writeIndex(1);
+                                        serializesubRecord135(((IndexedRecord) union146), (encoder));
+                                    }
+                                }
+                            }
+                        }
+                        (encoder).writeMapEnd();
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion147 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
+        if (recordsMapArrayUnion147 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsMapArrayUnion147 instanceof Map) {
+                (encoder).writeIndex(1);
+                (encoder).writeMapStart();
+                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).size());
+                    for (CharSequence key148 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key148);
+                        List<IndexedRecord> array149 = null;
+                        array149 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).get(key148);
+                        (encoder).writeArrayStart();
+                        if ((array149 == null)||array149 .isEmpty()) {
+                            (encoder).setItemCount(0);
+                        } else {
+                            (encoder).setItemCount(array149 .size());
+                            for (int counter150 = 0; (counter150 <((List<IndexedRecord> ) array149).size()); counter150 ++) {
+                                (encoder).startItem();
+                                IndexedRecord union151 = null;
+                                union151 = ((List<IndexedRecord> ) array149).get(counter150);
+                                if (union151 == null) {
+                                    (encoder).writeIndex(0);
+                                    (encoder).writeNull();
+                                } else {
+                                    if ((union151 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union151).getSchema().getFullName())) {
+                                        (encoder).writeIndex(1);
+                                        serializesubRecord135(((IndexedRecord) union151), (encoder));
+                                    }
+                                }
+                            }
+                        }
+                        (encoder).writeArrayEnd();
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord135(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField136 = ((CharSequence) data.get(0));
+        if (subField136 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField136 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField136 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField136));
+                } else {
+                    (encoder).writeString(subField136 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
@@ -1,0 +1,73 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        IndexedRecord record153 = ((IndexedRecord) data.get(0));
+        if (record153 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((record153 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record153).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializesubRecord154(((IndexedRecord) record153), (encoder));
+            }
+        }
+        IndexedRecord record1156 = ((IndexedRecord) data.get(1));
+        serializesubRecord154(record1156, (encoder));
+        CharSequence field157 = ((CharSequence) data.get(2));
+        if (field157 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field157 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field157 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field157));
+                } else {
+                    (encoder).writeString(field157 .toString());
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord154(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField155 = ((CharSequence) data.get(0));
+        if (subField155 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField155 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField155 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField155));
+                } else {
+                    (encoder).writeString(subField155 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_UNION_GenericSerializer_2087096002965517991
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+{
+
+
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key86 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key86);
+                IndexedRecord union87 = null;
+                union87 = ((Map<CharSequence, IndexedRecord> ) data).get(key86);
+                if (union87 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union87 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union87).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        serializerecord88(((IndexedRecord) union87), (encoder));
+                    }
+                }
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord88(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field89 = ((CharSequence) data.get(0));
+        if (field89 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field89 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field89 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field89));
+                } else {
+                    (encoder).writeString(field89 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -1,0 +1,55 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericSerializer_2141121767969292399
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+{
+
+
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key82 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key82);
+                IndexedRecord record83 = null;
+                record83 = ((Map<CharSequence, IndexedRecord> ) data).get(key82);
+                serializerecord84(record83, (encoder));
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord84(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field85 = ((CharSequence) data.get(0));
+        if (field85 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field85 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field85 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field85));
+                } else {
+                    (encoder).writeString(field85 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_UNION_GenericSerializer_585074122056792963
+    implements FastSerializer<List<IndexedRecord>>
+{
+
+
+    public void serialize(List<IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter64 = 0; (counter64 <((List<IndexedRecord> ) data).size()); counter64 ++) {
+                (encoder).startItem();
+                IndexedRecord union65 = null;
+                union65 = ((List<IndexedRecord> ) data).get(counter64);
+                if (union65 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union65 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union65).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        serializerecord66(((IndexedRecord) union65), (encoder));
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord66(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field67 = ((CharSequence) data.get(0));
+        if (field67 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field67 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field67 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field67));
+                } else {
+                    (encoder).writeString(field67 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -1,0 +1,54 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_record_GenericSerializer_1629046702287533603
+    implements FastSerializer<List<IndexedRecord>>
+{
+
+
+    public void serialize(List<IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter60 = 0; (counter60 <((List<IndexedRecord> ) data).size()); counter60 ++) {
+                (encoder).startItem();
+                IndexedRecord record61 = null;
+                record61 = ((List<IndexedRecord> ) data).get(counter60);
+                serializerecord62(record61, (encoder));
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord62(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field63 = ((CharSequence) data.get(0));
+        if (field63 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field63 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field63 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field63));
+                } else {
+                    (encoder).writeString(field63 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
+        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion69 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
+        if (testEnumUnion69 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((testEnumUnion69 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).toString()));
+            }
+        }
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray70 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
+        (encoder).writeArrayStart();
+        if ((testEnumArray70 == null)||testEnumArray70 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testEnumArray70 .size());
+            for (int counter71 = 0; (counter71 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray70).size()); counter71 ++) {
+                (encoder).startItem();
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).toString()));
+            }
+        }
+        (encoder).writeArrayEnd();
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray72 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
+        (encoder).writeArrayStart();
+        if ((testEnumUnionArray72 == null)||testEnumUnionArray72 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testEnumUnionArray72 .size());
+            for (int counter73 = 0; (counter73 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).size()); counter73 ++) {
+                (encoder).startItem();
+                org.apache.avro.generic.GenericData.EnumSymbol union74 = null;
+                union74 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).get(counter73);
+                if (union74 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union74 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union74).toString()));
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) data.get(0)).bytes());
+        org.apache.avro.generic.GenericData.Fixed testFixedUnion76 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
+        if (testFixedUnion76 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((testFixedUnion76 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).bytes());
+            }
+        }
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray77 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
+        (encoder).writeArrayStart();
+        if ((testFixedArray77 == null)||testFixedArray77 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testFixedArray77 .size());
+            for (int counter78 = 0; (counter78 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray77).size()); counter78 ++) {
+                (encoder).startItem();
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray77 .get(counter78)).bytes());
+            }
+        }
+        (encoder).writeArrayEnd();
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray79 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
+        (encoder).writeArrayStart();
+        if ((testFixedUnionArray79 == null)||testFixedUnionArray79 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(testFixedUnionArray79 .size());
+            for (int counter80 = 0; (counter80 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).size()); counter80 ++) {
+                (encoder).startItem();
+                org.apache.avro.generic.GenericData.Fixed union81 = null;
+                union81 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).get(counter80);
+                if (union81 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union81 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) union81).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union81).bytes());
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Object union99 = ((Object) data.get(0));
+        if (union99 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((union99 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union99).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializesubRecord100(((IndexedRecord) union99), (encoder));
+            } else {
+                if (union99 instanceof CharSequence) {
+                    (encoder).writeIndex(2);
+                    if (union99 instanceof Utf8) {
+                        (encoder).writeString(((Utf8) union99));
+                    } else {
+                        (encoder).writeString(union99 .toString());
+                    }
+                } else {
+                    if (union99 instanceof Integer) {
+                        (encoder).writeIndex(3);
+                        (encoder).writeInt(((Integer) union99));
+                    }
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord100(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField101 = ((CharSequence) data.get(0));
+        if (subField101 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField101 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField101 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField101));
+                } else {
+                    (encoder).writeString(subField101 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
@@ -1,0 +1,113 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeInt(((Integer) data.get(0)));
+        Integer testIntUnion103 = ((Integer) data.get(1));
+        if (testIntUnion103 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testIntUnion103 instanceof Integer) {
+                (encoder).writeIndex(1);
+                (encoder).writeInt(((Integer) testIntUnion103));
+            }
+        }
+        if (data.get(2) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(2)));
+        } else {
+            (encoder).writeString(data.get(2).toString());
+        }
+        CharSequence testStringUnion104 = ((CharSequence) data.get(3));
+        if (testStringUnion104 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testStringUnion104 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (testStringUnion104 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) testStringUnion104));
+                } else {
+                    (encoder).writeString(testStringUnion104 .toString());
+                }
+            }
+        }
+        (encoder).writeLong(((Long) data.get(4)));
+        Long testLongUnion105 = ((Long) data.get(5));
+        if (testLongUnion105 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testLongUnion105 instanceof Long) {
+                (encoder).writeIndex(1);
+                (encoder).writeLong(((Long) testLongUnion105));
+            }
+        }
+        (encoder).writeDouble(((Double) data.get(6)));
+        Double testDoubleUnion106 = ((Double) data.get(7));
+        if (testDoubleUnion106 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testDoubleUnion106 instanceof Double) {
+                (encoder).writeIndex(1);
+                (encoder).writeDouble(((Double) testDoubleUnion106));
+            }
+        }
+        (encoder).writeFloat(((Float) data.get(8)));
+        Float testFloatUnion107 = ((Float) data.get(9));
+        if (testFloatUnion107 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testFloatUnion107 instanceof Float) {
+                (encoder).writeIndex(1);
+                (encoder).writeFloat(((Float) testFloatUnion107));
+            }
+        }
+        (encoder).writeBoolean(((Boolean) data.get(10)));
+        Boolean testBooleanUnion108 = ((Boolean) data.get(11));
+        if (testBooleanUnion108 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testBooleanUnion108 instanceof Boolean) {
+                (encoder).writeIndex(1);
+                (encoder).writeBoolean(((Boolean) testBooleanUnion108));
+            }
+        }
+        (encoder).writeBytes(((ByteBuffer) data.get(12)));
+        ByteBuffer testBytesUnion109 = ((ByteBuffer) data.get(13));
+        if (testBytesUnion109 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (testBytesUnion109 instanceof ByteBuffer) {
+                (encoder).writeIndex(1);
+                (encoder).writeBytes(((ByteBuffer) testBytesUnion109));
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
@@ -1,0 +1,64 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        Object union_field111 = ((Object) data.get(0));
+        if (union_field111 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializerecord1112(((IndexedRecord) union_field111), (encoder));
+            } else {
+                if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+                    (encoder).writeIndex(2);
+                    serializerecord2113(((IndexedRecord) union_field111), (encoder));
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord1112(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        if (data.get(0) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(0)));
+        } else {
+            (encoder).writeString(data.get(0).toString());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord2113(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        if (data.get(0) instanceof Utf8) {
+            (encoder).writeString(((Utf8) data.get(0)));
+        } else {
+            (encoder).writeString(data.get(0).toString());
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
@@ -1,0 +1,139 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        List<IndexedRecord> recordsArray115 = ((List<IndexedRecord> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((recordsArray115 == null)||recordsArray115 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsArray115 .size());
+            for (int counter116 = 0; (counter116 <((List<IndexedRecord> ) recordsArray115).size()); counter116 ++) {
+                (encoder).startItem();
+                IndexedRecord subRecord117 = null;
+                subRecord117 = ((List<IndexedRecord> ) recordsArray115).get(counter116);
+                serializesubRecord118(subRecord117, (encoder));
+            }
+        }
+        (encoder).writeArrayEnd();
+        Map<CharSequence, IndexedRecord> recordsMap120 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        (encoder).writeMapStart();
+        if ((recordsMap120 == null)||recordsMap120 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsMap120 .size());
+            for (CharSequence key121 : ((Map<CharSequence, IndexedRecord> ) recordsMap120).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key121);
+                IndexedRecord subRecord122 = null;
+                subRecord122 = ((Map<CharSequence, IndexedRecord> ) recordsMap120).get(key121);
+                serializesubRecord118(subRecord122, (encoder));
+            }
+        }
+        (encoder).writeMapEnd();
+        List<IndexedRecord> recordsArrayUnion123 = ((List<IndexedRecord> ) data.get(2));
+        if (recordsArrayUnion123 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsArrayUnion123 instanceof List) {
+                (encoder).writeIndex(1);
+                (encoder).writeArrayStart();
+                if ((((List<IndexedRecord> ) recordsArrayUnion123) == null)||((List<IndexedRecord> ) recordsArrayUnion123).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion123).size());
+                    for (int counter124 = 0; (counter124 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).size()); counter124 ++) {
+                        (encoder).startItem();
+                        IndexedRecord union125 = null;
+                        union125 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).get(counter124);
+                        if (union125 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union125 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union125).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord118(((IndexedRecord) union125), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        Map<CharSequence, IndexedRecord> recordsMapUnion126 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
+        if (recordsMapUnion126 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsMapUnion126 instanceof Map) {
+                (encoder).writeIndex(1);
+                (encoder).writeMapStart();
+                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion126) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).size());
+                    for (CharSequence key127 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key127);
+                        IndexedRecord union128 = null;
+                        union128 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).get(key127);
+                        if (union128 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union128 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union128).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord118(((IndexedRecord) union128), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord118(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField119 = ((CharSequence) data.get(0));
+        if (subField119 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField119 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField119 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField119));
+                } else {
+                    (encoder).writeString(subField119 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
@@ -1,0 +1,205 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMap130 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((recordsArrayMap130 == null)||recordsArrayMap130 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsArrayMap130 .size());
+            for (int counter131 = 0; (counter131 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).size()); counter131 ++) {
+                (encoder).startItem();
+                Map<CharSequence, IndexedRecord> map132 = null;
+                map132 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).get(counter131);
+                (encoder).writeMapStart();
+                if ((map132 == null)||map132 .isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(map132 .size());
+                    for (CharSequence key133 : ((Map<CharSequence, IndexedRecord> ) map132).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key133);
+                        IndexedRecord union134 = null;
+                        union134 = ((Map<CharSequence, IndexedRecord> ) map132).get(key133);
+                        if (union134 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union134 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union134).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord135(((IndexedRecord) union134), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+        (encoder).writeArrayEnd();
+        Map<CharSequence, List<IndexedRecord>> recordsMapArray137 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        (encoder).writeMapStart();
+        if ((recordsMapArray137 == null)||recordsMapArray137 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(recordsMapArray137 .size());
+            for (CharSequence key138 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key138);
+                List<IndexedRecord> array139 = null;
+                array139 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).get(key138);
+                (encoder).writeArrayStart();
+                if ((array139 == null)||array139 .isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(array139 .size());
+                    for (int counter140 = 0; (counter140 <((List<IndexedRecord> ) array139).size()); counter140 ++) {
+                        (encoder).startItem();
+                        IndexedRecord union141 = null;
+                        union141 = ((List<IndexedRecord> ) array139).get(counter140);
+                        if (union141 == null) {
+                            (encoder).writeIndex(0);
+                            (encoder).writeNull();
+                        } else {
+                            if ((union141 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union141).getSchema().getFullName())) {
+                                (encoder).writeIndex(1);
+                                serializesubRecord135(((IndexedRecord) union141), (encoder));
+                            }
+                        }
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        (encoder).writeMapEnd();
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion142 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
+        if (recordsArrayMapUnion142 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsArrayMapUnion142 instanceof List) {
+                (encoder).writeIndex(1);
+                (encoder).writeArrayStart();
+                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).size());
+                    for (int counter143 = 0; (counter143 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).size()); counter143 ++) {
+                        (encoder).startItem();
+                        Map<CharSequence, IndexedRecord> map144 = null;
+                        map144 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).get(counter143);
+                        (encoder).writeMapStart();
+                        if ((map144 == null)||map144 .isEmpty()) {
+                            (encoder).setItemCount(0);
+                        } else {
+                            (encoder).setItemCount(map144 .size());
+                            for (CharSequence key145 : ((Map<CharSequence, IndexedRecord> ) map144).keySet()) {
+                                (encoder).startItem();
+                                (encoder).writeString(key145);
+                                IndexedRecord union146 = null;
+                                union146 = ((Map<CharSequence, IndexedRecord> ) map144).get(key145);
+                                if (union146 == null) {
+                                    (encoder).writeIndex(0);
+                                    (encoder).writeNull();
+                                } else {
+                                    if ((union146 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union146).getSchema().getFullName())) {
+                                        (encoder).writeIndex(1);
+                                        serializesubRecord135(((IndexedRecord) union146), (encoder));
+                                    }
+                                }
+                            }
+                        }
+                        (encoder).writeMapEnd();
+                    }
+                }
+                (encoder).writeArrayEnd();
+            }
+        }
+        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion147 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
+        if (recordsMapArrayUnion147 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (recordsMapArrayUnion147 instanceof Map) {
+                (encoder).writeIndex(1);
+                (encoder).writeMapStart();
+                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).isEmpty()) {
+                    (encoder).setItemCount(0);
+                } else {
+                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).size());
+                    for (CharSequence key148 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).keySet()) {
+                        (encoder).startItem();
+                        (encoder).writeString(key148);
+                        List<IndexedRecord> array149 = null;
+                        array149 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).get(key148);
+                        (encoder).writeArrayStart();
+                        if ((array149 == null)||array149 .isEmpty()) {
+                            (encoder).setItemCount(0);
+                        } else {
+                            (encoder).setItemCount(array149 .size());
+                            for (int counter150 = 0; (counter150 <((List<IndexedRecord> ) array149).size()); counter150 ++) {
+                                (encoder).startItem();
+                                IndexedRecord union151 = null;
+                                union151 = ((List<IndexedRecord> ) array149).get(counter150);
+                                if (union151 == null) {
+                                    (encoder).writeIndex(0);
+                                    (encoder).writeNull();
+                                } else {
+                                    if ((union151 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union151).getSchema().getFullName())) {
+                                        (encoder).writeIndex(1);
+                                        serializesubRecord135(((IndexedRecord) union151), (encoder));
+                                    }
+                                }
+                            }
+                        }
+                        (encoder).writeArrayEnd();
+                    }
+                }
+                (encoder).writeMapEnd();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord135(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField136 = ((CharSequence) data.get(0));
+        if (subField136 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField136 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField136 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField136));
+                } else {
+                    (encoder).writeString(subField136 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
@@ -1,0 +1,73 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(data, (encoder));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        IndexedRecord record153 = ((IndexedRecord) data.get(0));
+        if (record153 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if ((record153 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record153).getSchema().getFullName())) {
+                (encoder).writeIndex(1);
+                serializesubRecord154(((IndexedRecord) record153), (encoder));
+            }
+        }
+        IndexedRecord record1156 = ((IndexedRecord) data.get(1));
+        serializesubRecord154(record1156, (encoder));
+        CharSequence field157 = ((CharSequence) data.get(2));
+        if (field157 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field157 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field157 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field157));
+                } else {
+                    (encoder).writeString(field157 .toString());
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializesubRecord154(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence subField155 = ((CharSequence) data.get(0));
+        if (subField155 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (subField155 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (subField155 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField155));
+                } else {
+                    (encoder).writeString(subField155 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_UNION_GenericSerializer_2087096002965517991
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+{
+
+
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key86 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key86);
+                IndexedRecord union87 = null;
+                union87 = ((Map<CharSequence, IndexedRecord> ) data).get(key86);
+                if (union87 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    if ((union87 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union87).getSchema().getFullName())) {
+                        (encoder).writeIndex(1);
+                        serializerecord88(((IndexedRecord) union87), (encoder));
+                    }
+                }
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord88(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field89 = ((CharSequence) data.get(0));
+        if (field89 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field89 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field89 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field89));
+                } else {
+                    (encoder).writeString(field89 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -1,0 +1,55 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericSerializer_2141121767969292399
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+{
+
+
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+        throws IOException
+    {
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key82 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key82);
+                IndexedRecord record83 = null;
+                record83 = ((Map<CharSequence, IndexedRecord> ) data).get(key82);
+                serializerecord84(record83, (encoder));
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializerecord84(IndexedRecord data, Encoder encoder)
+        throws IOException
+    {
+        CharSequence field85 = ((CharSequence) data.get(0));
+        if (field85 == null) {
+            (encoder).writeIndex(0);
+            (encoder).writeNull();
+        } else {
+            if (field85 instanceof CharSequence) {
+                (encoder).writeIndex(1);
+                if (field85 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field85));
+                } else {
+                    (encoder).writeString(field85 .toString());
+                }
+            }
+        }
+    }
+
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -1,6 +1,7 @@
 package com.linkedin.avro.fastserde;
 
 import com.google.common.collect.Lists;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
@@ -21,15 +22,15 @@ import static com.linkedin.avro.fastserde.Utils.*;
 
 
 public abstract class FastDeserializerGeneratorBase<T> {
-  public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.deserialization.generated";
+  public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.generated.deserialization."
+      + AvroCompatibilityHelper.getRuntimeAvroVersion().name();
   public static final String GENERATED_SOURCES_PATH = generateSourcePathFromPackageName(GENERATED_PACKAGE_NAME);
 
   private static final AtomicInteger UNIQUE_ID_BASE = new AtomicInteger(0);
 
-  protected static final Symbol EMPTY_SYMBOL = new Symbol(Symbol.Kind.TERMINAL, new Symbol[]{}) {
-  };
-  protected static final Symbol END_SYMBOL = new Symbol(Symbol.Kind.TERMINAL, new Symbol[]{}) {
-  };
+  protected static final Symbol EMPTY_SYMBOL = new Symbol(Symbol.Kind.TERMINAL, new Symbol[]{}) {};
+  protected static final Symbol END_SYMBOL = new Symbol(Symbol.Kind.TERMINAL, new Symbol[]{}) {};
+  protected static final String SEP = "_";
   private static final Logger LOGGER = Logger.getLogger(FastDeserializerGeneratorBase.class);
   protected final Schema writer;
   protected final Schema reader;
@@ -63,14 +64,8 @@ public abstract class FastDeserializerGeneratorBase<T> {
     Long writerSchemaId = Math.abs(Utils.getSchemaFingerprint(writerSchema));
     Long readerSchemaId = Math.abs(Utils.getSchemaFingerprint(readerSchema));
     Schema.Type readerSchemaType = readerSchema.getType();
-    if (Schema.Type.RECORD.equals(readerSchemaType)) {
-      return readerSchema.getName() + description + "Deserializer" + writerSchemaId + "_" + readerSchemaId;
-    } else if (Schema.Type.ARRAY.equals(readerSchemaType)) {
-      return "Array" + description + "Deserializer" + writerSchemaId + "_" + readerSchemaId;
-    } else if (Schema.Type.MAP.equals(readerSchemaType)) {
-      return "Map" + description + "Deserializer" + writerSchemaId + "_" + readerSchemaId;
-    }
-    throw new FastDeserializerGeneratorException("Unsupported return type: " + readerSchema.getType());
+    String typeName = SchemaAssistant.getTypeName(readerSchema);
+    return typeName + SEP + description + "Deserializer" + SEP + writerSchemaId + SEP + readerSchemaId;
   }
 
   protected static String getVariableName(String name) {

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
@@ -1,5 +1,6 @@
 package com.linkedin.avro.fastserde;
 
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JDefinedClass;
 import java.io.File;
@@ -20,10 +21,12 @@ import static com.linkedin.avro.fastserde.Utils.*;
  * @param <T> type of Datum to be operated on
  */
 public abstract class FastSerializerGeneratorBase<T> {
-  public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.serialization.generated";
+  public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.generated.serialization."
+      + AvroCompatibilityHelper.getRuntimeAvroVersion().name();
   public static final String GENERATED_SOURCES_PATH = generateSourcePathFromPackageName(GENERATED_PACKAGE_NAME);
 
   private static final AtomicInteger UNIQUE_ID_BASE = new AtomicInteger(0);
+  protected static final String SEP = "_";
 
   private static final Logger LOGGER = Logger.getLogger(FastSerializerGeneratorBase.class);
 
@@ -44,14 +47,8 @@ public abstract class FastSerializerGeneratorBase<T> {
 
   public static String getClassName(Schema schema, String description) {
     Long schemaId = Math.abs(Utils.getSchemaFingerprint(schema));
-    if (Schema.Type.RECORD.equals(schema.getType())) {
-      return schema.getName() + description + "Serializer" + "_" + schemaId;
-    } else if (Schema.Type.ARRAY.equals(schema.getType())) {
-      return "Array" + description + "Serializer" + "_" + schemaId;
-    } else if (Schema.Type.MAP.equals(schema.getType())) {
-      return "Map" + description + "Serializer" + "_" + schemaId;
-    }
-    throw new FastSerializerGeneratorException("Unsupported return type: " + schema.getType());
+    String typeName = SchemaAssistant.getTypeName(schema);
+    return typeName + SEP + description + "Serializer" + SEP + schemaId;
   }
 
   protected static String getVariableName(String name) {

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -116,6 +116,19 @@ public class SchemaAssistant {
     }
   }
 
+  public static String getTypeName (Schema schema) {
+    Schema.Type schemaType = schema.getType();
+    if (Schema.Type.RECORD.equals(schemaType)) {
+      return schema.getName();
+    } else if (Schema.Type.ARRAY.equals(schemaType)) {
+      return "Array_of_" + getTypeName(schema.getElementType());
+    } else if (Schema.Type.MAP.equals(schemaType)) {
+      return "Map_of_" + getTypeName(schema.getValueType());
+    } else {
+      return schema.getType().name();
+    }
+  }
+
   public void resetExceptionsFromStringable() {
     exceptionsFromStringable = new HashSet<>();
   }

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeCacheTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeCacheTest.java
@@ -37,14 +37,6 @@ public class FastSerdeCacheTest {
         FastDeserializerGeneratorBase.getClassName(schema, schema, "");
       } else {
         Assert.assertFalse(FastSerdeCache.isSupportedForFastDeserializer(type));
-        try {
-          FastDeserializerGeneratorBase.getClassName(schema, schema, "");
-          Assert.fail("FastDeserializerGeneratorException should be thrown since " + type + " is not supported");
-        } catch (FastDeserializerGeneratorException e) {
-          // expected since currently, this lib only supports RECORD, MAP and ARRAY for top-level schema.
-        } catch (Exception ee) {
-          Assert.fail("Only FastDeserializerGeneratorException should be thrown when " + type + " is not supported");
-        }
       }
     }
   }

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeTestsSupport.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeTestsSupport.java
@@ -1,7 +1,13 @@
 package com.linkedin.avro.fastserde;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,6 +32,26 @@ public final class FastSerdeTestsSupport {
           Arrays.asList("A", "B", "C", "D", "E"));
 
   private FastSerdeTestsSupport() {
+  }
+
+  /**
+   * Ths function will infer a standardized name for the generated record, to help make generated deserializers
+   * more easily recognizable...
+   *
+   * @param fields
+   * @return
+   */
+  public static Schema createRecord(Schema.Field... fields) {
+    // Function name retrieval magic lifted from: https://stackoverflow.com/a/4065546
+    StackTraceElement[] stacktrace = Thread.currentThread().getStackTrace();
+    StackTraceElement e = stacktrace[2]; //maybe this number needs to be corrected
+    String methodName = e.getMethodName();
+
+    String className = e.getClassName();
+    String simpleClassName = className.substring(className.lastIndexOf("."));
+
+    String recordName = simpleClassName + "_" + methodName;
+    return createRecord(recordName, fields);
   }
 
   public static Schema createRecord(String name, Schema.Field... fields) {
@@ -140,5 +166,16 @@ public final class FastSerdeTestsSupport {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  public static File getCodeGenDirectory() throws IOException {
+    Path codeGenOutput = Paths.get("./src/codegen/java/");
+    File dir;
+    if (Files.notExists(codeGenOutput)) {
+      dir = Files.createDirectories(codeGenOutput).toFile();
+    } else {
+      dir = codeGenOutput.toFile();
+    }
+    return dir;
   }
 }


### PR DESCRIPTION
The goal of this change is to have the output of the fast-avro code gen
under version control, so that it can be diffed easily during pull
requests, and so that historical changes are easier to track. Given the
complexity of analyzing  meta-code changes, the hope is that this will
allow a more streamlined and robust workflow.

In order to facilitate this, the main code is changed as such:

- The algorithm for naming the generated classes has been tweaked, so
  that it's more easily recognizable. In particular, collection types
  now specify the type of their element in the class name, e.g.
  - Array_of_record
  - Array_of_LONG
  - Map_of_UNION
- The package name for generated classes is also tweaked, such that it
  includes the Avro version in it, e.g.
  - com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4
  - com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8

Furthermore, the build and tests are more significantly altered:

- A new src directory called codegen is created. It is confgured as a
  source set in the build with proper dependencies, in order to make
  the generated code easy to navigate in the IDE.
- FastGenericDeserializerGeneratorTest and FGSerializerGeneratorTest
  are modified as such:
  - Instead of using a temporary directory for generated serde classes,
    they now write to the new codegen directory.
  - The names of all top level record schemas is changed to include the
    class and function name, in order to facilitate the identification
    of which serde class maps to which test. This is figured out
    automatically via a new utility function in FastSerdeTestsSupport.
- FastGenericDeserializerGeneratorTest now includes 4 new primitive
  array tests which were previously untested: boolean, double, int and
  long.
- The avro-fastserde build now deletes the content of the codegen
  directory before running, to ensure that if test schemas change,
  older serde classes that aren't used anymore will get purged. At the
  end of the build, .class files are also deleted.