### PR TITLE
Made fast serde generation deterministic

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -21,33 +21,33 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
     public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
         throws IOException
     {
-        List<Boolean> array738 = null;
-        long chunkLen739 = (decoder.readArrayStart());
-        if (chunkLen739 > 0) {
-            List<Boolean> arrayReuse740 = null;
+        List<Boolean> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Boolean> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse740 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse740 != (null)) {
-                arrayReuse740 .clear();
-                array738 = arrayReuse740;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array738 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen739), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter741 = 0; (counter741 <chunkLen739); counter741 ++) {
-                    Object arrayArrayElementReuseVar742 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar742 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array738 .add((decoder.readBoolean()));
+                    array0 .add((decoder.readBoolean()));
                 }
-                chunkLen739 = (decoder.arrayNext());
-            } while (chunkLen739 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array738 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
         }
-        return array738;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -21,33 +21,33 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
     public List<Double> deserialize(List<Double> reuse, Decoder decoder)
         throws IOException
     {
-        List<Double> array743 = null;
-        long chunkLen744 = (decoder.readArrayStart());
-        if (chunkLen744 > 0) {
-            List<Double> arrayReuse745 = null;
+        List<Double> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Double> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse745 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse745 != (null)) {
-                arrayReuse745 .clear();
-                array743 = arrayReuse745;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array743 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen744), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter746 = 0; (counter746 <chunkLen744); counter746 ++) {
-                    Object arrayArrayElementReuseVar747 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar747 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array743 .add((decoder.readDouble()));
+                    array0 .add((decoder.readDouble()));
                 }
-                chunkLen744 = (decoder.arrayNext());
-            } while (chunkLen744 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array743 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
         }
-        return array743;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -21,9 +21,9 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
     public List<Float> deserialize(List<Float> reuse, Decoder decoder)
         throws IOException
     {
-        List<Float> array748 = null;
-        array748 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
-        return array748;
+        List<Float> array0 = null;
+        array0 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -21,33 +21,33 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
     public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
         throws IOException
     {
-        List<Integer> array749 = null;
-        long chunkLen750 = (decoder.readArrayStart());
-        if (chunkLen750 > 0) {
-            List<Integer> arrayReuse751 = null;
+        List<Integer> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Integer> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse751 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse751 != (null)) {
-                arrayReuse751 .clear();
-                array749 = arrayReuse751;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array749 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen750), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter752 = 0; (counter752 <chunkLen750); counter752 ++) {
-                    Object arrayArrayElementReuseVar753 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar753 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array749 .add((decoder.readInt()));
+                    array0 .add((decoder.readInt()));
                 }
-                chunkLen750 = (decoder.arrayNext());
-            } while (chunkLen750 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array749 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
         }
-        return array749;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -21,33 +21,33 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
     public List<Long> deserialize(List<Long> reuse, Decoder decoder)
         throws IOException
     {
-        List<Long> array754 = null;
-        long chunkLen755 = (decoder.readArrayStart());
-        if (chunkLen755 > 0) {
-            List<Long> arrayReuse756 = null;
+        List<Long> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Long> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse756 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse756 != (null)) {
-                arrayReuse756 .clear();
-                array754 = arrayReuse756;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array754 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen755), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter757 = 0; (counter757 <chunkLen755); counter757 ++) {
-                    Object arrayArrayElementReuseVar758 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar758 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array754 .add((decoder.readLong()));
+                    array0 .add((decoder.readLong()));
                 }
-                chunkLen755 = (decoder.arrayNext());
-            } while (chunkLen755 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array754 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
         }
-        return array754;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -15,69 +15,69 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
 {
 
     private final Schema readerSchema;
-    private final Schema arrayArrayElemSchema772;
-    private final Schema arrayElemOptionSchema775;
-    private final Schema field777;
+    private final Schema arrayArrayElemSchema0;
+    private final Schema arrayElemOptionSchema0;
+    private final Schema field0;
 
     public Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.arrayArrayElemSchema772 = readerSchema.getElementType();
-        this.arrayElemOptionSchema775 = arrayArrayElemSchema772 .getTypes().get(1);
-        this.field777 = arrayElemOptionSchema775 .getField("field").schema();
+        this.arrayArrayElemSchema0 = readerSchema.getElementType();
+        this.arrayElemOptionSchema0 = arrayArrayElemSchema0 .getTypes().get(1);
+        this.field0 = arrayElemOptionSchema0 .getField("field").schema();
     }
 
     public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        List<IndexedRecord> array768 = null;
-        long chunkLen769 = (decoder.readArrayStart());
-        if (chunkLen769 > 0) {
-            List<IndexedRecord> arrayReuse770 = null;
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse770 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse770 != (null)) {
-                arrayReuse770 .clear();
-                array768 = arrayReuse770;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array768 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen769), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter771 = 0; (counter771 <chunkLen769); counter771 ++) {
-                    Object arrayArrayElementReuseVar773 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar773 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    int unionIndex774 = (decoder.readIndex());
-                    if (unionIndex774 == 0) {
+                    int unionIndex0 = (decoder.readIndex());
+                    if (unionIndex0 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex774 == 1) {
-                        array768 .add(deserializerecord776(arrayArrayElementReuseVar773, (decoder)));
+                    if (unionIndex0 == 1) {
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                     }
                 }
-                chunkLen769 = (decoder.arrayNext());
-            } while (chunkLen769 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array768 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
         }
-        return array768;
+        return array0;
     }
 
-    public IndexedRecord deserializerecord776(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema775)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema775);
+            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema0);
         }
-        int unionIndex778 = (decoder.readIndex());
-        if (unionIndex778 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex778 == 1) {
+        if (unionIndex1 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -15,61 +15,61 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
 {
 
     private final Schema readerSchema;
-    private final Schema arrayArrayElemSchema763;
-    private final Schema field766;
+    private final Schema arrayArrayElemSchema0;
+    private final Schema field0;
 
     public Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.arrayArrayElemSchema763 = readerSchema.getElementType();
-        this.field766 = arrayArrayElemSchema763 .getField("field").schema();
+        this.arrayArrayElemSchema0 = readerSchema.getElementType();
+        this.field0 = arrayArrayElemSchema0 .getField("field").schema();
     }
 
     public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        List<IndexedRecord> array759 = null;
-        long chunkLen760 = (decoder.readArrayStart());
-        if (chunkLen760 > 0) {
-            List<IndexedRecord> arrayReuse761 = null;
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse761 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse761 != (null)) {
-                arrayReuse761 .clear();
-                array759 = arrayReuse761;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array759 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen760), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter762 = 0; (counter762 <chunkLen760); counter762 ++) {
-                    Object arrayArrayElementReuseVar764 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar764 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array759 .add(deserializerecord765(arrayArrayElementReuseVar764, (decoder)));
+                    array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen760 = (decoder.arrayNext());
-            } while (chunkLen760 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array759 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
         }
-        return array759;
+        return array0;
     }
 
-    public IndexedRecord deserializerecord765(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema763)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema763);
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
         }
-        int unionIndex767 = (decoder.readIndex());
-        if (unionIndex767 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex767 == 1) {
+        if (unionIndex0 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782.java
@@ -14,28 +14,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
 {
 
     private final Schema readerSchema;
-    private final Schema testEnum780;
-    private final Schema testEnumUnion781;
-    private final Schema testEnumArray783;
-    private final Schema testEnumUnionArray789;
-    private final Schema testEnumUnionArrayArrayElemSchema794;
+    private final Schema testEnum0;
+    private final Schema testEnumUnion0;
+    private final Schema testEnumArray0;
+    private final Schema testEnumUnionArray0;
+    private final Schema testEnumUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testEnum780 = readerSchema.getField("testEnum").schema();
-        this.testEnumUnion781 = readerSchema.getField("testEnumUnion").schema();
-        this.testEnumArray783 = readerSchema.getField("testEnumArray").schema();
-        this.testEnumUnionArray789 = readerSchema.getField("testEnumUnionArray").schema();
-        this.testEnumUnionArrayArrayElemSchema794 = testEnumUnionArray789 .getElementType();
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion0 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray0 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray0 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum779((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum779(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
@@ -44,74 +44,74 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
-        int unionIndex782 = (decoder.readIndex());
-        if (unionIndex782 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex782 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray784 = null;
-        long chunkLen785 = (decoder.readArrayStart());
-        if (chunkLen785 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse786 = null;
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
-                testEnumArrayReuse786 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+                testEnumArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
             }
-            if (testEnumArrayReuse786 != (null)) {
-                testEnumArrayReuse786 .clear();
-                testEnumArray784 = testEnumArrayReuse786;
+            if (testEnumArrayReuse0 != (null)) {
+                testEnumArrayReuse0 .clear();
+                testEnumArray1 = testEnumArrayReuse0;
             } else {
-                testEnumArray784 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen785), testEnumArray783);
+                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
             }
             do {
-                for (int counter787 = 0; (counter787 <chunkLen785); counter787 ++) {
-                    Object testEnumArrayArrayElementReuseVar788 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testEnumArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof GenericArray) {
-                        testEnumArrayArrayElementReuseVar788 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
+                        testEnumArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
                     }
-                    testEnumArray784 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+                    testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                 }
-                chunkLen785 = (decoder.arrayNext());
-            } while (chunkLen785 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testEnumArray784 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray783);
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray784);
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray790 = null;
-        long chunkLen791 = (decoder.readArrayStart());
-        if (chunkLen791 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse792 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
-                testEnumUnionArrayReuse792 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+                testEnumUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
             }
-            if (testEnumUnionArrayReuse792 != (null)) {
-                testEnumUnionArrayReuse792 .clear();
-                testEnumUnionArray790 = testEnumUnionArrayReuse792;
+            if (testEnumUnionArrayReuse0 != (null)) {
+                testEnumUnionArrayReuse0 .clear();
+                testEnumUnionArray1 = testEnumUnionArrayReuse0;
             } else {
-                testEnumUnionArray790 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen791), testEnumUnionArray789);
+                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
             }
             do {
-                for (int counter793 = 0; (counter793 <chunkLen791); counter793 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar795 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar795 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
                     }
-                    int unionIndex796 = (decoder.readIndex());
-                    if (unionIndex796 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex796 == 1) {
-                        testEnumUnionArray790 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum780 .getEnumSymbols().get((decoder.readEnum()))));
+                    if (unionIndex1 == 1) {
+                        testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                     }
                 }
-                chunkLen791 = (decoder.arrayNext());
-            } while (chunkLen791 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testEnumUnionArray790 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray789);
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray790);
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292.java
@@ -15,26 +15,26 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
 {
 
     private final Schema readerSchema;
-    private final Schema testFixedUnion799;
-    private final Schema testFixedArray802;
-    private final Schema testFixedUnionArray809;
-    private final Schema testFixedUnionArrayArrayElemSchema814;
+    private final Schema testFixedUnion0;
+    private final Schema testFixedArray0;
+    private final Schema testFixedUnionArray0;
+    private final Schema testFixedUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testFixedUnion799 = readerSchema.getField("testFixedUnion").schema();
-        this.testFixedArray802 = readerSchema.getField("testFixedArray").schema();
-        this.testFixedUnionArray809 = readerSchema.getField("testFixedUnionArray").schema();
-        this.testFixedUnionArrayArrayElemSchema814 = testFixedUnionArray809 .getElementType();
+        this.testFixedUnion0 = readerSchema.getField("testFixedUnion").schema();
+        this.testFixedArray0 = readerSchema.getField("testFixedArray").schema();
+        this.testFixedUnionArray0 = readerSchema.getField("testFixedUnionArray").schema();
+        this.testFixedUnionArrayArrayElemSchema0 = testFixedUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed797((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed797(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
@@ -43,102 +43,102 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadFixed = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        byte[] testFixed798;
+        byte[] testFixed0;
         if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes().length == (2))) {
-            testFixed798 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
+            testFixed0 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
         } else {
-            testFixed798 = ( new byte[2]);
+            testFixed0 = ( new byte[2]);
         }
-        decoder.readFixed(testFixed798);
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(testFixed798));
-        int unionIndex800 = (decoder.readIndex());
-        if (unionIndex800 == 0) {
+        decoder.readFixed(testFixed0);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(testFixed0));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex800 == 1) {
-            byte[] testFixed801;
+        if (unionIndex0 == 1) {
+            byte[] testFixed1;
             if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes().length == (2))) {
-                testFixed801 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
+                testFixed1 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
             } else {
-                testFixed801 = ( new byte[2]);
+                testFixed1 = ( new byte[2]);
             }
-            decoder.readFixed(testFixed801);
-            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(testFixed801));
+            decoder.readFixed(testFixed1);
+            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(testFixed1));
         }
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray803 = null;
-        long chunkLen804 = (decoder.readArrayStart());
-        if (chunkLen804 > 0) {
-            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse805 = null;
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
-                testFixedArrayReuse805 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+                testFixedArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
             }
-            if (testFixedArrayReuse805 != (null)) {
-                testFixedArrayReuse805 .clear();
-                testFixedArray803 = testFixedArrayReuse805;
+            if (testFixedArrayReuse0 != (null)) {
+                testFixedArrayReuse0 .clear();
+                testFixedArray1 = testFixedArrayReuse0;
             } else {
-                testFixedArray803 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen804), testFixedArray802);
+                testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
             }
             do {
-                for (int counter806 = 0; (counter806 <chunkLen804); counter806 ++) {
-                    Object testFixedArrayArrayElementReuseVar807 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testFixedArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
-                        testFixedArrayArrayElementReuseVar807 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                        testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
                     }
-                    byte[] testFixed808;
-                    if ((testFixedArrayArrayElementReuseVar807 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar807).bytes().length == (2))) {
-                        testFixed808 = ((GenericFixed) testFixedArrayArrayElementReuseVar807).bytes();
+                    byte[] testFixed2;
+                    if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
+                        testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
                     } else {
-                        testFixed808 = ( new byte[2]);
+                        testFixed2 = ( new byte[2]);
                     }
-                    decoder.readFixed(testFixed808);
-                    testFixedArray803 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed808));
+                    decoder.readFixed(testFixed2);
+                    testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed2));
                 }
-                chunkLen804 = (decoder.arrayNext());
-            } while (chunkLen804 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testFixedArray803 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray802);
+            testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray803);
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray810 = null;
-        long chunkLen811 = (decoder.readArrayStart());
-        if (chunkLen811 > 0) {
-            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse812 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
-                testFixedUnionArrayReuse812 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+                testFixedUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
             }
-            if (testFixedUnionArrayReuse812 != (null)) {
-                testFixedUnionArrayReuse812 .clear();
-                testFixedUnionArray810 = testFixedUnionArrayReuse812;
+            if (testFixedUnionArrayReuse0 != (null)) {
+                testFixedUnionArrayReuse0 .clear();
+                testFixedUnionArray1 = testFixedUnionArrayReuse0;
             } else {
-                testFixedUnionArray810 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen811), testFixedUnionArray809);
+                testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
             }
             do {
-                for (int counter813 = 0; (counter813 <chunkLen811); counter813 ++) {
-                    Object testFixedUnionArrayArrayElementReuseVar815 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testFixedUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
-                        testFixedUnionArrayArrayElementReuseVar815 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                        testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
                     }
-                    int unionIndex816 = (decoder.readIndex());
-                    if (unionIndex816 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex816 == 1) {
-                        byte[] testFixed817;
-                        if ((testFixedUnionArrayArrayElementReuseVar815 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar815).bytes().length == (2))) {
-                            testFixed817 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar815).bytes();
+                    if (unionIndex1 == 1) {
+                        byte[] testFixed3;
+                        if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
+                            testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
                         } else {
-                            testFixed817 = ( new byte[2]);
+                            testFixed3 = ( new byte[2]);
                         }
-                        decoder.readFixed(testFixed817);
-                        testFixedUnionArray810 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed817));
+                        decoder.readFixed(testFixed3);
+                        testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed3));
                     }
                 }
-                chunkLen811 = (decoder.arrayNext());
-            } while (chunkLen811 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testFixedUnionArray810 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray809);
+            testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray810);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819.java
@@ -13,24 +13,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
 {
 
     private final Schema readerSchema;
-    private final Schema union875;
-    private final Schema unionOptionSchema877;
-    private final Schema subField879;
+    private final Schema union0;
+    private final Schema unionOptionSchema0;
+    private final Schema subField0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_4313387729290221819_4313387729290221819(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.union875 = readerSchema.getField("union").schema();
-        this.unionOptionSchema877 = union875 .getTypes().get(1);
-        this.subField879 = unionOptionSchema877 .getField("subField").schema();
+        this.union0 = readerSchema.getField("union").schema();
+        this.unionOptionSchema0 = union0 .getTypes().get(1);
+        this.subField0 = unionOptionSchema0 .getField("subField").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion874((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion874(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
@@ -39,21 +39,21 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex876 = (decoder.readIndex());
-        if (unionIndex876 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex876 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord878(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
         } else {
-            if (unionIndex876 == 2) {
+            if (unionIndex0 == 2) {
                 if (FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0) instanceof Utf8) {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0))));
                 } else {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(null));
                 }
             } else {
-                if (unionIndex876 == 3) {
+                if (unionIndex0 == 3) {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
                 }
             }
@@ -61,20 +61,20 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
     }
 
-    public IndexedRecord deserializesubRecord878(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema877)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema877);
+            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema0);
         }
-        int unionIndex880 = (decoder.readIndex());
-        if (unionIndex880 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex880 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
@@ -18,24 +18,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
 {
 
     private final Schema readerSchema;
-    private final Schema mapField882;
-    private final Schema mapFieldMapValueSchema888;
-    private final Schema mapFieldValueMapValueSchema894;
+    private final Schema mapField0;
+    private final Schema mapFieldMapValueSchema0;
+    private final Schema mapFieldValueMapValueSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapField882 = readerSchema.getField("mapField").schema();
-        this.mapFieldMapValueSchema888 = mapField882 .getValueType();
-        this.mapFieldValueMapValueSchema894 = mapFieldMapValueSchema888 .getValueType();
+        this.mapField0 = readerSchema.getField("mapField").schema();
+        this.mapFieldMapValueSchema0 = mapField0 .getValueType();
+        this.mapFieldValueMapValueSchema0 = mapFieldMapValueSchema0 .getValueType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap881((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap881(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
@@ -44,79 +44,79 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadNestedMap = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        Map<Utf8, Map<Utf8, List<Integer>>> mapField883 = null;
-        long chunkLen884 = (decoder.readMapStart());
-        if (chunkLen884 > 0) {
-            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse885 = null;
+        Map<Utf8, Map<Utf8, List<Integer>>> mapField1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0) instanceof Map) {
-                mapFieldReuse885 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
+                mapFieldReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
             }
-            if (mapFieldReuse885 != (null)) {
-                mapFieldReuse885 .clear();
-                mapField883 = mapFieldReuse885;
+            if (mapFieldReuse0 != (null)) {
+                mapFieldReuse0 .clear();
+                mapField1 = mapFieldReuse0;
             } else {
-                mapField883 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
+                mapField1 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
             }
             do {
-                for (int counter886 = 0; (counter886 <chunkLen884); counter886 ++) {
-                    Utf8 key887 = (decoder.readString(null));
-                    Map<Utf8, List<Integer>> mapFieldValue889 = null;
-                    long chunkLen890 = (decoder.readMapStart());
-                    if (chunkLen890 > 0) {
-                        Map<Utf8, List<Integer>> mapFieldValueReuse891 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    Map<Utf8, List<Integer>> mapFieldValue0 = null;
+                    long chunkLen1 = (decoder.readMapStart());
+                    if (chunkLen1 > 0) {
+                        Map<Utf8, List<Integer>> mapFieldValueReuse0 = null;
                         if (null instanceof Map) {
-                            mapFieldValueReuse891 = ((Map) null);
+                            mapFieldValueReuse0 = ((Map) null);
                         }
-                        if (mapFieldValueReuse891 != (null)) {
-                            mapFieldValueReuse891 .clear();
-                            mapFieldValue889 = mapFieldValueReuse891;
+                        if (mapFieldValueReuse0 != (null)) {
+                            mapFieldValueReuse0 .clear();
+                            mapFieldValue0 = mapFieldValueReuse0;
                         } else {
-                            mapFieldValue889 = new HashMap<Utf8, List<Integer>>();
+                            mapFieldValue0 = new HashMap<Utf8, List<Integer>>();
                         }
                         do {
-                            for (int counter892 = 0; (counter892 <chunkLen890); counter892 ++) {
-                                Utf8 key893 = (decoder.readString(null));
-                                List<Integer> mapFieldValueValue895 = null;
-                                long chunkLen896 = (decoder.readArrayStart());
-                                if (chunkLen896 > 0) {
-                                    List<Integer> mapFieldValueValueReuse897 = null;
+                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                                Utf8 key1 = (decoder.readString(null));
+                                List<Integer> mapFieldValueValue0 = null;
+                                long chunkLen2 = (decoder.readArrayStart());
+                                if (chunkLen2 > 0) {
+                                    List<Integer> mapFieldValueValueReuse0 = null;
                                     if (null instanceof List) {
-                                        mapFieldValueValueReuse897 = ((List) null);
+                                        mapFieldValueValueReuse0 = ((List) null);
                                     }
-                                    if (mapFieldValueValueReuse897 != (null)) {
-                                        mapFieldValueValueReuse897 .clear();
-                                        mapFieldValueValue895 = mapFieldValueValueReuse897;
+                                    if (mapFieldValueValueReuse0 != (null)) {
+                                        mapFieldValueValueReuse0 .clear();
+                                        mapFieldValueValue0 = mapFieldValueValueReuse0;
                                     } else {
-                                        mapFieldValueValue895 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen896), mapFieldValueMapValueSchema894);
+                                        mapFieldValueValue0 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen2), mapFieldValueMapValueSchema0);
                                     }
                                     do {
-                                        for (int counter898 = 0; (counter898 <chunkLen896); counter898 ++) {
-                                            Object mapFieldValueValueArrayElementReuseVar899 = null;
+                                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                                            Object mapFieldValueValueArrayElementReuseVar0 = null;
                                             if (null instanceof GenericArray) {
-                                                mapFieldValueValueArrayElementReuseVar899 = ((GenericArray) null).peek();
+                                                mapFieldValueValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                             }
-                                            mapFieldValueValue895 .add((decoder.readInt()));
+                                            mapFieldValueValue0 .add((decoder.readInt()));
                                         }
-                                        chunkLen896 = (decoder.arrayNext());
-                                    } while (chunkLen896 > 0);
+                                        chunkLen2 = (decoder.arrayNext());
+                                    } while (chunkLen2 > 0);
                                 } else {
-                                    mapFieldValueValue895 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema894);
+                                    mapFieldValueValue0 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema0);
                                 }
-                                mapFieldValue889 .put(key893, mapFieldValueValue895);
+                                mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }
-                            chunkLen890 = (decoder.mapNext());
-                        } while (chunkLen890 > 0);
+                            chunkLen1 = (decoder.mapNext());
+                        } while (chunkLen1 > 0);
                     } else {
-                        mapFieldValue889 = Collections.emptyMap();
+                        mapFieldValue0 = Collections.emptyMap();
                     }
-                    mapField883 .put(key887, mapFieldValue889);
+                    mapField1 .put(key0, mapFieldValue0);
                 }
-                chunkLen884 = (decoder.mapNext());
-            } while (chunkLen884 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            mapField883 = Collections.emptyMap();
+            mapField1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField883);
+        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField1);
         return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
@@ -14,28 +14,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
 {
 
     private final Schema readerSchema;
-    private final Schema testEnum901;
-    private final Schema testEnumUnion904;
-    private final Schema testEnumArray908;
-    private final Schema testEnumUnionArray916;
-    private final Schema testEnumUnionArrayArrayElemSchema921;
+    private final Schema testEnum0;
+    private final Schema testEnumUnion0;
+    private final Schema testEnumArray0;
+    private final Schema testEnumUnionArray0;
+    private final Schema testEnumUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testEnum901 = readerSchema.getField("testEnum").schema();
-        this.testEnumUnion904 = readerSchema.getField("testEnumUnion").schema();
-        this.testEnumArray908 = readerSchema.getField("testEnumArray").schema();
-        this.testEnumUnionArray916 = readerSchema.getField("testEnumUnionArray").schema();
-        this.testEnumUnionArrayArrayElemSchema921 = testEnumUnionArray916 .getElementType();
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion0 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray0 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray0 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum900((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum900(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
@@ -44,142 +44,142 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int enumIndex902 = (decoder.readEnum());
-        org.apache.avro.generic.GenericData.EnumSymbol enumValue903 = null;
-        if (enumIndex902 == 0) {
-            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        if (enumIndex0 == 0) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
         }
-        if (enumIndex902 == 1) {
-            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+        if (enumIndex0 == 1) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
         }
-        if (enumIndex902 == 2) {
-            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+        if (enumIndex0 == 2) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
         }
-        if (enumIndex902 == 3) {
-            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+        if (enumIndex0 == 3) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
         }
-        if (enumIndex902 == 4) {
-            enumValue903 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+        if (enumIndex0 == 4) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue903);
-        int unionIndex905 = (decoder.readIndex());
-        if (unionIndex905 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex905 == 1) {
-            int enumIndex906 = (decoder.readEnum());
-            org.apache.avro.generic.GenericData.EnumSymbol enumValue907 = null;
-            if (enumIndex906 == 0) {
-                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+        if (unionIndex0 == 1) {
+            int enumIndex1 = (decoder.readEnum());
+            org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
+            if (enumIndex1 == 0) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
             }
-            if (enumIndex906 == 1) {
-                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+            if (enumIndex1 == 1) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
             }
-            if (enumIndex906 == 2) {
-                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+            if (enumIndex1 == 2) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
             }
-            if (enumIndex906 == 3) {
-                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+            if (enumIndex1 == 3) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
             }
-            if (enumIndex906 == 4) {
-                enumValue907 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+            if (enumIndex1 == 4) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
             }
-            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue907);
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray909 = null;
-        long chunkLen910 = (decoder.readArrayStart());
-        if (chunkLen910 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse911 = null;
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
-                testEnumArrayReuse911 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+                testEnumArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
             }
-            if (testEnumArrayReuse911 != (null)) {
-                testEnumArrayReuse911 .clear();
-                testEnumArray909 = testEnumArrayReuse911;
+            if (testEnumArrayReuse0 != (null)) {
+                testEnumArrayReuse0 .clear();
+                testEnumArray1 = testEnumArrayReuse0;
             } else {
-                testEnumArray909 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen910), testEnumArray908);
+                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
             }
             do {
-                for (int counter912 = 0; (counter912 <chunkLen910); counter912 ++) {
-                    Object testEnumArrayArrayElementReuseVar913 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testEnumArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof GenericArray) {
-                        testEnumArrayArrayElementReuseVar913 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
+                        testEnumArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
                     }
-                    int enumIndex914 = (decoder.readEnum());
-                    org.apache.avro.generic.GenericData.EnumSymbol enumValue915 = null;
-                    if (enumIndex914 == 0) {
-                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+                    int enumIndex2 = (decoder.readEnum());
+                    org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
+                    if (enumIndex2 == 0) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
                     }
-                    if (enumIndex914 == 1) {
-                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+                    if (enumIndex2 == 1) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
                     }
-                    if (enumIndex914 == 2) {
-                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+                    if (enumIndex2 == 2) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
                     }
-                    if (enumIndex914 == 3) {
-                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+                    if (enumIndex2 == 3) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
                     }
-                    if (enumIndex914 == 4) {
-                        enumValue915 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+                    if (enumIndex2 == 4) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
                     }
-                    testEnumArray909 .add(enumValue915);
+                    testEnumArray1 .add(enumValue2);
                 }
-                chunkLen910 = (decoder.arrayNext());
-            } while (chunkLen910 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testEnumArray909 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray908);
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray909);
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray917 = null;
-        long chunkLen918 = (decoder.readArrayStart());
-        if (chunkLen918 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse919 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
-                testEnumUnionArrayReuse919 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+                testEnumUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
             }
-            if (testEnumUnionArrayReuse919 != (null)) {
-                testEnumUnionArrayReuse919 .clear();
-                testEnumUnionArray917 = testEnumUnionArrayReuse919;
+            if (testEnumUnionArrayReuse0 != (null)) {
+                testEnumUnionArrayReuse0 .clear();
+                testEnumUnionArray1 = testEnumUnionArrayReuse0;
             } else {
-                testEnumUnionArray917 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen918), testEnumUnionArray916);
+                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
             }
             do {
-                for (int counter920 = 0; (counter920 <chunkLen918); counter920 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar922 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar922 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
                     }
-                    int unionIndex923 = (decoder.readIndex());
-                    if (unionIndex923 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex923 == 1) {
-                        int enumIndex924 = (decoder.readEnum());
-                        org.apache.avro.generic.GenericData.EnumSymbol enumValue925 = null;
-                        if (enumIndex924 == 0) {
-                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(1));
+                    if (unionIndex1 == 1) {
+                        int enumIndex3 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
+                        if (enumIndex3 == 0) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
                         }
-                        if (enumIndex924 == 1) {
-                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(0));
+                        if (enumIndex3 == 1) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
                         }
-                        if (enumIndex924 == 2) {
-                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(4));
+                        if (enumIndex3 == 2) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
                         }
-                        if (enumIndex924 == 3) {
-                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(2));
+                        if (enumIndex3 == 3) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
                         }
-                        if (enumIndex924 == 4) {
-                            enumValue925 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum901 .getEnumSymbols().get(3));
+                        if (enumIndex3 == 4) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
                         }
-                        testEnumUnionArray917 .add(enumValue925);
+                        testEnumUnionArray1 .add(enumValue3);
                     }
                 }
-                chunkLen918 = (decoder.arrayNext());
-            } while (chunkLen918 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testEnumUnionArray917 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray916);
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray917);
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957.java
@@ -14,32 +14,32 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
 {
 
     private final Schema readerSchema;
-    private final Schema testIntUnion927;
-    private final Schema testStringUnion929;
-    private final Schema testLongUnion931;
-    private final Schema testDoubleUnion933;
-    private final Schema testFloatUnion935;
-    private final Schema testBooleanUnion937;
-    private final Schema testBytesUnion939;
+    private final Schema testIntUnion0;
+    private final Schema testStringUnion0;
+    private final Schema testLongUnion0;
+    private final Schema testDoubleUnion0;
+    private final Schema testFloatUnion0;
+    private final Schema testBooleanUnion0;
+    private final Schema testBytesUnion0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_4124483613744867957_4124483613744867957(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testIntUnion927 = readerSchema.getField("testIntUnion").schema();
-        this.testStringUnion929 = readerSchema.getField("testStringUnion").schema();
-        this.testLongUnion931 = readerSchema.getField("testLongUnion").schema();
-        this.testDoubleUnion933 = readerSchema.getField("testDoubleUnion").schema();
-        this.testFloatUnion935 = readerSchema.getField("testFloatUnion").schema();
-        this.testBooleanUnion937 = readerSchema.getField("testBooleanUnion").schema();
-        this.testBytesUnion939 = readerSchema.getField("testBytesUnion").schema();
+        this.testIntUnion0 = readerSchema.getField("testIntUnion").schema();
+        this.testStringUnion0 = readerSchema.getField("testStringUnion").schema();
+        this.testLongUnion0 = readerSchema.getField("testLongUnion").schema();
+        this.testDoubleUnion0 = readerSchema.getField("testDoubleUnion").schema();
+        this.testFloatUnion0 = readerSchema.getField("testFloatUnion").schema();
+        this.testBooleanUnion0 = readerSchema.getField("testBooleanUnion").schema();
+        this.testBytesUnion0 = readerSchema.getField("testBytesUnion").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives926((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives926(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
@@ -49,11 +49,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
-        int unionIndex928 = (decoder.readIndex());
-        if (unionIndex928 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex928 == 1) {
+        if (unionIndex0 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
         }
         if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2) instanceof Utf8) {
@@ -61,11 +61,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(null));
         }
-        int unionIndex930 = (decoder.readIndex());
-        if (unionIndex930 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex930 == 1) {
+        if (unionIndex1 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3))));
             } else {
@@ -73,35 +73,35 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             }
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
-        int unionIndex932 = (decoder.readIndex());
-        if (unionIndex932 == 0) {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex932 == 1) {
+        if (unionIndex2 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
-        int unionIndex934 = (decoder.readIndex());
-        if (unionIndex934 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex934 == 1) {
+        if (unionIndex3 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
-        int unionIndex936 = (decoder.readIndex());
-        if (unionIndex936 == 0) {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
             decoder.readNull();
         }
-        if (unionIndex936 == 1) {
+        if (unionIndex4 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
-        int unionIndex938 = (decoder.readIndex());
-        if (unionIndex938 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex938 == 1) {
+        if (unionIndex5 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
         }
         if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12) instanceof ByteBuffer) {
@@ -109,11 +109,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes((null)));
         }
-        int unionIndex940 = (decoder.readIndex());
-        if (unionIndex940 == 0) {
+        int unionIndex6 = (decoder.readIndex());
+        if (unionIndex6 == 0) {
             decoder.readNull();
         }
-        if (unionIndex940 == 1) {
+        if (unionIndex6 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13) instanceof ByteBuffer) {
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123.java
@@ -18,38 +18,38 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
 {
 
     private final Schema readerSchema;
-    private final Schema recordsArray945;
-    private final Schema recordsArrayArrayElemSchema950;
-    private final Schema subField953;
-    private final Schema recordsMap955;
-    private final Schema recordsArrayUnion961;
-    private final Schema recordsArrayUnionOptionSchema963;
-    private final Schema recordsArrayUnionOptionArrayElemSchema968;
-    private final Schema recordsMapUnion971;
-    private final Schema recordsMapUnionOptionSchema973;
-    private final Schema recordsMapUnionOptionMapValueSchema979;
+    private final Schema recordsArray0;
+    private final Schema recordsArrayArrayElemSchema0;
+    private final Schema subField0;
+    private final Schema recordsMap0;
+    private final Schema recordsArrayUnion0;
+    private final Schema recordsArrayUnionOptionSchema0;
+    private final Schema recordsArrayUnionOptionArrayElemSchema0;
+    private final Schema recordsMapUnion0;
+    private final Schema recordsMapUnionOptionSchema0;
+    private final Schema recordsMapUnionOptionMapValueSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.recordsArray945 = readerSchema.getField("recordsArray").schema();
-        this.recordsArrayArrayElemSchema950 = recordsArray945 .getElementType();
-        this.subField953 = recordsArrayArrayElemSchema950 .getField("subField").schema();
-        this.recordsMap955 = readerSchema.getField("recordsMap").schema();
-        this.recordsArrayUnion961 = readerSchema.getField("recordsArrayUnion").schema();
-        this.recordsArrayUnionOptionSchema963 = recordsArrayUnion961 .getTypes().get(1);
-        this.recordsArrayUnionOptionArrayElemSchema968 = recordsArrayUnionOptionSchema963 .getElementType();
-        this.recordsMapUnion971 = readerSchema.getField("recordsMapUnion").schema();
-        this.recordsMapUnionOptionSchema973 = recordsMapUnion971 .getTypes().get(1);
-        this.recordsMapUnionOptionMapValueSchema979 = recordsMapUnionOptionSchema973 .getValueType();
+        this.recordsArray0 = readerSchema.getField("recordsArray").schema();
+        this.recordsArrayArrayElemSchema0 = recordsArray0 .getElementType();
+        this.subField0 = recordsArrayArrayElemSchema0 .getField("subField").schema();
+        this.recordsMap0 = readerSchema.getField("recordsMap").schema();
+        this.recordsArrayUnion0 = readerSchema.getField("recordsArrayUnion").schema();
+        this.recordsArrayUnionOptionSchema0 = recordsArrayUnion0 .getTypes().get(1);
+        this.recordsArrayUnionOptionArrayElemSchema0 = recordsArrayUnionOptionSchema0 .getElementType();
+        this.recordsMapUnion0 = readerSchema.getField("recordsMapUnion").schema();
+        this.recordsMapUnionOptionSchema0 = recordsMapUnion0 .getTypes().get(1);
+        this.recordsMapUnionOptionMapValueSchema0 = recordsMapUnionOptionSchema0 .getValueType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField944((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField944(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
@@ -58,149 +58,149 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        List<IndexedRecord> recordsArray946 = null;
-        long chunkLen947 = (decoder.readArrayStart());
-        if (chunkLen947 > 0) {
-            List<IndexedRecord> recordsArrayReuse948 = null;
+        List<IndexedRecord> recordsArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> recordsArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
-                recordsArrayReuse948 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+                recordsArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
             }
-            if (recordsArrayReuse948 != (null)) {
-                recordsArrayReuse948 .clear();
-                recordsArray946 = recordsArrayReuse948;
+            if (recordsArrayReuse0 != (null)) {
+                recordsArrayReuse0 .clear();
+                recordsArray1 = recordsArrayReuse0;
             } else {
-                recordsArray946 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen947), recordsArray945);
+                recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
             }
             do {
-                for (int counter949 = 0; (counter949 <chunkLen947); counter949 ++) {
-                    Object recordsArrayArrayElementReuseVar951 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object recordsArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayArrayElementReuseVar951 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                        recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
                     }
-                    recordsArray946 .add(deserializesubRecord952(recordsArrayArrayElementReuseVar951, (decoder)));
+                    recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen947 = (decoder.arrayNext());
-            } while (chunkLen947 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            recordsArray946 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray945);
+            recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray946);
-        Map<Utf8, IndexedRecord> recordsMap956 = null;
-        long chunkLen957 = (decoder.readMapStart());
-        if (chunkLen957 > 0) {
-            Map<Utf8, IndexedRecord> recordsMapReuse958 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
+        Map<Utf8, IndexedRecord> recordsMap1 = null;
+        long chunkLen1 = (decoder.readMapStart());
+        if (chunkLen1 > 0) {
+            Map<Utf8, IndexedRecord> recordsMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1) instanceof Map) {
-                recordsMapReuse958 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
+                recordsMapReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
             }
-            if (recordsMapReuse958 != (null)) {
-                recordsMapReuse958 .clear();
-                recordsMap956 = recordsMapReuse958;
+            if (recordsMapReuse0 != (null)) {
+                recordsMapReuse0 .clear();
+                recordsMap1 = recordsMapReuse0;
             } else {
-                recordsMap956 = new HashMap<Utf8, IndexedRecord>();
+                recordsMap1 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter959 = 0; (counter959 <chunkLen957); counter959 ++) {
-                    Utf8 key960 = (decoder.readString(null));
-                    recordsMap956 .put(key960, deserializesubRecord952(null, (decoder)));
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    recordsMap1 .put(key0, deserializesubRecord0(null, (decoder)));
                 }
-                chunkLen957 = (decoder.mapNext());
-            } while (chunkLen957 > 0);
+                chunkLen1 = (decoder.mapNext());
+            } while (chunkLen1 > 0);
         } else {
-            recordsMap956 = Collections.emptyMap();
+            recordsMap1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap956);
-        int unionIndex962 = (decoder.readIndex());
-        if (unionIndex962 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap1);
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex962 == 1) {
-            List<IndexedRecord> recordsArrayUnionOption964 = null;
-            long chunkLen965 = (decoder.readArrayStart());
-            if (chunkLen965 > 0) {
-                List<IndexedRecord> recordsArrayUnionOptionReuse966 = null;
+        if (unionIndex1 == 1) {
+            List<IndexedRecord> recordsArrayUnionOption0 = null;
+            long chunkLen2 = (decoder.readArrayStart());
+            if (chunkLen2 > 0) {
+                List<IndexedRecord> recordsArrayUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
-                    recordsArrayUnionOptionReuse966 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                    recordsArrayUnionOptionReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
                 }
-                if (recordsArrayUnionOptionReuse966 != (null)) {
-                    recordsArrayUnionOptionReuse966 .clear();
-                    recordsArrayUnionOption964 = recordsArrayUnionOptionReuse966;
+                if (recordsArrayUnionOptionReuse0 != (null)) {
+                    recordsArrayUnionOptionReuse0 .clear();
+                    recordsArrayUnionOption0 = recordsArrayUnionOptionReuse0;
                 } else {
-                    recordsArrayUnionOption964 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen965), recordsArrayUnionOptionSchema963);
+                    recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
                 }
                 do {
-                    for (int counter967 = 0; (counter967 <chunkLen965); counter967 ++) {
-                        Object recordsArrayUnionOptionArrayElementReuseVar969 = null;
+                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
                         if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
-                            recordsArrayUnionOptionArrayElementReuseVar969 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                            recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
                         }
-                        int unionIndex970 = (decoder.readIndex());
-                        if (unionIndex970 == 0) {
+                        int unionIndex2 = (decoder.readIndex());
+                        if (unionIndex2 == 0) {
                             decoder.readNull();
                         }
-                        if (unionIndex970 == 1) {
-                            recordsArrayUnionOption964 .add(deserializesubRecord952(recordsArrayUnionOptionArrayElementReuseVar969, (decoder)));
+                        if (unionIndex2 == 1) {
+                            recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
                         }
                     }
-                    chunkLen965 = (decoder.arrayNext());
-                } while (chunkLen965 > 0);
+                    chunkLen2 = (decoder.arrayNext());
+                } while (chunkLen2 > 0);
             } else {
-                recordsArrayUnionOption964 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema963);
+                recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema0);
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption964);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption0);
         }
-        int unionIndex972 = (decoder.readIndex());
-        if (unionIndex972 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex972 == 1) {
-            Map<Utf8, IndexedRecord> recordsMapUnionOption974 = null;
-            long chunkLen975 = (decoder.readMapStart());
-            if (chunkLen975 > 0) {
-                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse976 = null;
+        if (unionIndex3 == 1) {
+            Map<Utf8, IndexedRecord> recordsMapUnionOption0 = null;
+            long chunkLen3 = (decoder.readMapStart());
+            if (chunkLen3 > 0) {
+                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3) instanceof Map) {
-                    recordsMapUnionOptionReuse976 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
+                    recordsMapUnionOptionReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
                 }
-                if (recordsMapUnionOptionReuse976 != (null)) {
-                    recordsMapUnionOptionReuse976 .clear();
-                    recordsMapUnionOption974 = recordsMapUnionOptionReuse976;
+                if (recordsMapUnionOptionReuse0 != (null)) {
+                    recordsMapUnionOptionReuse0 .clear();
+                    recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
                 } else {
-                    recordsMapUnionOption974 = new HashMap<Utf8, IndexedRecord>();
+                    recordsMapUnionOption0 = new HashMap<Utf8, IndexedRecord>();
                 }
                 do {
-                    for (int counter977 = 0; (counter977 <chunkLen975); counter977 ++) {
-                        Utf8 key978 = (decoder.readString(null));
-                        int unionIndex980 = (decoder.readIndex());
-                        if (unionIndex980 == 0) {
+                    for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                        Utf8 key1 = (decoder.readString(null));
+                        int unionIndex4 = (decoder.readIndex());
+                        if (unionIndex4 == 0) {
                             decoder.readNull();
                         }
-                        if (unionIndex980 == 1) {
-                            recordsMapUnionOption974 .put(key978, deserializesubRecord952(null, (decoder)));
+                        if (unionIndex4 == 1) {
+                            recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder)));
                         }
                     }
-                    chunkLen975 = (decoder.mapNext());
-                } while (chunkLen975 > 0);
+                    chunkLen3 = (decoder.mapNext());
+                } while (chunkLen3 > 0);
             } else {
-                recordsMapUnionOption974 = Collections.emptyMap();
+                recordsMapUnionOption0 = Collections.emptyMap();
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption974);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption0);
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord952(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema950)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema950);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema0);
         }
-        int unionIndex954 = (decoder.readIndex());
-        if (unionIndex954 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex954 == 1) {
+        if (unionIndex0 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709.java
@@ -18,46 +18,46 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
 {
 
     private final Schema readerSchema;
-    private final Schema recordsArrayMap982;
-    private final Schema recordsArrayMapArrayElemSchema987;
-    private final Schema recordsArrayMapElemMapValueSchema994;
-    private final Schema recordsArrayMapElemValueOptionSchema996;
-    private final Schema subField998;
-    private final Schema recordsMapArray1000;
-    private final Schema recordsMapArrayMapValueSchema1006;
-    private final Schema recordsMapArrayValueArrayElemSchema1011;
-    private final Schema recordsArrayMapUnion1014;
-    private final Schema recordsArrayMapUnionOptionArrayElemSchema1020;
-    private final Schema recordsArrayMapUnionOptionElemMapValueSchema1027;
-    private final Schema recordsMapArrayUnion1029;
-    private final Schema recordsMapArrayUnionOptionSchema1031;
-    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema1041;
+    private final Schema recordsArrayMap0;
+    private final Schema recordsArrayMapArrayElemSchema0;
+    private final Schema recordsArrayMapElemMapValueSchema0;
+    private final Schema recordsArrayMapElemValueOptionSchema0;
+    private final Schema subField0;
+    private final Schema recordsMapArray0;
+    private final Schema recordsMapArrayMapValueSchema0;
+    private final Schema recordsMapArrayValueArrayElemSchema0;
+    private final Schema recordsArrayMapUnion0;
+    private final Schema recordsArrayMapUnionOptionArrayElemSchema0;
+    private final Schema recordsArrayMapUnionOptionElemMapValueSchema0;
+    private final Schema recordsMapArrayUnion0;
+    private final Schema recordsMapArrayUnionOptionSchema0;
+    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.recordsArrayMap982 = readerSchema.getField("recordsArrayMap").schema();
-        this.recordsArrayMapArrayElemSchema987 = recordsArrayMap982 .getElementType();
-        this.recordsArrayMapElemMapValueSchema994 = recordsArrayMapArrayElemSchema987 .getValueType();
-        this.recordsArrayMapElemValueOptionSchema996 = recordsArrayMapElemMapValueSchema994 .getTypes().get(1);
-        this.subField998 = recordsArrayMapElemValueOptionSchema996 .getField("subField").schema();
-        this.recordsMapArray1000 = readerSchema.getField("recordsMapArray").schema();
-        this.recordsMapArrayMapValueSchema1006 = recordsMapArray1000 .getValueType();
-        this.recordsMapArrayValueArrayElemSchema1011 = recordsMapArrayMapValueSchema1006 .getElementType();
-        this.recordsArrayMapUnion1014 = readerSchema.getField("recordsArrayMapUnion").schema();
-        this.recordsArrayMapUnionOptionArrayElemSchema1020 = recordsArrayMap982 .getElementType();
-        this.recordsArrayMapUnionOptionElemMapValueSchema1027 = recordsArrayMapUnionOptionArrayElemSchema1020 .getValueType();
-        this.recordsMapArrayUnion1029 = readerSchema.getField("recordsMapArrayUnion").schema();
-        this.recordsMapArrayUnionOptionSchema1031 = recordsMapArrayUnion1029 .getTypes().get(1);
-        this.recordsMapArrayUnionOptionValueArrayElemSchema1041 = recordsMapArrayMapValueSchema1006 .getElementType();
+        this.recordsArrayMap0 = readerSchema.getField("recordsArrayMap").schema();
+        this.recordsArrayMapArrayElemSchema0 = recordsArrayMap0 .getElementType();
+        this.recordsArrayMapElemMapValueSchema0 = recordsArrayMapArrayElemSchema0 .getValueType();
+        this.recordsArrayMapElemValueOptionSchema0 = recordsArrayMapElemMapValueSchema0 .getTypes().get(1);
+        this.subField0 = recordsArrayMapElemValueOptionSchema0 .getField("subField").schema();
+        this.recordsMapArray0 = readerSchema.getField("recordsMapArray").schema();
+        this.recordsMapArrayMapValueSchema0 = recordsMapArray0 .getValueType();
+        this.recordsMapArrayValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
+        this.recordsArrayMapUnion0 = readerSchema.getField("recordsArrayMapUnion").schema();
+        this.recordsArrayMapUnionOptionArrayElemSchema0 = recordsArrayMap0 .getElementType();
+        this.recordsArrayMapUnionOptionElemMapValueSchema0 = recordsArrayMapUnionOptionArrayElemSchema0 .getValueType();
+        this.recordsMapArrayUnion0 = readerSchema.getField("recordsMapArrayUnion").schema();
+        this.recordsMapArrayUnionOptionSchema0 = recordsMapArrayUnion0 .getTypes().get(1);
+        this.recordsMapArrayUnionOptionValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField981((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField981(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
@@ -66,259 +66,259 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        List<Map<Utf8, IndexedRecord>> recordsArrayMap983 = null;
-        long chunkLen984 = (decoder.readArrayStart());
-        if (chunkLen984 > 0) {
-            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse985 = null;
+        List<Map<Utf8, IndexedRecord>> recordsArrayMap1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
-                recordsArrayMapReuse985 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+                recordsArrayMapReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
             }
-            if (recordsArrayMapReuse985 != (null)) {
-                recordsArrayMapReuse985 .clear();
-                recordsArrayMap983 = recordsArrayMapReuse985;
+            if (recordsArrayMapReuse0 != (null)) {
+                recordsArrayMapReuse0 .clear();
+                recordsArrayMap1 = recordsArrayMapReuse0;
             } else {
-                recordsArrayMap983 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen984), recordsArrayMap982);
+                recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
             }
             do {
-                for (int counter986 = 0; (counter986 <chunkLen984); counter986 ++) {
-                    Object recordsArrayMapArrayElementReuseVar988 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object recordsArrayMapArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayMapArrayElementReuseVar988 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                        recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
                     }
-                    Map<Utf8, IndexedRecord> recordsArrayMapElem989 = null;
-                    long chunkLen990 = (decoder.readMapStart());
-                    if (chunkLen990 > 0) {
-                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse991 = null;
-                        if (recordsArrayMapArrayElementReuseVar988 instanceof Map) {
-                            recordsArrayMapElemReuse991 = ((Map) recordsArrayMapArrayElementReuseVar988);
+                    Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
+                    long chunkLen1 = (decoder.readMapStart());
+                    if (chunkLen1 > 0) {
+                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
+                        if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
+                            recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
                         }
-                        if (recordsArrayMapElemReuse991 != (null)) {
-                            recordsArrayMapElemReuse991 .clear();
-                            recordsArrayMapElem989 = recordsArrayMapElemReuse991;
+                        if (recordsArrayMapElemReuse0 != (null)) {
+                            recordsArrayMapElemReuse0 .clear();
+                            recordsArrayMapElem0 = recordsArrayMapElemReuse0;
                         } else {
-                            recordsArrayMapElem989 = new HashMap<Utf8, IndexedRecord>();
+                            recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
                         }
                         do {
-                            for (int counter992 = 0; (counter992 <chunkLen990); counter992 ++) {
-                                Utf8 key993 = (decoder.readString(null));
-                                int unionIndex995 = (decoder.readIndex());
-                                if (unionIndex995 == 0) {
+                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                                Utf8 key0 = (decoder.readString(null));
+                                int unionIndex0 = (decoder.readIndex());
+                                if (unionIndex0 == 0) {
                                     decoder.readNull();
                                 }
-                                if (unionIndex995 == 1) {
-                                    recordsArrayMapElem989 .put(key993, deserializesubRecord997(null, (decoder)));
+                                if (unionIndex0 == 1) {
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
                                 }
                             }
-                            chunkLen990 = (decoder.mapNext());
-                        } while (chunkLen990 > 0);
+                            chunkLen1 = (decoder.mapNext());
+                        } while (chunkLen1 > 0);
                     } else {
-                        recordsArrayMapElem989 = Collections.emptyMap();
+                        recordsArrayMapElem0 = Collections.emptyMap();
                     }
-                    recordsArrayMap983 .add(recordsArrayMapElem989);
+                    recordsArrayMap1 .add(recordsArrayMapElem0);
                 }
-                chunkLen984 = (decoder.arrayNext());
-            } while (chunkLen984 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            recordsArrayMap983 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap982);
+            recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap983);
-        Map<Utf8, List<IndexedRecord>> recordsMapArray1001 = null;
-        long chunkLen1002 = (decoder.readMapStart());
-        if (chunkLen1002 > 0) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse1003 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
+        Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
+        long chunkLen2 = (decoder.readMapStart());
+        if (chunkLen2 > 0) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1) instanceof Map) {
-                recordsMapArrayReuse1003 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
+                recordsMapArrayReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
             }
-            if (recordsMapArrayReuse1003 != (null)) {
-                recordsMapArrayReuse1003 .clear();
-                recordsMapArray1001 = recordsMapArrayReuse1003;
+            if (recordsMapArrayReuse0 != (null)) {
+                recordsMapArrayReuse0 .clear();
+                recordsMapArray1 = recordsMapArrayReuse0;
             } else {
-                recordsMapArray1001 = new HashMap<Utf8, List<IndexedRecord>>();
+                recordsMapArray1 = new HashMap<Utf8, List<IndexedRecord>>();
             }
             do {
-                for (int counter1004 = 0; (counter1004 <chunkLen1002); counter1004 ++) {
-                    Utf8 key1005 = (decoder.readString(null));
-                    List<IndexedRecord> recordsMapArrayValue1007 = null;
-                    long chunkLen1008 = (decoder.readArrayStart());
-                    if (chunkLen1008 > 0) {
-                        List<IndexedRecord> recordsMapArrayValueReuse1009 = null;
+                for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                    Utf8 key1 = (decoder.readString(null));
+                    List<IndexedRecord> recordsMapArrayValue0 = null;
+                    long chunkLen3 = (decoder.readArrayStart());
+                    if (chunkLen3 > 0) {
+                        List<IndexedRecord> recordsMapArrayValueReuse0 = null;
                         if (null instanceof List) {
-                            recordsMapArrayValueReuse1009 = ((List) null);
+                            recordsMapArrayValueReuse0 = ((List) null);
                         }
-                        if (recordsMapArrayValueReuse1009 != (null)) {
-                            recordsMapArrayValueReuse1009 .clear();
-                            recordsMapArrayValue1007 = recordsMapArrayValueReuse1009;
+                        if (recordsMapArrayValueReuse0 != (null)) {
+                            recordsMapArrayValueReuse0 .clear();
+                            recordsMapArrayValue0 = recordsMapArrayValueReuse0;
                         } else {
-                            recordsMapArrayValue1007 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1008), recordsMapArrayMapValueSchema1006);
+                            recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
                         }
                         do {
-                            for (int counter1010 = 0; (counter1010 <chunkLen1008); counter1010 ++) {
-                                Object recordsMapArrayValueArrayElementReuseVar1012 = null;
+                            for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                                Object recordsMapArrayValueArrayElementReuseVar0 = null;
                                 if (null instanceof GenericArray) {
-                                    recordsMapArrayValueArrayElementReuseVar1012 = ((GenericArray) null).peek();
+                                    recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                 }
-                                int unionIndex1013 = (decoder.readIndex());
-                                if (unionIndex1013 == 0) {
+                                int unionIndex2 = (decoder.readIndex());
+                                if (unionIndex2 == 0) {
                                     decoder.readNull();
                                 }
-                                if (unionIndex1013 == 1) {
-                                    recordsMapArrayValue1007 .add(deserializesubRecord997(recordsMapArrayValueArrayElementReuseVar1012, (decoder)));
+                                if (unionIndex2 == 1) {
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
                                 }
                             }
-                            chunkLen1008 = (decoder.arrayNext());
-                        } while (chunkLen1008 > 0);
+                            chunkLen3 = (decoder.arrayNext());
+                        } while (chunkLen3 > 0);
                     } else {
-                        recordsMapArrayValue1007 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema1006);
+                        recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema0);
                     }
-                    recordsMapArray1001 .put(key1005, recordsMapArrayValue1007);
+                    recordsMapArray1 .put(key1, recordsMapArrayValue0);
                 }
-                chunkLen1002 = (decoder.mapNext());
-            } while (chunkLen1002 > 0);
+                chunkLen2 = (decoder.mapNext());
+            } while (chunkLen2 > 0);
         } else {
-            recordsMapArray1001 = Collections.emptyMap();
+            recordsMapArray1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray1001);
-        int unionIndex1015 = (decoder.readIndex());
-        if (unionIndex1015 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray1);
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1015 == 1) {
-            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption1016 = null;
-            long chunkLen1017 = (decoder.readArrayStart());
-            if (chunkLen1017 > 0) {
-                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse1018 = null;
+        if (unionIndex3 == 1) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption0 = null;
+            long chunkLen4 = (decoder.readArrayStart());
+            if (chunkLen4 > 0) {
+                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
-                    recordsArrayMapUnionOptionReuse1018 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                    recordsArrayMapUnionOptionReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
                 }
-                if (recordsArrayMapUnionOptionReuse1018 != (null)) {
-                    recordsArrayMapUnionOptionReuse1018 .clear();
-                    recordsArrayMapUnionOption1016 = recordsArrayMapUnionOptionReuse1018;
+                if (recordsArrayMapUnionOptionReuse0 != (null)) {
+                    recordsArrayMapUnionOptionReuse0 .clear();
+                    recordsArrayMapUnionOption0 = recordsArrayMapUnionOptionReuse0;
                 } else {
-                    recordsArrayMapUnionOption1016 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen1017), recordsArrayMap982);
+                    recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
                 }
                 do {
-                    for (int counter1019 = 0; (counter1019 <chunkLen1017); counter1019 ++) {
-                        Object recordsArrayMapUnionOptionArrayElementReuseVar1021 = null;
+                    for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
                         if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
-                            recordsArrayMapUnionOptionArrayElementReuseVar1021 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                            recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
                         }
-                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem1022 = null;
-                        long chunkLen1023 = (decoder.readMapStart());
-                        if (chunkLen1023 > 0) {
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse1024 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar1021 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse1024 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar1021);
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
+                        long chunkLen5 = (decoder.readMapStart());
+                        if (chunkLen5 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
                             }
-                            if (recordsArrayMapUnionOptionElemReuse1024 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse1024 .clear();
-                                recordsArrayMapUnionOptionElem1022 = recordsArrayMapUnionOptionElemReuse1024;
+                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse0 .clear();
+                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
                             } else {
-                                recordsArrayMapUnionOptionElem1022 = new HashMap<Utf8, IndexedRecord>();
+                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
                             }
                             do {
-                                for (int counter1025 = 0; (counter1025 <chunkLen1023); counter1025 ++) {
-                                    Utf8 key1026 = (decoder.readString(null));
-                                    int unionIndex1028 = (decoder.readIndex());
-                                    if (unionIndex1028 == 0) {
+                                for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
+                                    Utf8 key2 = (decoder.readString(null));
+                                    int unionIndex4 = (decoder.readIndex());
+                                    if (unionIndex4 == 0) {
                                         decoder.readNull();
                                     }
-                                    if (unionIndex1028 == 1) {
-                                        recordsArrayMapUnionOptionElem1022 .put(key1026, deserializesubRecord997(null, (decoder)));
+                                    if (unionIndex4 == 1) {
+                                        recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
                                     }
                                 }
-                                chunkLen1023 = (decoder.mapNext());
-                            } while (chunkLen1023 > 0);
+                                chunkLen5 = (decoder.mapNext());
+                            } while (chunkLen5 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem1022 = Collections.emptyMap();
+                            recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
                         }
-                        recordsArrayMapUnionOption1016 .add(recordsArrayMapUnionOptionElem1022);
+                        recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
-                    chunkLen1017 = (decoder.arrayNext());
-                } while (chunkLen1017 > 0);
+                    chunkLen4 = (decoder.arrayNext());
+                } while (chunkLen4 > 0);
             } else {
-                recordsArrayMapUnionOption1016 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap982);
+                recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap0);
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption1016);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption0);
         }
-        int unionIndex1030 = (decoder.readIndex());
-        if (unionIndex1030 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1030 == 1) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption1032 = null;
-            long chunkLen1033 = (decoder.readMapStart());
-            if (chunkLen1033 > 0) {
-                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse1034 = null;
+        if (unionIndex5 == 1) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption0 = null;
+            long chunkLen6 = (decoder.readMapStart());
+            if (chunkLen6 > 0) {
+                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3) instanceof Map) {
-                    recordsMapArrayUnionOptionReuse1034 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
+                    recordsMapArrayUnionOptionReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
                 }
-                if (recordsMapArrayUnionOptionReuse1034 != (null)) {
-                    recordsMapArrayUnionOptionReuse1034 .clear();
-                    recordsMapArrayUnionOption1032 = recordsMapArrayUnionOptionReuse1034;
+                if (recordsMapArrayUnionOptionReuse0 != (null)) {
+                    recordsMapArrayUnionOptionReuse0 .clear();
+                    recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
                 } else {
-                    recordsMapArrayUnionOption1032 = new HashMap<Utf8, List<IndexedRecord>>();
+                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<IndexedRecord>>();
                 }
                 do {
-                    for (int counter1035 = 0; (counter1035 <chunkLen1033); counter1035 ++) {
-                        Utf8 key1036 = (decoder.readString(null));
-                        List<IndexedRecord> recordsMapArrayUnionOptionValue1037 = null;
-                        long chunkLen1038 = (decoder.readArrayStart());
-                        if (chunkLen1038 > 0) {
-                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse1039 = null;
+                    for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
+                        Utf8 key3 = (decoder.readString(null));
+                        List<IndexedRecord> recordsMapArrayUnionOptionValue0 = null;
+                        long chunkLen7 = (decoder.readArrayStart());
+                        if (chunkLen7 > 0) {
+                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse0 = null;
                             if (null instanceof List) {
-                                recordsMapArrayUnionOptionValueReuse1039 = ((List) null);
+                                recordsMapArrayUnionOptionValueReuse0 = ((List) null);
                             }
-                            if (recordsMapArrayUnionOptionValueReuse1039 != (null)) {
-                                recordsMapArrayUnionOptionValueReuse1039 .clear();
-                                recordsMapArrayUnionOptionValue1037 = recordsMapArrayUnionOptionValueReuse1039;
+                            if (recordsMapArrayUnionOptionValueReuse0 != (null)) {
+                                recordsMapArrayUnionOptionValueReuse0 .clear();
+                                recordsMapArrayUnionOptionValue0 = recordsMapArrayUnionOptionValueReuse0;
                             } else {
-                                recordsMapArrayUnionOptionValue1037 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1038), recordsMapArrayMapValueSchema1006);
+                                recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
                             }
                             do {
-                                for (int counter1040 = 0; (counter1040 <chunkLen1038); counter1040 ++) {
-                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar1042 = null;
+                                for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
                                     if (null instanceof GenericArray) {
-                                        recordsMapArrayUnionOptionValueArrayElementReuseVar1042 = ((GenericArray) null).peek();
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                     }
-                                    int unionIndex1043 = (decoder.readIndex());
-                                    if (unionIndex1043 == 0) {
+                                    int unionIndex6 = (decoder.readIndex());
+                                    if (unionIndex6 == 0) {
                                         decoder.readNull();
                                     }
-                                    if (unionIndex1043 == 1) {
-                                        recordsMapArrayUnionOptionValue1037 .add(deserializesubRecord997(recordsMapArrayUnionOptionValueArrayElementReuseVar1042, (decoder)));
+                                    if (unionIndex6 == 1) {
+                                        recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
                                     }
                                 }
-                                chunkLen1038 = (decoder.arrayNext());
-                            } while (chunkLen1038 > 0);
+                                chunkLen7 = (decoder.arrayNext());
+                            } while (chunkLen7 > 0);
                         } else {
-                            recordsMapArrayUnionOptionValue1037 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema1006);
+                            recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema0);
                         }
-                        recordsMapArrayUnionOption1032 .put(key1036, recordsMapArrayUnionOptionValue1037);
+                        recordsMapArrayUnionOption0 .put(key3, recordsMapArrayUnionOptionValue0);
                     }
-                    chunkLen1033 = (decoder.mapNext());
-                } while (chunkLen1033 > 0);
+                    chunkLen6 = (decoder.mapNext());
+                } while (chunkLen6 > 0);
             } else {
-                recordsMapArrayUnionOption1032 = Collections.emptyMap();
+                recordsMapArrayUnionOption0 = Collections.emptyMap();
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption1032);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption0);
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord997(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema996)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema996);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema0);
         }
-        int unionIndex999 = (decoder.readIndex());
-        if (unionIndex999 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex999 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531.java
@@ -13,26 +13,26 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
 {
 
     private final Schema readerSchema;
-    private final Schema record1045;
-    private final Schema recordOptionSchema1047;
-    private final Schema subField1049;
-    private final Schema field1051;
+    private final Schema record0;
+    private final Schema recordOptionSchema0;
+    private final Schema subField0;
+    private final Schema field0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1226932714285867531_1226932714285867531(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.record1045 = readerSchema.getField("record").schema();
-        this.recordOptionSchema1047 = record1045 .getTypes().get(1);
-        this.subField1049 = recordOptionSchema1047 .getField("subField").schema();
-        this.field1051 = readerSchema.getField("field").schema();
+        this.record0 = readerSchema.getField("record").schema();
+        this.recordOptionSchema0 = record0 .getTypes().get(1);
+        this.subField0 = recordOptionSchema0 .getField("subField").schema();
+        this.field0 = readerSchema.getField("field").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField1044((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField1044(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
@@ -41,19 +41,19 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex1046 = (decoder.readIndex());
-        if (unionIndex1046 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1046 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord1048(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord1048(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
-        int unionIndex1052 = (decoder.readIndex());
-        if (unionIndex1052 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1052 == 1) {
+        if (unionIndex2 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2))));
             } else {
@@ -63,20 +63,20 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
     }
 
-    public IndexedRecord deserializesubRecord1048(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema1047)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema1047);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema0);
         }
-        int unionIndex1050 = (decoder.readIndex());
-        if (unionIndex1050 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1050 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106.java
@@ -18,34 +18,34 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
 {
 
     private final Schema readerSchema;
-    private final Schema testNotRemoved1054;
-    private final Schema testNotRemoved21057;
-    private final Schema subRecord1059;
-    private final Schema subRecordOptionSchema1061;
-    private final Schema testNotRemoved1063;
-    private final Schema testNotRemoved21066;
-    private final Schema subRecordMap1068;
-    private final Schema subRecordArray1074;
+    private final Schema testNotRemoved0;
+    private final Schema testNotRemoved20;
+    private final Schema subRecord0;
+    private final Schema subRecordOptionSchema0;
+    private final Schema testNotRemoved1;
+    private final Schema testNotRemoved21;
+    private final Schema subRecordMap0;
+    private final Schema subRecordArray0;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testNotRemoved1054 = readerSchema.getField("testNotRemoved").schema();
-        this.testNotRemoved21057 = readerSchema.getField("testNotRemoved2").schema();
-        this.subRecord1059 = readerSchema.getField("subRecord").schema();
-        this.subRecordOptionSchema1061 = subRecord1059 .getTypes().get(1);
-        this.testNotRemoved1063 = subRecordOptionSchema1061 .getField("testNotRemoved").schema();
-        this.testNotRemoved21066 = subRecordOptionSchema1061 .getField("testNotRemoved2").schema();
-        this.subRecordMap1068 = readerSchema.getField("subRecordMap").schema();
-        this.subRecordArray1074 = readerSchema.getField("subRecordArray").schema();
+        this.testNotRemoved0 = readerSchema.getField("testNotRemoved").schema();
+        this.testNotRemoved20 = readerSchema.getField("testNotRemoved2").schema();
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordOptionSchema0 = subRecord0 .getTypes().get(1);
+        this.testNotRemoved1 = subRecordOptionSchema0 .getField("testNotRemoved").schema();
+        this.testNotRemoved21 = subRecordOptionSchema0 .getField("testNotRemoved2").schema();
+        this.subRecordMap0 = readerSchema.getField("subRecordMap").schema();
+        this.subRecordArray0 = readerSchema.getField("subRecordArray").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField1053((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField1053(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
@@ -54,128 +54,128 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex1055 = (decoder.readIndex());
-        if (unionIndex1055 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1055 == 1) {
+        if (unionIndex0 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex1056 = (decoder.readIndex());
-        if (unionIndex1056 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1056 == 1) {
+        if (unionIndex1 == 1) {
             decoder.skipString();
         }
-        int unionIndex1058 = (decoder.readIndex());
-        if (unionIndex1058 == 0) {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1058 == 1) {
+        if (unionIndex2 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(null));
             }
         }
-        int unionIndex1060 = (decoder.readIndex());
-        if (unionIndex1060 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1060 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord1062(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+        if (unionIndex3 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
         }
-        Map<Utf8, IndexedRecord> subRecordMap1069 = null;
-        long chunkLen1070 = (decoder.readMapStart());
-        if (chunkLen1070 > 0) {
-            Map<Utf8, IndexedRecord> subRecordMapReuse1071 = null;
+        Map<Utf8, IndexedRecord> subRecordMap1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> subRecordMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3) instanceof Map) {
-                subRecordMapReuse1071 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
+                subRecordMapReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
             }
-            if (subRecordMapReuse1071 != (null)) {
-                subRecordMapReuse1071 .clear();
-                subRecordMap1069 = subRecordMapReuse1071;
+            if (subRecordMapReuse0 != (null)) {
+                subRecordMapReuse0 .clear();
+                subRecordMap1 = subRecordMapReuse0;
             } else {
-                subRecordMap1069 = new HashMap<Utf8, IndexedRecord>();
+                subRecordMap1 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter1072 = 0; (counter1072 <chunkLen1070); counter1072 ++) {
-                    Utf8 key1073 = (decoder.readString(null));
-                    subRecordMap1069 .put(key1073, deserializesubRecord1062(null, (decoder)));
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    subRecordMap1 .put(key0, deserializesubRecord0(null, (decoder)));
                 }
-                chunkLen1070 = (decoder.mapNext());
-            } while (chunkLen1070 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            subRecordMap1069 = Collections.emptyMap();
+            subRecordMap1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1069);
-        List<IndexedRecord> subRecordArray1075 = null;
-        long chunkLen1076 = (decoder.readArrayStart());
-        if (chunkLen1076 > 0) {
-            List<IndexedRecord> subRecordArrayReuse1077 = null;
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
+        List<IndexedRecord> subRecordArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<IndexedRecord> subRecordArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
-                subRecordArrayReuse1077 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+                subRecordArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
             }
-            if (subRecordArrayReuse1077 != (null)) {
-                subRecordArrayReuse1077 .clear();
-                subRecordArray1075 = subRecordArrayReuse1077;
+            if (subRecordArrayReuse0 != (null)) {
+                subRecordArrayReuse0 .clear();
+                subRecordArray1 = subRecordArrayReuse0;
             } else {
-                subRecordArray1075 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1076), subRecordArray1074);
+                subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
             }
             do {
-                for (int counter1078 = 0; (counter1078 <chunkLen1076); counter1078 ++) {
-                    Object subRecordArrayArrayElementReuseVar1079 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object subRecordArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
-                        subRecordArrayArrayElementReuseVar1079 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                        subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
                     }
-                    subRecordArray1075 .add(deserializesubRecord1062(subRecordArrayArrayElementReuseVar1079, (decoder)));
+                    subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen1076 = (decoder.arrayNext());
-            } while (chunkLen1076 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            subRecordArray1075 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray1074);
+            subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1075);
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1);
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
     }
 
-    public IndexedRecord deserializesubRecord1062(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema1061)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema1061);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema0);
         }
-        int unionIndex1064 = (decoder.readIndex());
-        if (unionIndex1064 == 0) {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1064 == 1) {
+        if (unionIndex4 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {
                 subRecord.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex1065 = (decoder.readIndex());
-        if (unionIndex1065 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1065 == 1) {
+        if (unionIndex5 == 1) {
             decoder.skipString();
         }
-        int unionIndex1067 = (decoder.readIndex());
-        if (unionIndex1067 == 0) {
+        int unionIndex6 = (decoder.readIndex());
+        if (unionIndex6 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1067 == 1) {
+        if (unionIndex6 == 1) {
             if (subRecord.get(1) instanceof Utf8) {
                 subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565.java
@@ -13,20 +13,20 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
 {
 
     private final Schema readerSchema;
-    private final Schema subRecord1081;
+    private final Schema subRecord0;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1758853045511797997_8691597471955696565(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.subRecord1081 = readerSchema.getField("subRecord").schema();
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord1080((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord1080(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
@@ -35,31 +35,31 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord1082(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
     }
 
-    public IndexedRecord deserializesubRecord1082(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord1081)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord1081);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
         }
         if (subRecord.get(0) instanceof Utf8) {
             subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
         } else {
             subRecord.put(0, (decoder).readString(null));
         }
-        deserializesubSubRecord1083(null, (decoder));
-        int unionIndex1084 = (decoder.readIndex());
-        if (unionIndex1084 == 0) {
+        deserializesubSubRecord0(null, (decoder));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1084 == 1) {
-            deserializesubSubRecord1083(null, (decoder));
+        if (unionIndex0 == 1) {
+            deserializesubSubRecord0(null, (decoder));
         }
         if (subRecord.get(1) instanceof Utf8) {
             subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
@@ -69,7 +69,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         return subRecord;
     }
 
-    public void deserializesubSubRecord1083(Object reuse, Decoder decoder)
+    public void deserializesubSubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899.java
@@ -13,20 +13,20 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
 {
 
     private final Schema readerSchema;
-    private final Schema subRecord11086;
+    private final Schema subRecord10;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_2934652623027673603_1427867983386866899(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.subRecord11086 = readerSchema.getField("subRecord1").schema();
+        this.subRecord10 = readerSchema.getField("subRecord1").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1085((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1085(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
@@ -35,27 +35,27 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord1087(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
-        deserializesubRecord21088(null, (decoder));
-        int unionIndex1089 = (decoder.readIndex());
-        if (unionIndex1089 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
+        deserializesubRecord20(null, (decoder));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex1089 == 1) {
-            deserializesubRecord21088(null, (decoder));
+        if (unionIndex0 == 1) {
+            deserializesubRecord20(null, (decoder));
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord1087(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
     }
 
-    public IndexedRecord deserializesubRecord1087(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord11086)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord10)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord11086);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord10);
         }
         if (subRecord.get(0) instanceof Utf8) {
             subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
@@ -70,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         return subRecord;
     }
 
-    public void deserializesubRecord21088(Object reuse, Decoder decoder)
+    public void deserializesubRecord20(Object reuse, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -16,66 +16,66 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
 {
 
     private final Schema readerSchema;
-    private final Schema mapMapValueSchema854;
-    private final Schema mapValueOptionSchema856;
-    private final Schema field858;
+    private final Schema mapMapValueSchema0;
+    private final Schema mapValueOptionSchema0;
+    private final Schema field0;
 
     public Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapMapValueSchema854 = readerSchema.getValueType();
-        this.mapValueOptionSchema856 = mapMapValueSchema854 .getTypes().get(1);
-        this.field858 = mapValueOptionSchema856 .getField("field").schema();
+        this.mapMapValueSchema0 = readerSchema.getValueType();
+        this.mapValueOptionSchema0 = mapMapValueSchema0 .getTypes().get(1);
+        this.field0 = mapValueOptionSchema0 .getField("field").schema();
     }
 
     public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        Map<Utf8, IndexedRecord> map849 = null;
-        long chunkLen850 = (decoder.readMapStart());
-        if (chunkLen850 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse851 = null;
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
             if ((reuse) instanceof Map) {
-                mapReuse851 = ((Map)(reuse));
+                mapReuse0 = ((Map)(reuse));
             }
-            if (mapReuse851 != (null)) {
-                mapReuse851 .clear();
-                map849 = mapReuse851;
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
             } else {
-                map849 = new HashMap<Utf8, IndexedRecord>();
+                map0 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter852 = 0; (counter852 <chunkLen850); counter852 ++) {
-                    Utf8 key853 = (decoder.readString(null));
-                    int unionIndex855 = (decoder.readIndex());
-                    if (unionIndex855 == 0) {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    int unionIndex0 = (decoder.readIndex());
+                    if (unionIndex0 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex855 == 1) {
-                        map849 .put(key853, deserializerecord857(null, (decoder)));
+                    if (unionIndex0 == 1) {
+                        map0 .put(key0, deserializerecord0(null, (decoder)));
                     }
                 }
-                chunkLen850 = (decoder.mapNext());
-            } while (chunkLen850 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            map849 = Collections.emptyMap();
+            map0 = Collections.emptyMap();
         }
-        return map849;
+        return map0;
     }
 
-    public IndexedRecord deserializerecord857(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema856)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema856);
+            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema0);
         }
-        int unionIndex859 = (decoder.readIndex());
-        if (unionIndex859 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex859 == 1) {
+        if (unionIndex1 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -16,58 +16,58 @@ public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969
 {
 
     private final Schema readerSchema;
-    private final Schema mapMapValueSchema845;
-    private final Schema field847;
+    private final Schema mapMapValueSchema0;
+    private final Schema field0;
 
     public Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapMapValueSchema845 = readerSchema.getValueType();
-        this.field847 = mapMapValueSchema845 .getField("field").schema();
+        this.mapMapValueSchema0 = readerSchema.getValueType();
+        this.field0 = mapMapValueSchema0 .getField("field").schema();
     }
 
     public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        Map<Utf8, IndexedRecord> map840 = null;
-        long chunkLen841 = (decoder.readMapStart());
-        if (chunkLen841 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse842 = null;
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
             if ((reuse) instanceof Map) {
-                mapReuse842 = ((Map)(reuse));
+                mapReuse0 = ((Map)(reuse));
             }
-            if (mapReuse842 != (null)) {
-                mapReuse842 .clear();
-                map840 = mapReuse842;
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
             } else {
-                map840 = new HashMap<Utf8, IndexedRecord>();
+                map0 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter843 = 0; (counter843 <chunkLen841); counter843 ++) {
-                    Utf8 key844 = (decoder.readString(null));
-                    map840 .put(key844, deserializerecord846(null, (decoder)));
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
                 }
-                chunkLen841 = (decoder.mapNext());
-            } while (chunkLen841 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            map840 = Collections.emptyMap();
+            map0 = Collections.emptyMap();
         }
-        return map840;
+        return map0;
     }
 
-    public IndexedRecord deserializerecord846(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema845)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema845);
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
         }
-        int unionIndex848 = (decoder.readIndex());
-        if (unionIndex848 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex848 == 1) {
+        if (unionIndex0 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -13,20 +13,20 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
 {
 
     private final Schema readerSchema;
-    private final Schema unionField942;
+    private final Schema unionField0;
 
     public recordName_GenericDeserializer_6897301803194779359_6897301803194779359(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.unionField942 = readerSchema.getField("unionField").schema();
+        this.unionField0 = readerSchema.getField("unionField").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializerecordName941((reuse), (decoder));
+        return deserializerecordName0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializerecordName941(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecordName0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord recordName;
@@ -40,12 +40,12 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
         } else {
             recordName.put(0, (decoder).readString(null));
         }
-        int unionIndex943 = (decoder.readIndex());
-        if (unionIndex943 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex943 == 1) {
-            recordName.put(1, deserializerecordName941(recordName.get(1), (decoder)));
+        if (unionIndex0 == 1) {
+            recordName.put(1, deserializerecordName0(recordName.get(1), (decoder)));
         }
         return recordName;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -21,33 +21,33 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
     public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
         throws IOException
     {
-        List<Boolean> array592 = null;
-        long chunkLen593 = (decoder.readArrayStart());
-        if (chunkLen593 > 0) {
-            List<Boolean> arrayReuse594 = null;
+        List<Boolean> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Boolean> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse594 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse594 != (null)) {
-                arrayReuse594 .clear();
-                array592 = arrayReuse594;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen593), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter595 = 0; (counter595 <chunkLen593); counter595 ++) {
-                    Object arrayArrayElementReuseVar596 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar596 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array592 .add((decoder.readBoolean()));
+                    array0 .add((decoder.readBoolean()));
                 }
-                chunkLen593 = (decoder.arrayNext());
-            } while (chunkLen593 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
         }
-        return array592;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -21,33 +21,33 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
     public List<Double> deserialize(List<Double> reuse, Decoder decoder)
         throws IOException
     {
-        List<Double> array597 = null;
-        long chunkLen598 = (decoder.readArrayStart());
-        if (chunkLen598 > 0) {
-            List<Double> arrayReuse599 = null;
+        List<Double> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Double> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse599 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse599 != (null)) {
-                arrayReuse599 .clear();
-                array597 = arrayReuse599;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array597 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen598), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter600 = 0; (counter600 <chunkLen598); counter600 ++) {
-                    Object arrayArrayElementReuseVar601 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar601 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array597 .add((decoder.readDouble()));
+                    array0 .add((decoder.readDouble()));
                 }
-                chunkLen598 = (decoder.arrayNext());
-            } while (chunkLen598 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array597 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
         }
-        return array597;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -21,9 +21,9 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
     public List<Float> deserialize(List<Float> reuse, Decoder decoder)
         throws IOException
     {
-        List<Float> array602 = null;
-        array602 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
-        return array602;
+        List<Float> array0 = null;
+        array0 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -21,33 +21,33 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
     public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
         throws IOException
     {
-        List<Integer> array603 = null;
-        long chunkLen604 = (decoder.readArrayStart());
-        if (chunkLen604 > 0) {
-            List<Integer> arrayReuse605 = null;
+        List<Integer> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Integer> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse605 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse605 != (null)) {
-                arrayReuse605 .clear();
-                array603 = arrayReuse605;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array603 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen604), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter606 = 0; (counter606 <chunkLen604); counter606 ++) {
-                    Object arrayArrayElementReuseVar607 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar607 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array603 .add((decoder.readInt()));
+                    array0 .add((decoder.readInt()));
                 }
-                chunkLen604 = (decoder.arrayNext());
-            } while (chunkLen604 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array603 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
         }
-        return array603;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -21,33 +21,33 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
     public List<Long> deserialize(List<Long> reuse, Decoder decoder)
         throws IOException
     {
-        List<Long> array608 = null;
-        long chunkLen609 = (decoder.readArrayStart());
-        if (chunkLen609 > 0) {
-            List<Long> arrayReuse610 = null;
+        List<Long> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Long> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse610 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse610 != (null)) {
-                arrayReuse610 .clear();
-                array608 = arrayReuse610;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array608 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen609), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter611 = 0; (counter611 <chunkLen609); counter611 ++) {
-                    Object arrayArrayElementReuseVar612 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar612 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array608 .add((decoder.readLong()));
+                    array0 .add((decoder.readLong()));
                 }
-                chunkLen609 = (decoder.arrayNext());
-            } while (chunkLen609 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array608 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
         }
-        return array608;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -15,69 +15,69 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
 {
 
     private final Schema readerSchema;
-    private final Schema arrayArrayElemSchema626;
-    private final Schema arrayElemOptionSchema629;
-    private final Schema field631;
+    private final Schema arrayArrayElemSchema0;
+    private final Schema arrayElemOptionSchema0;
+    private final Schema field0;
 
     public Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.arrayArrayElemSchema626 = readerSchema.getElementType();
-        this.arrayElemOptionSchema629 = arrayArrayElemSchema626 .getTypes().get(1);
-        this.field631 = arrayElemOptionSchema629 .getField("field").schema();
+        this.arrayArrayElemSchema0 = readerSchema.getElementType();
+        this.arrayElemOptionSchema0 = arrayArrayElemSchema0 .getTypes().get(1);
+        this.field0 = arrayElemOptionSchema0 .getField("field").schema();
     }
 
     public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        List<IndexedRecord> array622 = null;
-        long chunkLen623 = (decoder.readArrayStart());
-        if (chunkLen623 > 0) {
-            List<IndexedRecord> arrayReuse624 = null;
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse624 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse624 != (null)) {
-                arrayReuse624 .clear();
-                array622 = arrayReuse624;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen623), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter625 = 0; (counter625 <chunkLen623); counter625 ++) {
-                    Object arrayArrayElementReuseVar627 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar627 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    int unionIndex628 = (decoder.readIndex());
-                    if (unionIndex628 == 0) {
+                    int unionIndex0 = (decoder.readIndex());
+                    if (unionIndex0 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex628 == 1) {
-                        array622 .add(deserializerecord630(arrayArrayElementReuseVar627, (decoder)));
+                    if (unionIndex0 == 1) {
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                     }
                 }
-                chunkLen623 = (decoder.arrayNext());
-            } while (chunkLen623 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
         }
-        return array622;
+        return array0;
     }
 
-    public IndexedRecord deserializerecord630(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema629)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema629);
+            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema0);
         }
-        int unionIndex632 = (decoder.readIndex());
-        if (unionIndex632 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex632 == 1) {
+        if (unionIndex1 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -15,61 +15,61 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
 {
 
     private final Schema readerSchema;
-    private final Schema arrayArrayElemSchema617;
-    private final Schema field620;
+    private final Schema arrayArrayElemSchema0;
+    private final Schema field0;
 
     public Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.arrayArrayElemSchema617 = readerSchema.getElementType();
-        this.field620 = arrayArrayElemSchema617 .getField("field").schema();
+        this.arrayArrayElemSchema0 = readerSchema.getElementType();
+        this.field0 = arrayArrayElemSchema0 .getField("field").schema();
     }
 
     public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        List<IndexedRecord> array613 = null;
-        long chunkLen614 = (decoder.readArrayStart());
-        if (chunkLen614 > 0) {
-            List<IndexedRecord> arrayReuse615 = null;
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse615 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse615 != (null)) {
-                arrayReuse615 .clear();
-                array613 = arrayReuse615;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen614), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter616 = 0; (counter616 <chunkLen614); counter616 ++) {
-                    Object arrayArrayElementReuseVar618 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar618 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array613 .add(deserializerecord619(arrayArrayElementReuseVar618, (decoder)));
+                    array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen614 = (decoder.arrayNext());
-            } while (chunkLen614 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
         }
-        return array613;
+        return array0;
     }
 
-    public IndexedRecord deserializerecord619(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema617)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema617);
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
         }
-        int unionIndex621 = (decoder.readIndex());
-        if (unionIndex621 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex621 == 1) {
+        if (unionIndex0 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
@@ -13,22 +13,22 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
 {
 
     private final Schema readerSchema;
-    private final Schema testString588;
-    private final Schema testStringUnionAlias590;
+    private final Schema testString0;
+    private final Schema testStringUnionAlias0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testString588 = readerSchema.getField("testString").schema();
-        this.testStringUnionAlias590 = readerSchema.getField("testStringUnionAlias").schema();
+        this.testString0 = readerSchema.getField("testString").schema();
+        this.testStringUnionAlias0 = readerSchema.getField("testStringUnionAlias").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
@@ -37,22 +37,22 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadAliasedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex589 = (decoder.readIndex());
-        if (unionIndex589 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex589 == 1) {
+        if (unionIndex0 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex591 = (decoder.readIndex());
-        if (unionIndex591 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex591 == 1) {
+        if (unionIndex1 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -14,28 +14,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
 {
 
     private final Schema readerSchema;
-    private final Schema testEnum634;
-    private final Schema testEnumUnion635;
-    private final Schema testEnumArray637;
-    private final Schema testEnumUnionArray643;
-    private final Schema testEnumUnionArrayArrayElemSchema648;
+    private final Schema testEnum0;
+    private final Schema testEnumUnion0;
+    private final Schema testEnumArray0;
+    private final Schema testEnumUnionArray0;
+    private final Schema testEnumUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testEnum634 = readerSchema.getField("testEnum").schema();
-        this.testEnumUnion635 = readerSchema.getField("testEnumUnion").schema();
-        this.testEnumArray637 = readerSchema.getField("testEnumArray").schema();
-        this.testEnumUnionArray643 = readerSchema.getField("testEnumUnionArray").schema();
-        this.testEnumUnionArrayArrayElemSchema648 = testEnumUnionArray643 .getElementType();
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion0 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray0 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray0 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
@@ -44,74 +44,74 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
-        int unionIndex636 = (decoder.readIndex());
-        if (unionIndex636 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex636 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray638 = null;
-        long chunkLen639 = (decoder.readArrayStart());
-        if (chunkLen639 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse640 = null;
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
-                testEnumArrayReuse640 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+                testEnumArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
             }
-            if (testEnumArrayReuse640 != (null)) {
-                testEnumArrayReuse640 .clear();
-                testEnumArray638 = testEnumArrayReuse640;
+            if (testEnumArrayReuse0 != (null)) {
+                testEnumArrayReuse0 .clear();
+                testEnumArray1 = testEnumArrayReuse0;
             } else {
-                testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen639), testEnumArray637);
+                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
             }
             do {
-                for (int counter641 = 0; (counter641 <chunkLen639); counter641 ++) {
-                    Object testEnumArrayArrayElementReuseVar642 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testEnumArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof GenericArray) {
-                        testEnumArrayArrayElementReuseVar642 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
+                        testEnumArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
                     }
-                    testEnumArray638 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                    testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                 }
-                chunkLen639 = (decoder.arrayNext());
-            } while (chunkLen639 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray637);
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray638);
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray644 = null;
-        long chunkLen645 = (decoder.readArrayStart());
-        if (chunkLen645 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse646 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
-                testEnumUnionArrayReuse646 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+                testEnumUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
             }
-            if (testEnumUnionArrayReuse646 != (null)) {
-                testEnumUnionArrayReuse646 .clear();
-                testEnumUnionArray644 = testEnumUnionArrayReuse646;
+            if (testEnumUnionArrayReuse0 != (null)) {
+                testEnumUnionArrayReuse0 .clear();
+                testEnumUnionArray1 = testEnumUnionArrayReuse0;
             } else {
-                testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen645), testEnumUnionArray643);
+                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
             }
             do {
-                for (int counter647 = 0; (counter647 <chunkLen645); counter647 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar649 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar649 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
                     }
-                    int unionIndex650 = (decoder.readIndex());
-                    if (unionIndex650 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex650 == 1) {
-                        testEnumUnionArray644 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                    if (unionIndex1 == 1) {
+                        testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                     }
                 }
-                chunkLen645 = (decoder.arrayNext());
-            } while (chunkLen645 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray643);
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray644);
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -15,26 +15,26 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
 {
 
     private final Schema readerSchema;
-    private final Schema testFixedUnion653;
-    private final Schema testFixedArray656;
-    private final Schema testFixedUnionArray663;
-    private final Schema testFixedUnionArrayArrayElemSchema668;
+    private final Schema testFixedUnion0;
+    private final Schema testFixedArray0;
+    private final Schema testFixedUnionArray0;
+    private final Schema testFixedUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testFixedUnion653 = readerSchema.getField("testFixedUnion").schema();
-        this.testFixedArray656 = readerSchema.getField("testFixedArray").schema();
-        this.testFixedUnionArray663 = readerSchema.getField("testFixedUnionArray").schema();
-        this.testFixedUnionArrayArrayElemSchema668 = testFixedUnionArray663 .getElementType();
+        this.testFixedUnion0 = readerSchema.getField("testFixedUnion").schema();
+        this.testFixedArray0 = readerSchema.getField("testFixedArray").schema();
+        this.testFixedUnionArray0 = readerSchema.getField("testFixedUnionArray").schema();
+        this.testFixedUnionArrayArrayElemSchema0 = testFixedUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
@@ -43,102 +43,102 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadFixed = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        byte[] testFixed652;
+        byte[] testFixed0;
         if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes().length == (2))) {
-            testFixed652 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
+            testFixed0 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
         } else {
-            testFixed652 = ( new byte[2]);
+            testFixed0 = ( new byte[2]);
         }
-        decoder.readFixed(testFixed652);
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(null, testFixed652));
-        int unionIndex654 = (decoder.readIndex());
-        if (unionIndex654 == 0) {
+        decoder.readFixed(testFixed0);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(null, testFixed0));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex654 == 1) {
-            byte[] testFixed655;
+        if (unionIndex0 == 1) {
+            byte[] testFixed1;
             if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes().length == (2))) {
-                testFixed655 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
+                testFixed1 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
             } else {
-                testFixed655 = ( new byte[2]);
+                testFixed1 = ( new byte[2]);
             }
-            decoder.readFixed(testFixed655);
-            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(null, testFixed655));
+            decoder.readFixed(testFixed1);
+            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(null, testFixed1));
         }
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray657 = null;
-        long chunkLen658 = (decoder.readArrayStart());
-        if (chunkLen658 > 0) {
-            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse659 = null;
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
-                testFixedArrayReuse659 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+                testFixedArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
             }
-            if (testFixedArrayReuse659 != (null)) {
-                testFixedArrayReuse659 .clear();
-                testFixedArray657 = testFixedArrayReuse659;
+            if (testFixedArrayReuse0 != (null)) {
+                testFixedArrayReuse0 .clear();
+                testFixedArray1 = testFixedArrayReuse0;
             } else {
-                testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen658), testFixedArray656);
+                testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
             }
             do {
-                for (int counter660 = 0; (counter660 <chunkLen658); counter660 ++) {
-                    Object testFixedArrayArrayElementReuseVar661 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testFixedArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
-                        testFixedArrayArrayElementReuseVar661 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                        testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
                     }
-                    byte[] testFixed662;
-                    if ((testFixedArrayArrayElementReuseVar661 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes().length == (2))) {
-                        testFixed662 = ((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes();
+                    byte[] testFixed2;
+                    if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
+                        testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
                     } else {
-                        testFixed662 = ( new byte[2]);
+                        testFixed2 = ( new byte[2]);
                     }
-                    decoder.readFixed(testFixed662);
-                    testFixedArray657 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed662));
+                    decoder.readFixed(testFixed2);
+                    testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed2));
                 }
-                chunkLen658 = (decoder.arrayNext());
-            } while (chunkLen658 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray656);
+            testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray657);
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray664 = null;
-        long chunkLen665 = (decoder.readArrayStart());
-        if (chunkLen665 > 0) {
-            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse666 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
-                testFixedUnionArrayReuse666 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+                testFixedUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
             }
-            if (testFixedUnionArrayReuse666 != (null)) {
-                testFixedUnionArrayReuse666 .clear();
-                testFixedUnionArray664 = testFixedUnionArrayReuse666;
+            if (testFixedUnionArrayReuse0 != (null)) {
+                testFixedUnionArrayReuse0 .clear();
+                testFixedUnionArray1 = testFixedUnionArrayReuse0;
             } else {
-                testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen665), testFixedUnionArray663);
+                testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
             }
             do {
-                for (int counter667 = 0; (counter667 <chunkLen665); counter667 ++) {
-                    Object testFixedUnionArrayArrayElementReuseVar669 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testFixedUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
-                        testFixedUnionArrayArrayElementReuseVar669 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                        testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
                     }
-                    int unionIndex670 = (decoder.readIndex());
-                    if (unionIndex670 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex670 == 1) {
-                        byte[] testFixed671;
-                        if ((testFixedUnionArrayArrayElementReuseVar669 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes().length == (2))) {
-                            testFixed671 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes();
+                    if (unionIndex1 == 1) {
+                        byte[] testFixed3;
+                        if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
+                            testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
                         } else {
-                            testFixed671 = ( new byte[2]);
+                            testFixed3 = ( new byte[2]);
                         }
-                        decoder.readFixed(testFixed671);
-                        testFixedUnionArray664 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed671));
+                        decoder.readFixed(testFixed3);
+                        testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed3));
                     }
                 }
-                chunkLen665 = (decoder.arrayNext());
-            } while (chunkLen665 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray663);
+            testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray664);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
@@ -13,24 +13,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
 {
 
     private final Schema readerSchema;
-    private final Schema union729;
-    private final Schema unionOptionSchema731;
-    private final Schema subField733;
+    private final Schema union0;
+    private final Schema unionOptionSchema0;
+    private final Schema subField0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.union729 = readerSchema.getField("union").schema();
-        this.unionOptionSchema731 = union729 .getTypes().get(1);
-        this.subField733 = unionOptionSchema731 .getField("subField").schema();
+        this.union0 = readerSchema.getField("union").schema();
+        this.unionOptionSchema0 = union0 .getTypes().get(1);
+        this.subField0 = unionOptionSchema0 .getField("subField").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
@@ -39,21 +39,21 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex730 = (decoder.readIndex());
-        if (unionIndex730 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex730 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord732(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
         } else {
-            if (unionIndex730 == 2) {
+            if (unionIndex0 == 2) {
                 if (FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0) instanceof Utf8) {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0))));
                 } else {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(null));
                 }
             } else {
-                if (unionIndex730 == 3) {
+                if (unionIndex0 == 3) {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
                 }
             }
@@ -61,20 +61,20 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
     }
 
-    public IndexedRecord deserializesubRecord732(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema731)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema731);
+            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema0);
         }
-        int unionIndex734 = (decoder.readIndex());
-        if (unionIndex734 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex734 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -18,24 +18,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
 {
 
     private final Schema readerSchema;
-    private final Schema mapField736;
-    private final Schema mapFieldMapValueSchema742;
-    private final Schema mapFieldValueMapValueSchema748;
+    private final Schema mapField0;
+    private final Schema mapFieldMapValueSchema0;
+    private final Schema mapFieldValueMapValueSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapField736 = readerSchema.getField("mapField").schema();
-        this.mapFieldMapValueSchema742 = mapField736 .getValueType();
-        this.mapFieldValueMapValueSchema748 = mapFieldMapValueSchema742 .getValueType();
+        this.mapField0 = readerSchema.getField("mapField").schema();
+        this.mapFieldMapValueSchema0 = mapField0 .getValueType();
+        this.mapFieldValueMapValueSchema0 = mapFieldMapValueSchema0 .getValueType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
@@ -44,79 +44,79 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadNestedMap = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        Map<Utf8, Map<Utf8, List<Integer>>> mapField737 = null;
-        long chunkLen738 = (decoder.readMapStart());
-        if (chunkLen738 > 0) {
-            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse739 = null;
+        Map<Utf8, Map<Utf8, List<Integer>>> mapField1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0) instanceof Map) {
-                mapFieldReuse739 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
+                mapFieldReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
             }
-            if (mapFieldReuse739 != (null)) {
-                mapFieldReuse739 .clear();
-                mapField737 = mapFieldReuse739;
+            if (mapFieldReuse0 != (null)) {
+                mapFieldReuse0 .clear();
+                mapField1 = mapFieldReuse0;
             } else {
-                mapField737 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
+                mapField1 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
             }
             do {
-                for (int counter740 = 0; (counter740 <chunkLen738); counter740 ++) {
-                    Utf8 key741 = (decoder.readString(null));
-                    Map<Utf8, List<Integer>> mapFieldValue743 = null;
-                    long chunkLen744 = (decoder.readMapStart());
-                    if (chunkLen744 > 0) {
-                        Map<Utf8, List<Integer>> mapFieldValueReuse745 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    Map<Utf8, List<Integer>> mapFieldValue0 = null;
+                    long chunkLen1 = (decoder.readMapStart());
+                    if (chunkLen1 > 0) {
+                        Map<Utf8, List<Integer>> mapFieldValueReuse0 = null;
                         if (null instanceof Map) {
-                            mapFieldValueReuse745 = ((Map) null);
+                            mapFieldValueReuse0 = ((Map) null);
                         }
-                        if (mapFieldValueReuse745 != (null)) {
-                            mapFieldValueReuse745 .clear();
-                            mapFieldValue743 = mapFieldValueReuse745;
+                        if (mapFieldValueReuse0 != (null)) {
+                            mapFieldValueReuse0 .clear();
+                            mapFieldValue0 = mapFieldValueReuse0;
                         } else {
-                            mapFieldValue743 = new HashMap<Utf8, List<Integer>>();
+                            mapFieldValue0 = new HashMap<Utf8, List<Integer>>();
                         }
                         do {
-                            for (int counter746 = 0; (counter746 <chunkLen744); counter746 ++) {
-                                Utf8 key747 = (decoder.readString(null));
-                                List<Integer> mapFieldValueValue749 = null;
-                                long chunkLen750 = (decoder.readArrayStart());
-                                if (chunkLen750 > 0) {
-                                    List<Integer> mapFieldValueValueReuse751 = null;
+                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                                Utf8 key1 = (decoder.readString(null));
+                                List<Integer> mapFieldValueValue0 = null;
+                                long chunkLen2 = (decoder.readArrayStart());
+                                if (chunkLen2 > 0) {
+                                    List<Integer> mapFieldValueValueReuse0 = null;
                                     if (null instanceof List) {
-                                        mapFieldValueValueReuse751 = ((List) null);
+                                        mapFieldValueValueReuse0 = ((List) null);
                                     }
-                                    if (mapFieldValueValueReuse751 != (null)) {
-                                        mapFieldValueValueReuse751 .clear();
-                                        mapFieldValueValue749 = mapFieldValueValueReuse751;
+                                    if (mapFieldValueValueReuse0 != (null)) {
+                                        mapFieldValueValueReuse0 .clear();
+                                        mapFieldValueValue0 = mapFieldValueValueReuse0;
                                     } else {
-                                        mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen750), mapFieldValueMapValueSchema748);
+                                        mapFieldValueValue0 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen2), mapFieldValueMapValueSchema0);
                                     }
                                     do {
-                                        for (int counter752 = 0; (counter752 <chunkLen750); counter752 ++) {
-                                            Object mapFieldValueValueArrayElementReuseVar753 = null;
+                                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                                            Object mapFieldValueValueArrayElementReuseVar0 = null;
                                             if (null instanceof GenericArray) {
-                                                mapFieldValueValueArrayElementReuseVar753 = ((GenericArray) null).peek();
+                                                mapFieldValueValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                             }
-                                            mapFieldValueValue749 .add((decoder.readInt()));
+                                            mapFieldValueValue0 .add((decoder.readInt()));
                                         }
-                                        chunkLen750 = (decoder.arrayNext());
-                                    } while (chunkLen750 > 0);
+                                        chunkLen2 = (decoder.arrayNext());
+                                    } while (chunkLen2 > 0);
                                 } else {
-                                    mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema748);
+                                    mapFieldValueValue0 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema0);
                                 }
-                                mapFieldValue743 .put(key747, mapFieldValueValue749);
+                                mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }
-                            chunkLen744 = (decoder.mapNext());
-                        } while (chunkLen744 > 0);
+                            chunkLen1 = (decoder.mapNext());
+                        } while (chunkLen1 > 0);
                     } else {
-                        mapFieldValue743 = Collections.emptyMap();
+                        mapFieldValue0 = Collections.emptyMap();
                     }
-                    mapField737 .put(key741, mapFieldValue743);
+                    mapField1 .put(key0, mapFieldValue0);
                 }
-                chunkLen738 = (decoder.mapNext());
-            } while (chunkLen738 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            mapField737 = Collections.emptyMap();
+            mapField1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField737);
+        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField1);
         return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -14,28 +14,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
 {
 
     private final Schema readerSchema;
-    private final Schema testEnum755;
-    private final Schema testEnumUnion758;
-    private final Schema testEnumArray762;
-    private final Schema testEnumUnionArray770;
-    private final Schema testEnumUnionArrayArrayElemSchema775;
+    private final Schema testEnum0;
+    private final Schema testEnumUnion0;
+    private final Schema testEnumArray0;
+    private final Schema testEnumUnionArray0;
+    private final Schema testEnumUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testEnum755 = readerSchema.getField("testEnum").schema();
-        this.testEnumUnion758 = readerSchema.getField("testEnumUnion").schema();
-        this.testEnumArray762 = readerSchema.getField("testEnumArray").schema();
-        this.testEnumUnionArray770 = readerSchema.getField("testEnumUnionArray").schema();
-        this.testEnumUnionArrayArrayElemSchema775 = testEnumUnionArray770 .getElementType();
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion0 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray0 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray0 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
@@ -44,142 +44,142 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int enumIndex756 = (decoder.readEnum());
-        org.apache.avro.generic.GenericData.EnumSymbol enumValue757 = null;
-        if (enumIndex756 == 0) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        if (enumIndex0 == 0) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
         }
-        if (enumIndex756 == 1) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+        if (enumIndex0 == 1) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
         }
-        if (enumIndex756 == 2) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+        if (enumIndex0 == 2) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
         }
-        if (enumIndex756 == 3) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+        if (enumIndex0 == 3) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
         }
-        if (enumIndex756 == 4) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+        if (enumIndex0 == 4) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue757);
-        int unionIndex759 = (decoder.readIndex());
-        if (unionIndex759 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex759 == 1) {
-            int enumIndex760 = (decoder.readEnum());
-            org.apache.avro.generic.GenericData.EnumSymbol enumValue761 = null;
-            if (enumIndex760 == 0) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+        if (unionIndex0 == 1) {
+            int enumIndex1 = (decoder.readEnum());
+            org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
+            if (enumIndex1 == 0) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
             }
-            if (enumIndex760 == 1) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+            if (enumIndex1 == 1) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
             }
-            if (enumIndex760 == 2) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+            if (enumIndex1 == 2) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
             }
-            if (enumIndex760 == 3) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+            if (enumIndex1 == 3) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
             }
-            if (enumIndex760 == 4) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+            if (enumIndex1 == 4) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
             }
-            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue761);
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray763 = null;
-        long chunkLen764 = (decoder.readArrayStart());
-        if (chunkLen764 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse765 = null;
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
-                testEnumArrayReuse765 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+                testEnumArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
             }
-            if (testEnumArrayReuse765 != (null)) {
-                testEnumArrayReuse765 .clear();
-                testEnumArray763 = testEnumArrayReuse765;
+            if (testEnumArrayReuse0 != (null)) {
+                testEnumArrayReuse0 .clear();
+                testEnumArray1 = testEnumArrayReuse0;
             } else {
-                testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen764), testEnumArray762);
+                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
             }
             do {
-                for (int counter766 = 0; (counter766 <chunkLen764); counter766 ++) {
-                    Object testEnumArrayArrayElementReuseVar767 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testEnumArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof GenericArray) {
-                        testEnumArrayArrayElementReuseVar767 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
+                        testEnumArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
                     }
-                    int enumIndex768 = (decoder.readEnum());
-                    org.apache.avro.generic.GenericData.EnumSymbol enumValue769 = null;
-                    if (enumIndex768 == 0) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                    int enumIndex2 = (decoder.readEnum());
+                    org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
+                    if (enumIndex2 == 0) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
                     }
-                    if (enumIndex768 == 1) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                    if (enumIndex2 == 1) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                     }
-                    if (enumIndex768 == 2) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                    if (enumIndex2 == 2) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                     }
-                    if (enumIndex768 == 3) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                    if (enumIndex2 == 3) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                     }
-                    if (enumIndex768 == 4) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                    if (enumIndex2 == 4) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                     }
-                    testEnumArray763 .add(enumValue769);
+                    testEnumArray1 .add(enumValue2);
                 }
-                chunkLen764 = (decoder.arrayNext());
-            } while (chunkLen764 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray762);
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray763);
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray771 = null;
-        long chunkLen772 = (decoder.readArrayStart());
-        if (chunkLen772 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse773 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
-                testEnumUnionArrayReuse773 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+                testEnumUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
             }
-            if (testEnumUnionArrayReuse773 != (null)) {
-                testEnumUnionArrayReuse773 .clear();
-                testEnumUnionArray771 = testEnumUnionArrayReuse773;
+            if (testEnumUnionArrayReuse0 != (null)) {
+                testEnumUnionArrayReuse0 .clear();
+                testEnumUnionArray1 = testEnumUnionArrayReuse0;
             } else {
-                testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen772), testEnumUnionArray770);
+                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
             }
             do {
-                for (int counter774 = 0; (counter774 <chunkLen772); counter774 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar776 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar776 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
                     }
-                    int unionIndex777 = (decoder.readIndex());
-                    if (unionIndex777 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex777 == 1) {
-                        int enumIndex778 = (decoder.readEnum());
-                        org.apache.avro.generic.GenericData.EnumSymbol enumValue779 = null;
-                        if (enumIndex778 == 0) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                    if (unionIndex1 == 1) {
+                        int enumIndex3 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
+                        if (enumIndex3 == 0) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
                         }
-                        if (enumIndex778 == 1) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                        if (enumIndex3 == 1) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                         }
-                        if (enumIndex778 == 2) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                        if (enumIndex3 == 2) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                         }
-                        if (enumIndex778 == 3) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                        if (enumIndex3 == 3) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                         }
-                        if (enumIndex778 == 4) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                        if (enumIndex3 == 4) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                         }
-                        testEnumUnionArray771 .add(enumValue779);
+                        testEnumUnionArray1 .add(enumValue3);
                     }
                 }
-                chunkLen772 = (decoder.arrayNext());
-            } while (chunkLen772 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray770);
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray771);
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
@@ -14,32 +14,32 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
 {
 
     private final Schema readerSchema;
-    private final Schema testIntUnion781;
-    private final Schema testStringUnion783;
-    private final Schema testLongUnion785;
-    private final Schema testDoubleUnion787;
-    private final Schema testFloatUnion789;
-    private final Schema testBooleanUnion791;
-    private final Schema testBytesUnion793;
+    private final Schema testIntUnion0;
+    private final Schema testStringUnion0;
+    private final Schema testLongUnion0;
+    private final Schema testDoubleUnion0;
+    private final Schema testFloatUnion0;
+    private final Schema testBooleanUnion0;
+    private final Schema testBytesUnion0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testIntUnion781 = readerSchema.getField("testIntUnion").schema();
-        this.testStringUnion783 = readerSchema.getField("testStringUnion").schema();
-        this.testLongUnion785 = readerSchema.getField("testLongUnion").schema();
-        this.testDoubleUnion787 = readerSchema.getField("testDoubleUnion").schema();
-        this.testFloatUnion789 = readerSchema.getField("testFloatUnion").schema();
-        this.testBooleanUnion791 = readerSchema.getField("testBooleanUnion").schema();
-        this.testBytesUnion793 = readerSchema.getField("testBytesUnion").schema();
+        this.testIntUnion0 = readerSchema.getField("testIntUnion").schema();
+        this.testStringUnion0 = readerSchema.getField("testStringUnion").schema();
+        this.testLongUnion0 = readerSchema.getField("testLongUnion").schema();
+        this.testDoubleUnion0 = readerSchema.getField("testDoubleUnion").schema();
+        this.testFloatUnion0 = readerSchema.getField("testFloatUnion").schema();
+        this.testBooleanUnion0 = readerSchema.getField("testBooleanUnion").schema();
+        this.testBytesUnion0 = readerSchema.getField("testBytesUnion").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
@@ -49,11 +49,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
-        int unionIndex782 = (decoder.readIndex());
-        if (unionIndex782 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex782 == 1) {
+        if (unionIndex0 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
         }
         if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2) instanceof Utf8) {
@@ -61,11 +61,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(null));
         }
-        int unionIndex784 = (decoder.readIndex());
-        if (unionIndex784 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex784 == 1) {
+        if (unionIndex1 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3))));
             } else {
@@ -73,35 +73,35 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             }
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
-        int unionIndex786 = (decoder.readIndex());
-        if (unionIndex786 == 0) {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex786 == 1) {
+        if (unionIndex2 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
-        int unionIndex788 = (decoder.readIndex());
-        if (unionIndex788 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex788 == 1) {
+        if (unionIndex3 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
-        int unionIndex790 = (decoder.readIndex());
-        if (unionIndex790 == 0) {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
             decoder.readNull();
         }
-        if (unionIndex790 == 1) {
+        if (unionIndex4 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
-        int unionIndex792 = (decoder.readIndex());
-        if (unionIndex792 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex792 == 1) {
+        if (unionIndex5 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
         }
         if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12) instanceof ByteBuffer) {
@@ -109,11 +109,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes((null)));
         }
-        int unionIndex794 = (decoder.readIndex());
-        if (unionIndex794 == 0) {
+        int unionIndex6 = (decoder.readIndex());
+        if (unionIndex6 == 0) {
             decoder.readNull();
         }
-        if (unionIndex794 == 1) {
+        if (unionIndex6 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13) instanceof ByteBuffer) {
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -18,38 +18,38 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
 {
 
     private final Schema readerSchema;
-    private final Schema recordsArray799;
-    private final Schema recordsArrayArrayElemSchema804;
-    private final Schema subField807;
-    private final Schema recordsMap809;
-    private final Schema recordsArrayUnion815;
-    private final Schema recordsArrayUnionOptionSchema817;
-    private final Schema recordsArrayUnionOptionArrayElemSchema822;
-    private final Schema recordsMapUnion825;
-    private final Schema recordsMapUnionOptionSchema827;
-    private final Schema recordsMapUnionOptionMapValueSchema833;
+    private final Schema recordsArray0;
+    private final Schema recordsArrayArrayElemSchema0;
+    private final Schema subField0;
+    private final Schema recordsMap0;
+    private final Schema recordsArrayUnion0;
+    private final Schema recordsArrayUnionOptionSchema0;
+    private final Schema recordsArrayUnionOptionArrayElemSchema0;
+    private final Schema recordsMapUnion0;
+    private final Schema recordsMapUnionOptionSchema0;
+    private final Schema recordsMapUnionOptionMapValueSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.recordsArray799 = readerSchema.getField("recordsArray").schema();
-        this.recordsArrayArrayElemSchema804 = recordsArray799 .getElementType();
-        this.subField807 = recordsArrayArrayElemSchema804 .getField("subField").schema();
-        this.recordsMap809 = readerSchema.getField("recordsMap").schema();
-        this.recordsArrayUnion815 = readerSchema.getField("recordsArrayUnion").schema();
-        this.recordsArrayUnionOptionSchema817 = recordsArrayUnion815 .getTypes().get(1);
-        this.recordsArrayUnionOptionArrayElemSchema822 = recordsArrayUnionOptionSchema817 .getElementType();
-        this.recordsMapUnion825 = readerSchema.getField("recordsMapUnion").schema();
-        this.recordsMapUnionOptionSchema827 = recordsMapUnion825 .getTypes().get(1);
-        this.recordsMapUnionOptionMapValueSchema833 = recordsMapUnionOptionSchema827 .getValueType();
+        this.recordsArray0 = readerSchema.getField("recordsArray").schema();
+        this.recordsArrayArrayElemSchema0 = recordsArray0 .getElementType();
+        this.subField0 = recordsArrayArrayElemSchema0 .getField("subField").schema();
+        this.recordsMap0 = readerSchema.getField("recordsMap").schema();
+        this.recordsArrayUnion0 = readerSchema.getField("recordsArrayUnion").schema();
+        this.recordsArrayUnionOptionSchema0 = recordsArrayUnion0 .getTypes().get(1);
+        this.recordsArrayUnionOptionArrayElemSchema0 = recordsArrayUnionOptionSchema0 .getElementType();
+        this.recordsMapUnion0 = readerSchema.getField("recordsMapUnion").schema();
+        this.recordsMapUnionOptionSchema0 = recordsMapUnion0 .getTypes().get(1);
+        this.recordsMapUnionOptionMapValueSchema0 = recordsMapUnionOptionSchema0 .getValueType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
@@ -58,149 +58,149 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        List<IndexedRecord> recordsArray800 = null;
-        long chunkLen801 = (decoder.readArrayStart());
-        if (chunkLen801 > 0) {
-            List<IndexedRecord> recordsArrayReuse802 = null;
+        List<IndexedRecord> recordsArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> recordsArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
-                recordsArrayReuse802 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+                recordsArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
             }
-            if (recordsArrayReuse802 != (null)) {
-                recordsArrayReuse802 .clear();
-                recordsArray800 = recordsArrayReuse802;
+            if (recordsArrayReuse0 != (null)) {
+                recordsArrayReuse0 .clear();
+                recordsArray1 = recordsArrayReuse0;
             } else {
-                recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen801), recordsArray799);
+                recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
             }
             do {
-                for (int counter803 = 0; (counter803 <chunkLen801); counter803 ++) {
-                    Object recordsArrayArrayElementReuseVar805 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object recordsArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayArrayElementReuseVar805 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                        recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
                     }
-                    recordsArray800 .add(deserializesubRecord806(recordsArrayArrayElementReuseVar805, (decoder)));
+                    recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen801 = (decoder.arrayNext());
-            } while (chunkLen801 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray799);
+            recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray800);
-        Map<Utf8, IndexedRecord> recordsMap810 = null;
-        long chunkLen811 = (decoder.readMapStart());
-        if (chunkLen811 > 0) {
-            Map<Utf8, IndexedRecord> recordsMapReuse812 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
+        Map<Utf8, IndexedRecord> recordsMap1 = null;
+        long chunkLen1 = (decoder.readMapStart());
+        if (chunkLen1 > 0) {
+            Map<Utf8, IndexedRecord> recordsMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1) instanceof Map) {
-                recordsMapReuse812 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
+                recordsMapReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
             }
-            if (recordsMapReuse812 != (null)) {
-                recordsMapReuse812 .clear();
-                recordsMap810 = recordsMapReuse812;
+            if (recordsMapReuse0 != (null)) {
+                recordsMapReuse0 .clear();
+                recordsMap1 = recordsMapReuse0;
             } else {
-                recordsMap810 = new HashMap<Utf8, IndexedRecord>();
+                recordsMap1 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter813 = 0; (counter813 <chunkLen811); counter813 ++) {
-                    Utf8 key814 = (decoder.readString(null));
-                    recordsMap810 .put(key814, deserializesubRecord806(null, (decoder)));
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    recordsMap1 .put(key0, deserializesubRecord0(null, (decoder)));
                 }
-                chunkLen811 = (decoder.mapNext());
-            } while (chunkLen811 > 0);
+                chunkLen1 = (decoder.mapNext());
+            } while (chunkLen1 > 0);
         } else {
-            recordsMap810 = Collections.emptyMap();
+            recordsMap1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap810);
-        int unionIndex816 = (decoder.readIndex());
-        if (unionIndex816 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap1);
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex816 == 1) {
-            List<IndexedRecord> recordsArrayUnionOption818 = null;
-            long chunkLen819 = (decoder.readArrayStart());
-            if (chunkLen819 > 0) {
-                List<IndexedRecord> recordsArrayUnionOptionReuse820 = null;
+        if (unionIndex1 == 1) {
+            List<IndexedRecord> recordsArrayUnionOption0 = null;
+            long chunkLen2 = (decoder.readArrayStart());
+            if (chunkLen2 > 0) {
+                List<IndexedRecord> recordsArrayUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
-                    recordsArrayUnionOptionReuse820 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                    recordsArrayUnionOptionReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
                 }
-                if (recordsArrayUnionOptionReuse820 != (null)) {
-                    recordsArrayUnionOptionReuse820 .clear();
-                    recordsArrayUnionOption818 = recordsArrayUnionOptionReuse820;
+                if (recordsArrayUnionOptionReuse0 != (null)) {
+                    recordsArrayUnionOptionReuse0 .clear();
+                    recordsArrayUnionOption0 = recordsArrayUnionOptionReuse0;
                 } else {
-                    recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen819), recordsArrayUnionOptionSchema817);
+                    recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
                 }
                 do {
-                    for (int counter821 = 0; (counter821 <chunkLen819); counter821 ++) {
-                        Object recordsArrayUnionOptionArrayElementReuseVar823 = null;
+                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
                         if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
-                            recordsArrayUnionOptionArrayElementReuseVar823 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                            recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
                         }
-                        int unionIndex824 = (decoder.readIndex());
-                        if (unionIndex824 == 0) {
+                        int unionIndex2 = (decoder.readIndex());
+                        if (unionIndex2 == 0) {
                             decoder.readNull();
                         }
-                        if (unionIndex824 == 1) {
-                            recordsArrayUnionOption818 .add(deserializesubRecord806(recordsArrayUnionOptionArrayElementReuseVar823, (decoder)));
+                        if (unionIndex2 == 1) {
+                            recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
                         }
                     }
-                    chunkLen819 = (decoder.arrayNext());
-                } while (chunkLen819 > 0);
+                    chunkLen2 = (decoder.arrayNext());
+                } while (chunkLen2 > 0);
             } else {
-                recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema817);
+                recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema0);
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption818);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption0);
         }
-        int unionIndex826 = (decoder.readIndex());
-        if (unionIndex826 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex826 == 1) {
-            Map<Utf8, IndexedRecord> recordsMapUnionOption828 = null;
-            long chunkLen829 = (decoder.readMapStart());
-            if (chunkLen829 > 0) {
-                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse830 = null;
+        if (unionIndex3 == 1) {
+            Map<Utf8, IndexedRecord> recordsMapUnionOption0 = null;
+            long chunkLen3 = (decoder.readMapStart());
+            if (chunkLen3 > 0) {
+                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3) instanceof Map) {
-                    recordsMapUnionOptionReuse830 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
+                    recordsMapUnionOptionReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
                 }
-                if (recordsMapUnionOptionReuse830 != (null)) {
-                    recordsMapUnionOptionReuse830 .clear();
-                    recordsMapUnionOption828 = recordsMapUnionOptionReuse830;
+                if (recordsMapUnionOptionReuse0 != (null)) {
+                    recordsMapUnionOptionReuse0 .clear();
+                    recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
                 } else {
-                    recordsMapUnionOption828 = new HashMap<Utf8, IndexedRecord>();
+                    recordsMapUnionOption0 = new HashMap<Utf8, IndexedRecord>();
                 }
                 do {
-                    for (int counter831 = 0; (counter831 <chunkLen829); counter831 ++) {
-                        Utf8 key832 = (decoder.readString(null));
-                        int unionIndex834 = (decoder.readIndex());
-                        if (unionIndex834 == 0) {
+                    for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                        Utf8 key1 = (decoder.readString(null));
+                        int unionIndex4 = (decoder.readIndex());
+                        if (unionIndex4 == 0) {
                             decoder.readNull();
                         }
-                        if (unionIndex834 == 1) {
-                            recordsMapUnionOption828 .put(key832, deserializesubRecord806(null, (decoder)));
+                        if (unionIndex4 == 1) {
+                            recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder)));
                         }
                     }
-                    chunkLen829 = (decoder.mapNext());
-                } while (chunkLen829 > 0);
+                    chunkLen3 = (decoder.mapNext());
+                } while (chunkLen3 > 0);
             } else {
-                recordsMapUnionOption828 = Collections.emptyMap();
+                recordsMapUnionOption0 = Collections.emptyMap();
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption828);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption0);
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord806(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema804)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema804);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema0);
         }
-        int unionIndex808 = (decoder.readIndex());
-        if (unionIndex808 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex808 == 1) {
+        if (unionIndex0 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -18,46 +18,46 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
 {
 
     private final Schema readerSchema;
-    private final Schema recordsArrayMap836;
-    private final Schema recordsArrayMapArrayElemSchema841;
-    private final Schema recordsArrayMapElemMapValueSchema848;
-    private final Schema recordsArrayMapElemValueOptionSchema850;
-    private final Schema subField852;
-    private final Schema recordsMapArray854;
-    private final Schema recordsMapArrayMapValueSchema860;
-    private final Schema recordsMapArrayValueArrayElemSchema865;
-    private final Schema recordsArrayMapUnion868;
-    private final Schema recordsArrayMapUnionOptionArrayElemSchema874;
-    private final Schema recordsArrayMapUnionOptionElemMapValueSchema881;
-    private final Schema recordsMapArrayUnion883;
-    private final Schema recordsMapArrayUnionOptionSchema885;
-    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema895;
+    private final Schema recordsArrayMap0;
+    private final Schema recordsArrayMapArrayElemSchema0;
+    private final Schema recordsArrayMapElemMapValueSchema0;
+    private final Schema recordsArrayMapElemValueOptionSchema0;
+    private final Schema subField0;
+    private final Schema recordsMapArray0;
+    private final Schema recordsMapArrayMapValueSchema0;
+    private final Schema recordsMapArrayValueArrayElemSchema0;
+    private final Schema recordsArrayMapUnion0;
+    private final Schema recordsArrayMapUnionOptionArrayElemSchema0;
+    private final Schema recordsArrayMapUnionOptionElemMapValueSchema0;
+    private final Schema recordsMapArrayUnion0;
+    private final Schema recordsMapArrayUnionOptionSchema0;
+    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.recordsArrayMap836 = readerSchema.getField("recordsArrayMap").schema();
-        this.recordsArrayMapArrayElemSchema841 = recordsArrayMap836 .getElementType();
-        this.recordsArrayMapElemMapValueSchema848 = recordsArrayMapArrayElemSchema841 .getValueType();
-        this.recordsArrayMapElemValueOptionSchema850 = recordsArrayMapElemMapValueSchema848 .getTypes().get(1);
-        this.subField852 = recordsArrayMapElemValueOptionSchema850 .getField("subField").schema();
-        this.recordsMapArray854 = readerSchema.getField("recordsMapArray").schema();
-        this.recordsMapArrayMapValueSchema860 = recordsMapArray854 .getValueType();
-        this.recordsMapArrayValueArrayElemSchema865 = recordsMapArrayMapValueSchema860 .getElementType();
-        this.recordsArrayMapUnion868 = readerSchema.getField("recordsArrayMapUnion").schema();
-        this.recordsArrayMapUnionOptionArrayElemSchema874 = recordsArrayMap836 .getElementType();
-        this.recordsArrayMapUnionOptionElemMapValueSchema881 = recordsArrayMapUnionOptionArrayElemSchema874 .getValueType();
-        this.recordsMapArrayUnion883 = readerSchema.getField("recordsMapArrayUnion").schema();
-        this.recordsMapArrayUnionOptionSchema885 = recordsMapArrayUnion883 .getTypes().get(1);
-        this.recordsMapArrayUnionOptionValueArrayElemSchema895 = recordsMapArrayMapValueSchema860 .getElementType();
+        this.recordsArrayMap0 = readerSchema.getField("recordsArrayMap").schema();
+        this.recordsArrayMapArrayElemSchema0 = recordsArrayMap0 .getElementType();
+        this.recordsArrayMapElemMapValueSchema0 = recordsArrayMapArrayElemSchema0 .getValueType();
+        this.recordsArrayMapElemValueOptionSchema0 = recordsArrayMapElemMapValueSchema0 .getTypes().get(1);
+        this.subField0 = recordsArrayMapElemValueOptionSchema0 .getField("subField").schema();
+        this.recordsMapArray0 = readerSchema.getField("recordsMapArray").schema();
+        this.recordsMapArrayMapValueSchema0 = recordsMapArray0 .getValueType();
+        this.recordsMapArrayValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
+        this.recordsArrayMapUnion0 = readerSchema.getField("recordsArrayMapUnion").schema();
+        this.recordsArrayMapUnionOptionArrayElemSchema0 = recordsArrayMap0 .getElementType();
+        this.recordsArrayMapUnionOptionElemMapValueSchema0 = recordsArrayMapUnionOptionArrayElemSchema0 .getValueType();
+        this.recordsMapArrayUnion0 = readerSchema.getField("recordsMapArrayUnion").schema();
+        this.recordsMapArrayUnionOptionSchema0 = recordsMapArrayUnion0 .getTypes().get(1);
+        this.recordsMapArrayUnionOptionValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
@@ -66,259 +66,259 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        List<Map<Utf8, IndexedRecord>> recordsArrayMap837 = null;
-        long chunkLen838 = (decoder.readArrayStart());
-        if (chunkLen838 > 0) {
-            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse839 = null;
+        List<Map<Utf8, IndexedRecord>> recordsArrayMap1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
-                recordsArrayMapReuse839 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+                recordsArrayMapReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
             }
-            if (recordsArrayMapReuse839 != (null)) {
-                recordsArrayMapReuse839 .clear();
-                recordsArrayMap837 = recordsArrayMapReuse839;
+            if (recordsArrayMapReuse0 != (null)) {
+                recordsArrayMapReuse0 .clear();
+                recordsArrayMap1 = recordsArrayMapReuse0;
             } else {
-                recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen838), recordsArrayMap836);
+                recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
             }
             do {
-                for (int counter840 = 0; (counter840 <chunkLen838); counter840 ++) {
-                    Object recordsArrayMapArrayElementReuseVar842 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object recordsArrayMapArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayMapArrayElementReuseVar842 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                        recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
                     }
-                    Map<Utf8, IndexedRecord> recordsArrayMapElem843 = null;
-                    long chunkLen844 = (decoder.readMapStart());
-                    if (chunkLen844 > 0) {
-                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse845 = null;
-                        if (recordsArrayMapArrayElementReuseVar842 instanceof Map) {
-                            recordsArrayMapElemReuse845 = ((Map) recordsArrayMapArrayElementReuseVar842);
+                    Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
+                    long chunkLen1 = (decoder.readMapStart());
+                    if (chunkLen1 > 0) {
+                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
+                        if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
+                            recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
                         }
-                        if (recordsArrayMapElemReuse845 != (null)) {
-                            recordsArrayMapElemReuse845 .clear();
-                            recordsArrayMapElem843 = recordsArrayMapElemReuse845;
+                        if (recordsArrayMapElemReuse0 != (null)) {
+                            recordsArrayMapElemReuse0 .clear();
+                            recordsArrayMapElem0 = recordsArrayMapElemReuse0;
                         } else {
-                            recordsArrayMapElem843 = new HashMap<Utf8, IndexedRecord>();
+                            recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
                         }
                         do {
-                            for (int counter846 = 0; (counter846 <chunkLen844); counter846 ++) {
-                                Utf8 key847 = (decoder.readString(null));
-                                int unionIndex849 = (decoder.readIndex());
-                                if (unionIndex849 == 0) {
+                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                                Utf8 key0 = (decoder.readString(null));
+                                int unionIndex0 = (decoder.readIndex());
+                                if (unionIndex0 == 0) {
                                     decoder.readNull();
                                 }
-                                if (unionIndex849 == 1) {
-                                    recordsArrayMapElem843 .put(key847, deserializesubRecord851(null, (decoder)));
+                                if (unionIndex0 == 1) {
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
                                 }
                             }
-                            chunkLen844 = (decoder.mapNext());
-                        } while (chunkLen844 > 0);
+                            chunkLen1 = (decoder.mapNext());
+                        } while (chunkLen1 > 0);
                     } else {
-                        recordsArrayMapElem843 = Collections.emptyMap();
+                        recordsArrayMapElem0 = Collections.emptyMap();
                     }
-                    recordsArrayMap837 .add(recordsArrayMapElem843);
+                    recordsArrayMap1 .add(recordsArrayMapElem0);
                 }
-                chunkLen838 = (decoder.arrayNext());
-            } while (chunkLen838 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+            recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap837);
-        Map<Utf8, List<IndexedRecord>> recordsMapArray855 = null;
-        long chunkLen856 = (decoder.readMapStart());
-        if (chunkLen856 > 0) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse857 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
+        Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
+        long chunkLen2 = (decoder.readMapStart());
+        if (chunkLen2 > 0) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1) instanceof Map) {
-                recordsMapArrayReuse857 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
+                recordsMapArrayReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
             }
-            if (recordsMapArrayReuse857 != (null)) {
-                recordsMapArrayReuse857 .clear();
-                recordsMapArray855 = recordsMapArrayReuse857;
+            if (recordsMapArrayReuse0 != (null)) {
+                recordsMapArrayReuse0 .clear();
+                recordsMapArray1 = recordsMapArrayReuse0;
             } else {
-                recordsMapArray855 = new HashMap<Utf8, List<IndexedRecord>>();
+                recordsMapArray1 = new HashMap<Utf8, List<IndexedRecord>>();
             }
             do {
-                for (int counter858 = 0; (counter858 <chunkLen856); counter858 ++) {
-                    Utf8 key859 = (decoder.readString(null));
-                    List<IndexedRecord> recordsMapArrayValue861 = null;
-                    long chunkLen862 = (decoder.readArrayStart());
-                    if (chunkLen862 > 0) {
-                        List<IndexedRecord> recordsMapArrayValueReuse863 = null;
+                for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                    Utf8 key1 = (decoder.readString(null));
+                    List<IndexedRecord> recordsMapArrayValue0 = null;
+                    long chunkLen3 = (decoder.readArrayStart());
+                    if (chunkLen3 > 0) {
+                        List<IndexedRecord> recordsMapArrayValueReuse0 = null;
                         if (null instanceof List) {
-                            recordsMapArrayValueReuse863 = ((List) null);
+                            recordsMapArrayValueReuse0 = ((List) null);
                         }
-                        if (recordsMapArrayValueReuse863 != (null)) {
-                            recordsMapArrayValueReuse863 .clear();
-                            recordsMapArrayValue861 = recordsMapArrayValueReuse863;
+                        if (recordsMapArrayValueReuse0 != (null)) {
+                            recordsMapArrayValueReuse0 .clear();
+                            recordsMapArrayValue0 = recordsMapArrayValueReuse0;
                         } else {
-                            recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen862), recordsMapArrayMapValueSchema860);
+                            recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
                         }
                         do {
-                            for (int counter864 = 0; (counter864 <chunkLen862); counter864 ++) {
-                                Object recordsMapArrayValueArrayElementReuseVar866 = null;
+                            for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                                Object recordsMapArrayValueArrayElementReuseVar0 = null;
                                 if (null instanceof GenericArray) {
-                                    recordsMapArrayValueArrayElementReuseVar866 = ((GenericArray) null).peek();
+                                    recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                 }
-                                int unionIndex867 = (decoder.readIndex());
-                                if (unionIndex867 == 0) {
+                                int unionIndex2 = (decoder.readIndex());
+                                if (unionIndex2 == 0) {
                                     decoder.readNull();
                                 }
-                                if (unionIndex867 == 1) {
-                                    recordsMapArrayValue861 .add(deserializesubRecord851(recordsMapArrayValueArrayElementReuseVar866, (decoder)));
+                                if (unionIndex2 == 1) {
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
                                 }
                             }
-                            chunkLen862 = (decoder.arrayNext());
-                        } while (chunkLen862 > 0);
+                            chunkLen3 = (decoder.arrayNext());
+                        } while (chunkLen3 > 0);
                     } else {
-                        recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                        recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema0);
                     }
-                    recordsMapArray855 .put(key859, recordsMapArrayValue861);
+                    recordsMapArray1 .put(key1, recordsMapArrayValue0);
                 }
-                chunkLen856 = (decoder.mapNext());
-            } while (chunkLen856 > 0);
+                chunkLen2 = (decoder.mapNext());
+            } while (chunkLen2 > 0);
         } else {
-            recordsMapArray855 = Collections.emptyMap();
+            recordsMapArray1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray855);
-        int unionIndex869 = (decoder.readIndex());
-        if (unionIndex869 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray1);
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex869 == 1) {
-            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption870 = null;
-            long chunkLen871 = (decoder.readArrayStart());
-            if (chunkLen871 > 0) {
-                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse872 = null;
+        if (unionIndex3 == 1) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption0 = null;
+            long chunkLen4 = (decoder.readArrayStart());
+            if (chunkLen4 > 0) {
+                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
-                    recordsArrayMapUnionOptionReuse872 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                    recordsArrayMapUnionOptionReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
                 }
-                if (recordsArrayMapUnionOptionReuse872 != (null)) {
-                    recordsArrayMapUnionOptionReuse872 .clear();
-                    recordsArrayMapUnionOption870 = recordsArrayMapUnionOptionReuse872;
+                if (recordsArrayMapUnionOptionReuse0 != (null)) {
+                    recordsArrayMapUnionOptionReuse0 .clear();
+                    recordsArrayMapUnionOption0 = recordsArrayMapUnionOptionReuse0;
                 } else {
-                    recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen871), recordsArrayMap836);
+                    recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
                 }
                 do {
-                    for (int counter873 = 0; (counter873 <chunkLen871); counter873 ++) {
-                        Object recordsArrayMapUnionOptionArrayElementReuseVar875 = null;
+                    for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
                         if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
-                            recordsArrayMapUnionOptionArrayElementReuseVar875 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                            recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
                         }
-                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem876 = null;
-                        long chunkLen877 = (decoder.readMapStart());
-                        if (chunkLen877 > 0) {
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse878 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar875 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse878 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar875);
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
+                        long chunkLen5 = (decoder.readMapStart());
+                        if (chunkLen5 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
                             }
-                            if (recordsArrayMapUnionOptionElemReuse878 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse878 .clear();
-                                recordsArrayMapUnionOptionElem876 = recordsArrayMapUnionOptionElemReuse878;
+                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse0 .clear();
+                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
                             } else {
-                                recordsArrayMapUnionOptionElem876 = new HashMap<Utf8, IndexedRecord>();
+                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
                             }
                             do {
-                                for (int counter879 = 0; (counter879 <chunkLen877); counter879 ++) {
-                                    Utf8 key880 = (decoder.readString(null));
-                                    int unionIndex882 = (decoder.readIndex());
-                                    if (unionIndex882 == 0) {
+                                for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
+                                    Utf8 key2 = (decoder.readString(null));
+                                    int unionIndex4 = (decoder.readIndex());
+                                    if (unionIndex4 == 0) {
                                         decoder.readNull();
                                     }
-                                    if (unionIndex882 == 1) {
-                                        recordsArrayMapUnionOptionElem876 .put(key880, deserializesubRecord851(null, (decoder)));
+                                    if (unionIndex4 == 1) {
+                                        recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
                                     }
                                 }
-                                chunkLen877 = (decoder.mapNext());
-                            } while (chunkLen877 > 0);
+                                chunkLen5 = (decoder.mapNext());
+                            } while (chunkLen5 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem876 = Collections.emptyMap();
+                            recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
                         }
-                        recordsArrayMapUnionOption870 .add(recordsArrayMapUnionOptionElem876);
+                        recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
-                    chunkLen871 = (decoder.arrayNext());
-                } while (chunkLen871 > 0);
+                    chunkLen4 = (decoder.arrayNext());
+                } while (chunkLen4 > 0);
             } else {
-                recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+                recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap0);
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption870);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption0);
         }
-        int unionIndex884 = (decoder.readIndex());
-        if (unionIndex884 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex884 == 1) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption886 = null;
-            long chunkLen887 = (decoder.readMapStart());
-            if (chunkLen887 > 0) {
-                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse888 = null;
+        if (unionIndex5 == 1) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption0 = null;
+            long chunkLen6 = (decoder.readMapStart());
+            if (chunkLen6 > 0) {
+                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3) instanceof Map) {
-                    recordsMapArrayUnionOptionReuse888 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
+                    recordsMapArrayUnionOptionReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
                 }
-                if (recordsMapArrayUnionOptionReuse888 != (null)) {
-                    recordsMapArrayUnionOptionReuse888 .clear();
-                    recordsMapArrayUnionOption886 = recordsMapArrayUnionOptionReuse888;
+                if (recordsMapArrayUnionOptionReuse0 != (null)) {
+                    recordsMapArrayUnionOptionReuse0 .clear();
+                    recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
                 } else {
-                    recordsMapArrayUnionOption886 = new HashMap<Utf8, List<IndexedRecord>>();
+                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<IndexedRecord>>();
                 }
                 do {
-                    for (int counter889 = 0; (counter889 <chunkLen887); counter889 ++) {
-                        Utf8 key890 = (decoder.readString(null));
-                        List<IndexedRecord> recordsMapArrayUnionOptionValue891 = null;
-                        long chunkLen892 = (decoder.readArrayStart());
-                        if (chunkLen892 > 0) {
-                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse893 = null;
+                    for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
+                        Utf8 key3 = (decoder.readString(null));
+                        List<IndexedRecord> recordsMapArrayUnionOptionValue0 = null;
+                        long chunkLen7 = (decoder.readArrayStart());
+                        if (chunkLen7 > 0) {
+                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse0 = null;
                             if (null instanceof List) {
-                                recordsMapArrayUnionOptionValueReuse893 = ((List) null);
+                                recordsMapArrayUnionOptionValueReuse0 = ((List) null);
                             }
-                            if (recordsMapArrayUnionOptionValueReuse893 != (null)) {
-                                recordsMapArrayUnionOptionValueReuse893 .clear();
-                                recordsMapArrayUnionOptionValue891 = recordsMapArrayUnionOptionValueReuse893;
+                            if (recordsMapArrayUnionOptionValueReuse0 != (null)) {
+                                recordsMapArrayUnionOptionValueReuse0 .clear();
+                                recordsMapArrayUnionOptionValue0 = recordsMapArrayUnionOptionValueReuse0;
                             } else {
-                                recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen892), recordsMapArrayMapValueSchema860);
+                                recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
                             }
                             do {
-                                for (int counter894 = 0; (counter894 <chunkLen892); counter894 ++) {
-                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar896 = null;
+                                for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
                                     if (null instanceof GenericArray) {
-                                        recordsMapArrayUnionOptionValueArrayElementReuseVar896 = ((GenericArray) null).peek();
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                     }
-                                    int unionIndex897 = (decoder.readIndex());
-                                    if (unionIndex897 == 0) {
+                                    int unionIndex6 = (decoder.readIndex());
+                                    if (unionIndex6 == 0) {
                                         decoder.readNull();
                                     }
-                                    if (unionIndex897 == 1) {
-                                        recordsMapArrayUnionOptionValue891 .add(deserializesubRecord851(recordsMapArrayUnionOptionValueArrayElementReuseVar896, (decoder)));
+                                    if (unionIndex6 == 1) {
+                                        recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
                                     }
                                 }
-                                chunkLen892 = (decoder.arrayNext());
-                            } while (chunkLen892 > 0);
+                                chunkLen7 = (decoder.arrayNext());
+                            } while (chunkLen7 > 0);
                         } else {
-                            recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                            recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema0);
                         }
-                        recordsMapArrayUnionOption886 .put(key890, recordsMapArrayUnionOptionValue891);
+                        recordsMapArrayUnionOption0 .put(key3, recordsMapArrayUnionOptionValue0);
                     }
-                    chunkLen887 = (decoder.mapNext());
-                } while (chunkLen887 > 0);
+                    chunkLen6 = (decoder.mapNext());
+                } while (chunkLen6 > 0);
             } else {
-                recordsMapArrayUnionOption886 = Collections.emptyMap();
+                recordsMapArrayUnionOption0 = Collections.emptyMap();
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption886);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption0);
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord851(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema850)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema850);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema0);
         }
-        int unionIndex853 = (decoder.readIndex());
-        if (unionIndex853 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex853 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
@@ -13,26 +13,26 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
 {
 
     private final Schema readerSchema;
-    private final Schema record899;
-    private final Schema recordOptionSchema901;
-    private final Schema subField903;
-    private final Schema field905;
+    private final Schema record0;
+    private final Schema recordOptionSchema0;
+    private final Schema subField0;
+    private final Schema field0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.record899 = readerSchema.getField("record").schema();
-        this.recordOptionSchema901 = record899 .getTypes().get(1);
-        this.subField903 = recordOptionSchema901 .getField("subField").schema();
-        this.field905 = readerSchema.getField("field").schema();
+        this.record0 = readerSchema.getField("record").schema();
+        this.recordOptionSchema0 = record0 .getTypes().get(1);
+        this.subField0 = recordOptionSchema0 .getField("subField").schema();
+        this.field0 = readerSchema.getField("field").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
@@ -41,19 +41,19 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex900 = (decoder.readIndex());
-        if (unionIndex900 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex900 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
-        int unionIndex906 = (decoder.readIndex());
-        if (unionIndex906 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex906 == 1) {
+        if (unionIndex2 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2))));
             } else {
@@ -63,20 +63,20 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
     }
 
-    public IndexedRecord deserializesubRecord902(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema901)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema901);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema0);
         }
-        int unionIndex904 = (decoder.readIndex());
-        if (unionIndex904 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex904 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -18,34 +18,34 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
 {
 
     private final Schema readerSchema;
-    private final Schema testNotRemoved908;
-    private final Schema testNotRemoved2911;
-    private final Schema subRecord913;
-    private final Schema subRecordOptionSchema915;
-    private final Schema testNotRemoved917;
-    private final Schema testNotRemoved2920;
-    private final Schema subRecordMap922;
-    private final Schema subRecordArray928;
+    private final Schema testNotRemoved0;
+    private final Schema testNotRemoved20;
+    private final Schema subRecord0;
+    private final Schema subRecordOptionSchema0;
+    private final Schema testNotRemoved1;
+    private final Schema testNotRemoved21;
+    private final Schema subRecordMap0;
+    private final Schema subRecordArray0;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testNotRemoved908 = readerSchema.getField("testNotRemoved").schema();
-        this.testNotRemoved2911 = readerSchema.getField("testNotRemoved2").schema();
-        this.subRecord913 = readerSchema.getField("subRecord").schema();
-        this.subRecordOptionSchema915 = subRecord913 .getTypes().get(1);
-        this.testNotRemoved917 = subRecordOptionSchema915 .getField("testNotRemoved").schema();
-        this.testNotRemoved2920 = subRecordOptionSchema915 .getField("testNotRemoved2").schema();
-        this.subRecordMap922 = readerSchema.getField("subRecordMap").schema();
-        this.subRecordArray928 = readerSchema.getField("subRecordArray").schema();
+        this.testNotRemoved0 = readerSchema.getField("testNotRemoved").schema();
+        this.testNotRemoved20 = readerSchema.getField("testNotRemoved2").schema();
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordOptionSchema0 = subRecord0 .getTypes().get(1);
+        this.testNotRemoved1 = subRecordOptionSchema0 .getField("testNotRemoved").schema();
+        this.testNotRemoved21 = subRecordOptionSchema0 .getField("testNotRemoved2").schema();
+        this.subRecordMap0 = readerSchema.getField("subRecordMap").schema();
+        this.subRecordArray0 = readerSchema.getField("subRecordArray").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
@@ -54,128 +54,128 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex909 = (decoder.readIndex());
-        if (unionIndex909 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex909 == 1) {
+        if (unionIndex0 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex910 = (decoder.readIndex());
-        if (unionIndex910 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex910 == 1) {
+        if (unionIndex1 == 1) {
             decoder.skipString();
         }
-        int unionIndex912 = (decoder.readIndex());
-        if (unionIndex912 == 0) {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex912 == 1) {
+        if (unionIndex2 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(null));
             }
         }
-        int unionIndex914 = (decoder.readIndex());
-        if (unionIndex914 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex914 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord916(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+        if (unionIndex3 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
         }
-        Map<Utf8, IndexedRecord> subRecordMap923 = null;
-        long chunkLen924 = (decoder.readMapStart());
-        if (chunkLen924 > 0) {
-            Map<Utf8, IndexedRecord> subRecordMapReuse925 = null;
+        Map<Utf8, IndexedRecord> subRecordMap1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> subRecordMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3) instanceof Map) {
-                subRecordMapReuse925 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
+                subRecordMapReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
             }
-            if (subRecordMapReuse925 != (null)) {
-                subRecordMapReuse925 .clear();
-                subRecordMap923 = subRecordMapReuse925;
+            if (subRecordMapReuse0 != (null)) {
+                subRecordMapReuse0 .clear();
+                subRecordMap1 = subRecordMapReuse0;
             } else {
-                subRecordMap923 = new HashMap<Utf8, IndexedRecord>();
+                subRecordMap1 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter926 = 0; (counter926 <chunkLen924); counter926 ++) {
-                    Utf8 key927 = (decoder.readString(null));
-                    subRecordMap923 .put(key927, deserializesubRecord916(null, (decoder)));
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    subRecordMap1 .put(key0, deserializesubRecord0(null, (decoder)));
                 }
-                chunkLen924 = (decoder.mapNext());
-            } while (chunkLen924 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            subRecordMap923 = Collections.emptyMap();
+            subRecordMap1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap923);
-        List<IndexedRecord> subRecordArray929 = null;
-        long chunkLen930 = (decoder.readArrayStart());
-        if (chunkLen930 > 0) {
-            List<IndexedRecord> subRecordArrayReuse931 = null;
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
+        List<IndexedRecord> subRecordArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<IndexedRecord> subRecordArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
-                subRecordArrayReuse931 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+                subRecordArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
             }
-            if (subRecordArrayReuse931 != (null)) {
-                subRecordArrayReuse931 .clear();
-                subRecordArray929 = subRecordArrayReuse931;
+            if (subRecordArrayReuse0 != (null)) {
+                subRecordArrayReuse0 .clear();
+                subRecordArray1 = subRecordArrayReuse0;
             } else {
-                subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen930), subRecordArray928);
+                subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
             }
             do {
-                for (int counter932 = 0; (counter932 <chunkLen930); counter932 ++) {
-                    Object subRecordArrayArrayElementReuseVar933 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object subRecordArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
-                        subRecordArrayArrayElementReuseVar933 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                        subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
                     }
-                    subRecordArray929 .add(deserializesubRecord916(subRecordArrayArrayElementReuseVar933, (decoder)));
+                    subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen930 = (decoder.arrayNext());
-            } while (chunkLen930 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray928);
+            subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray929);
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1);
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
     }
 
-    public IndexedRecord deserializesubRecord916(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema915)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema915);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema0);
         }
-        int unionIndex918 = (decoder.readIndex());
-        if (unionIndex918 == 0) {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
             decoder.readNull();
         }
-        if (unionIndex918 == 1) {
+        if (unionIndex4 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {
                 subRecord.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex919 = (decoder.readIndex());
-        if (unionIndex919 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex919 == 1) {
+        if (unionIndex5 == 1) {
             decoder.skipString();
         }
-        int unionIndex921 = (decoder.readIndex());
-        if (unionIndex921 == 0) {
+        int unionIndex6 = (decoder.readIndex());
+        if (unionIndex6 == 0) {
             decoder.readNull();
         }
-        if (unionIndex921 == 1) {
+        if (unionIndex6 == 1) {
             if (subRecord.get(1) instanceof Utf8) {
                 subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
@@ -13,20 +13,20 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
 {
 
     private final Schema readerSchema;
-    private final Schema subRecord935;
+    private final Schema subRecord0;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.subRecord935 = readerSchema.getField("subRecord").schema();
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
@@ -35,31 +35,31 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord936(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
     }
 
-    public IndexedRecord deserializesubRecord936(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord935)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord935);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
         }
         if (subRecord.get(0) instanceof Utf8) {
             subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
         } else {
             subRecord.put(0, (decoder).readString(null));
         }
-        deserializesubSubRecord937(null, (decoder));
-        int unionIndex938 = (decoder.readIndex());
-        if (unionIndex938 == 0) {
+        deserializesubSubRecord0(null, (decoder));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex938 == 1) {
-            deserializesubSubRecord937(null, (decoder));
+        if (unionIndex0 == 1) {
+            deserializesubSubRecord0(null, (decoder));
         }
         if (subRecord.get(1) instanceof Utf8) {
             subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
@@ -69,7 +69,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         return subRecord;
     }
 
-    public void deserializesubSubRecord937(Object reuse, Decoder decoder)
+    public void deserializesubSubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
@@ -13,20 +13,20 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
 {
 
     private final Schema readerSchema;
-    private final Schema subRecord1940;
+    private final Schema subRecord10;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.subRecord1940 = readerSchema.getField("subRecord1").schema();
+        this.subRecord10 = readerSchema.getField("subRecord1").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
@@ -35,27 +35,27 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
-        deserializesubRecord2942(null, (decoder));
-        int unionIndex943 = (decoder.readIndex());
-        if (unionIndex943 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
+        deserializesubRecord20(null, (decoder));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex943 == 1) {
-            deserializesubRecord2942(null, (decoder));
+        if (unionIndex0 == 1) {
+            deserializesubRecord20(null, (decoder));
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
     }
 
-    public IndexedRecord deserializesubRecord941(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord1940)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord10)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord1940);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord10);
         }
         if (subRecord.get(0) instanceof Utf8) {
             subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
@@ -70,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         return subRecord;
     }
 
-    public void deserializesubRecord2942(Object reuse, Decoder decoder)
+    public void deserializesubRecord20(Object reuse, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -16,66 +16,66 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
 {
 
     private final Schema readerSchema;
-    private final Schema mapMapValueSchema708;
-    private final Schema mapValueOptionSchema710;
-    private final Schema field712;
+    private final Schema mapMapValueSchema0;
+    private final Schema mapValueOptionSchema0;
+    private final Schema field0;
 
     public Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapMapValueSchema708 = readerSchema.getValueType();
-        this.mapValueOptionSchema710 = mapMapValueSchema708 .getTypes().get(1);
-        this.field712 = mapValueOptionSchema710 .getField("field").schema();
+        this.mapMapValueSchema0 = readerSchema.getValueType();
+        this.mapValueOptionSchema0 = mapMapValueSchema0 .getTypes().get(1);
+        this.field0 = mapValueOptionSchema0 .getField("field").schema();
     }
 
     public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        Map<Utf8, IndexedRecord> map703 = null;
-        long chunkLen704 = (decoder.readMapStart());
-        if (chunkLen704 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse705 = null;
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
             if ((reuse) instanceof Map) {
-                mapReuse705 = ((Map)(reuse));
+                mapReuse0 = ((Map)(reuse));
             }
-            if (mapReuse705 != (null)) {
-                mapReuse705 .clear();
-                map703 = mapReuse705;
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
             } else {
-                map703 = new HashMap<Utf8, IndexedRecord>();
+                map0 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter706 = 0; (counter706 <chunkLen704); counter706 ++) {
-                    Utf8 key707 = (decoder.readString(null));
-                    int unionIndex709 = (decoder.readIndex());
-                    if (unionIndex709 == 0) {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    int unionIndex0 = (decoder.readIndex());
+                    if (unionIndex0 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex709 == 1) {
-                        map703 .put(key707, deserializerecord711(null, (decoder)));
+                    if (unionIndex0 == 1) {
+                        map0 .put(key0, deserializerecord0(null, (decoder)));
                     }
                 }
-                chunkLen704 = (decoder.mapNext());
-            } while (chunkLen704 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            map703 = Collections.emptyMap();
+            map0 = Collections.emptyMap();
         }
-        return map703;
+        return map0;
     }
 
-    public IndexedRecord deserializerecord711(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema710)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema710);
+            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema0);
         }
-        int unionIndex713 = (decoder.readIndex());
-        if (unionIndex713 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex713 == 1) {
+        if (unionIndex1 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -16,58 +16,58 @@ public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969
 {
 
     private final Schema readerSchema;
-    private final Schema mapMapValueSchema699;
-    private final Schema field701;
+    private final Schema mapMapValueSchema0;
+    private final Schema field0;
 
     public Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapMapValueSchema699 = readerSchema.getValueType();
-        this.field701 = mapMapValueSchema699 .getField("field").schema();
+        this.mapMapValueSchema0 = readerSchema.getValueType();
+        this.field0 = mapMapValueSchema0 .getField("field").schema();
     }
 
     public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        Map<Utf8, IndexedRecord> map694 = null;
-        long chunkLen695 = (decoder.readMapStart());
-        if (chunkLen695 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse696 = null;
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
             if ((reuse) instanceof Map) {
-                mapReuse696 = ((Map)(reuse));
+                mapReuse0 = ((Map)(reuse));
             }
-            if (mapReuse696 != (null)) {
-                mapReuse696 .clear();
-                map694 = mapReuse696;
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
             } else {
-                map694 = new HashMap<Utf8, IndexedRecord>();
+                map0 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter697 = 0; (counter697 <chunkLen695); counter697 ++) {
-                    Utf8 key698 = (decoder.readString(null));
-                    map694 .put(key698, deserializerecord700(null, (decoder)));
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
                 }
-                chunkLen695 = (decoder.mapNext());
-            } while (chunkLen695 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            map694 = Collections.emptyMap();
+            map0 = Collections.emptyMap();
         }
-        return map694;
+        return map0;
     }
 
-    public IndexedRecord deserializerecord700(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema699)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema699);
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
         }
-        int unionIndex702 = (decoder.readIndex());
-        if (unionIndex702 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex702 == 1) {
+        if (unionIndex0 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -13,20 +13,20 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
 {
 
     private final Schema readerSchema;
-    private final Schema unionField796;
+    private final Schema unionField0;
 
     public recordName_GenericDeserializer_6897301803194779359_6897301803194779359(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.unionField796 = readerSchema.getField("unionField").schema();
+        this.unionField0 = readerSchema.getField("unionField").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializerecordName795((reuse), (decoder));
+        return deserializerecordName0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializerecordName795(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecordName0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord recordName;
@@ -40,12 +40,12 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
         } else {
             recordName.put(0, (decoder).readString(null));
         }
-        int unionIndex797 = (decoder.readIndex());
-        if (unionIndex797 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex797 == 1) {
-            recordName.put(1, deserializerecordName795(recordName.get(1), (decoder)));
+        if (unionIndex0 == 1) {
+            recordName.put(1, deserializerecordName0(recordName.get(1), (decoder)));
         }
         return recordName;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -21,33 +21,33 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
     public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
         throws IOException
     {
-        List<Boolean> array592 = null;
-        long chunkLen593 = (decoder.readArrayStart());
-        if (chunkLen593 > 0) {
-            List<Boolean> arrayReuse594 = null;
+        List<Boolean> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Boolean> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse594 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse594 != (null)) {
-                arrayReuse594 .clear();
-                array592 = arrayReuse594;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen593), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Boolean>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter595 = 0; (counter595 <chunkLen593); counter595 ++) {
-                    Object arrayArrayElementReuseVar596 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar596 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array592 .add((decoder.readBoolean()));
+                    array0 .add((decoder.readBoolean()));
                 }
-                chunkLen593 = (decoder.arrayNext());
-            } while (chunkLen593 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array592 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Boolean>(0, readerSchema);
         }
-        return array592;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -21,33 +21,33 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
     public List<Double> deserialize(List<Double> reuse, Decoder decoder)
         throws IOException
     {
-        List<Double> array597 = null;
-        long chunkLen598 = (decoder.readArrayStart());
-        if (chunkLen598 > 0) {
-            List<Double> arrayReuse599 = null;
+        List<Double> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Double> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse599 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse599 != (null)) {
-                arrayReuse599 .clear();
-                array597 = arrayReuse599;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array597 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen598), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Double>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter600 = 0; (counter600 <chunkLen598); counter600 ++) {
-                    Object arrayArrayElementReuseVar601 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar601 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array597 .add((decoder.readDouble()));
+                    array0 .add((decoder.readDouble()));
                 }
-                chunkLen598 = (decoder.arrayNext());
-            } while (chunkLen598 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array597 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Double>(0, readerSchema);
         }
-        return array597;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -21,9 +21,9 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
     public List<Float> deserialize(List<Float> reuse, Decoder decoder)
         throws IOException
     {
-        List<Float> array602 = null;
-        array602 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
-        return array602;
+        List<Float> array0 = null;
+        array0 = ((List<Float> ) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -21,33 +21,33 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
     public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
         throws IOException
     {
-        List<Integer> array603 = null;
-        long chunkLen604 = (decoder.readArrayStart());
-        if (chunkLen604 > 0) {
-            List<Integer> arrayReuse605 = null;
+        List<Integer> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Integer> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse605 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse605 != (null)) {
-                arrayReuse605 .clear();
-                array603 = arrayReuse605;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array603 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen604), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter606 = 0; (counter606 <chunkLen604); counter606 ++) {
-                    Object arrayArrayElementReuseVar607 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar607 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array603 .add((decoder.readInt()));
+                    array0 .add((decoder.readInt()));
                 }
-                chunkLen604 = (decoder.arrayNext());
-            } while (chunkLen604 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array603 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Integer>(0, readerSchema);
         }
-        return array603;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -21,33 +21,33 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
     public List<Long> deserialize(List<Long> reuse, Decoder decoder)
         throws IOException
     {
-        List<Long> array608 = null;
-        long chunkLen609 = (decoder.readArrayStart());
-        if (chunkLen609 > 0) {
-            List<Long> arrayReuse610 = null;
+        List<Long> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Long> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse610 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse610 != (null)) {
-                arrayReuse610 .clear();
-                array608 = arrayReuse610;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array608 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen609), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<Long>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter611 = 0; (counter611 <chunkLen609); counter611 ++) {
-                    Object arrayArrayElementReuseVar612 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar612 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array608 .add((decoder.readLong()));
+                    array0 .add((decoder.readLong()));
                 }
-                chunkLen609 = (decoder.arrayNext());
-            } while (chunkLen609 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array608 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<Long>(0, readerSchema);
         }
-        return array608;
+        return array0;
     }
 
 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -15,69 +15,69 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
 {
 
     private final Schema readerSchema;
-    private final Schema arrayArrayElemSchema626;
-    private final Schema arrayElemOptionSchema629;
-    private final Schema field631;
+    private final Schema arrayArrayElemSchema0;
+    private final Schema arrayElemOptionSchema0;
+    private final Schema field0;
 
     public Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.arrayArrayElemSchema626 = readerSchema.getElementType();
-        this.arrayElemOptionSchema629 = arrayArrayElemSchema626 .getTypes().get(1);
-        this.field631 = arrayElemOptionSchema629 .getField("field").schema();
+        this.arrayArrayElemSchema0 = readerSchema.getElementType();
+        this.arrayElemOptionSchema0 = arrayArrayElemSchema0 .getTypes().get(1);
+        this.field0 = arrayElemOptionSchema0 .getField("field").schema();
     }
 
     public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        List<IndexedRecord> array622 = null;
-        long chunkLen623 = (decoder.readArrayStart());
-        if (chunkLen623 > 0) {
-            List<IndexedRecord> arrayReuse624 = null;
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse624 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse624 != (null)) {
-                arrayReuse624 .clear();
-                array622 = arrayReuse624;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen623), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter625 = 0; (counter625 <chunkLen623); counter625 ++) {
-                    Object arrayArrayElementReuseVar627 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar627 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    int unionIndex628 = (decoder.readIndex());
-                    if (unionIndex628 == 0) {
+                    int unionIndex0 = (decoder.readIndex());
+                    if (unionIndex0 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex628 == 1) {
-                        array622 .add(deserializerecord630(arrayArrayElementReuseVar627, (decoder)));
+                    if (unionIndex0 == 1) {
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                     }
                 }
-                chunkLen623 = (decoder.arrayNext());
-            } while (chunkLen623 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array622 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
         }
-        return array622;
+        return array0;
     }
 
-    public IndexedRecord deserializerecord630(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema629)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayElemOptionSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema629);
+            record = new org.apache.avro.generic.GenericData.Record(arrayElemOptionSchema0);
         }
-        int unionIndex632 = (decoder.readIndex());
-        if (unionIndex632 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex632 == 1) {
+        if (unionIndex1 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -15,61 +15,61 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
 {
 
     private final Schema readerSchema;
-    private final Schema arrayArrayElemSchema617;
-    private final Schema field620;
+    private final Schema arrayArrayElemSchema0;
+    private final Schema field0;
 
     public Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.arrayArrayElemSchema617 = readerSchema.getElementType();
-        this.field620 = arrayArrayElemSchema617 .getField("field").schema();
+        this.arrayArrayElemSchema0 = readerSchema.getElementType();
+        this.field0 = arrayArrayElemSchema0 .getField("field").schema();
     }
 
     public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        List<IndexedRecord> array613 = null;
-        long chunkLen614 = (decoder.readArrayStart());
-        if (chunkLen614 > 0) {
-            List<IndexedRecord> arrayReuse615 = null;
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> arrayReuse0 = null;
             if ((reuse) instanceof List) {
-                arrayReuse615 = ((List)(reuse));
+                arrayReuse0 = ((List)(reuse));
             }
-            if (arrayReuse615 != (null)) {
-                arrayReuse615 .clear();
-                array613 = arrayReuse615;
+            if (arrayReuse0 != (null)) {
+                arrayReuse0 .clear();
+                array0 = arrayReuse0;
             } else {
-                array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen614), readerSchema);
+                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
             }
             do {
-                for (int counter616 = 0; (counter616 <chunkLen614); counter616 ++) {
-                    Object arrayArrayElementReuseVar618 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object arrayArrayElementReuseVar0 = null;
                     if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar618 = ((GenericArray)(reuse)).peek();
+                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                     }
-                    array613 .add(deserializerecord619(arrayArrayElementReuseVar618, (decoder)));
+                    array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen614 = (decoder.arrayNext());
-            } while (chunkLen614 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            array613 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, readerSchema);
         }
-        return array613;
+        return array0;
     }
 
-    public IndexedRecord deserializerecord619(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema617)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema617);
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
         }
-        int unionIndex621 = (decoder.readIndex());
-        if (unionIndex621 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex621 == 1) {
+        if (unionIndex0 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
@@ -13,22 +13,22 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
 {
 
     private final Schema readerSchema;
-    private final Schema testString588;
-    private final Schema testStringUnionAlias590;
+    private final Schema testString0;
+    private final Schema testStringUnionAlias0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testString588 = readerSchema.getField("testString").schema();
-        this.testStringUnionAlias590 = readerSchema.getField("testStringUnionAlias").schema();
+        this.testString0 = readerSchema.getField("testString").schema();
+        this.testStringUnionAlias0 = readerSchema.getField("testStringUnionAlias").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField587(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
@@ -37,22 +37,22 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadAliasedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex589 = (decoder.readIndex());
-        if (unionIndex589 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex589 == 1) {
+        if (unionIndex0 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(0))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex591 = (decoder.readIndex());
-        if (unionIndex591 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex591 == 1) {
+        if (unionIndex1 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadAliasedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadAliasedField.get(1))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -14,28 +14,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
 {
 
     private final Schema readerSchema;
-    private final Schema testEnum634;
-    private final Schema testEnumUnion635;
-    private final Schema testEnumArray637;
-    private final Schema testEnumUnionArray643;
-    private final Schema testEnumUnionArrayArrayElemSchema648;
+    private final Schema testEnum0;
+    private final Schema testEnumUnion0;
+    private final Schema testEnumArray0;
+    private final Schema testEnumUnionArray0;
+    private final Schema testEnumUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testEnum634 = readerSchema.getField("testEnum").schema();
-        this.testEnumUnion635 = readerSchema.getField("testEnumUnion").schema();
-        this.testEnumArray637 = readerSchema.getField("testEnumArray").schema();
-        this.testEnumUnionArray643 = readerSchema.getField("testEnumUnionArray").schema();
-        this.testEnumUnionArrayArrayElemSchema648 = testEnumUnionArray643 .getElementType();
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion0 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray0 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray0 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum633(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
@@ -44,74 +44,74 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
-        int unionIndex636 = (decoder.readIndex());
-        if (unionIndex636 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex636 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray638 = null;
-        long chunkLen639 = (decoder.readArrayStart());
-        if (chunkLen639 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse640 = null;
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
-                testEnumArrayReuse640 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+                testEnumArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
             }
-            if (testEnumArrayReuse640 != (null)) {
-                testEnumArrayReuse640 .clear();
-                testEnumArray638 = testEnumArrayReuse640;
+            if (testEnumArrayReuse0 != (null)) {
+                testEnumArrayReuse0 .clear();
+                testEnumArray1 = testEnumArrayReuse0;
             } else {
-                testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen639), testEnumArray637);
+                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
             }
             do {
-                for (int counter641 = 0; (counter641 <chunkLen639); counter641 ++) {
-                    Object testEnumArrayArrayElementReuseVar642 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testEnumArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof GenericArray) {
-                        testEnumArrayArrayElementReuseVar642 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
+                        testEnumArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2)).peek();
                     }
-                    testEnumArray638 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                    testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                 }
-                chunkLen639 = (decoder.arrayNext());
-            } while (chunkLen639 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testEnumArray638 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray637);
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray638);
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray644 = null;
-        long chunkLen645 = (decoder.readArrayStart());
-        if (chunkLen645 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse646 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
-                testEnumUnionArrayReuse646 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+                testEnumUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
             }
-            if (testEnumUnionArrayReuse646 != (null)) {
-                testEnumUnionArrayReuse646 .clear();
-                testEnumUnionArray644 = testEnumUnionArrayReuse646;
+            if (testEnumUnionArrayReuse0 != (null)) {
+                testEnumUnionArrayReuse0 .clear();
+                testEnumUnionArray1 = testEnumUnionArrayReuse0;
             } else {
-                testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen645), testEnumUnionArray643);
+                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
             }
             do {
-                for (int counter647 = 0; (counter647 <chunkLen645); counter647 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar649 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar649 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
                     }
-                    int unionIndex650 = (decoder.readIndex());
-                    if (unionIndex650 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex650 == 1) {
-                        testEnumUnionArray644 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum634, testEnum634 .getEnumSymbols().get((decoder.readEnum()))));
+                    if (unionIndex1 == 1) {
+                        testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                     }
                 }
-                chunkLen645 = (decoder.arrayNext());
-            } while (chunkLen645 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testEnumUnionArray644 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray643);
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray644);
+        FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -15,26 +15,26 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
 {
 
     private final Schema readerSchema;
-    private final Schema testFixedUnion653;
-    private final Schema testFixedArray656;
-    private final Schema testFixedUnionArray663;
-    private final Schema testFixedUnionArrayArrayElemSchema668;
+    private final Schema testFixedUnion0;
+    private final Schema testFixedArray0;
+    private final Schema testFixedUnionArray0;
+    private final Schema testFixedUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testFixedUnion653 = readerSchema.getField("testFixedUnion").schema();
-        this.testFixedArray656 = readerSchema.getField("testFixedArray").schema();
-        this.testFixedUnionArray663 = readerSchema.getField("testFixedUnionArray").schema();
-        this.testFixedUnionArrayArrayElemSchema668 = testFixedUnionArray663 .getElementType();
+        this.testFixedUnion0 = readerSchema.getField("testFixedUnion").schema();
+        this.testFixedArray0 = readerSchema.getField("testFixedArray").schema();
+        this.testFixedUnionArray0 = readerSchema.getField("testFixedUnionArray").schema();
+        this.testFixedUnionArrayArrayElemSchema0 = testFixedUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed651(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
@@ -43,102 +43,102 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadFixed = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        byte[] testFixed652;
+        byte[] testFixed0;
         if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes().length == (2))) {
-            testFixed652 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
+            testFixed0 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(0)).bytes();
         } else {
-            testFixed652 = ( new byte[2]);
+            testFixed0 = ( new byte[2]);
         }
-        decoder.readFixed(testFixed652);
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(null, testFixed652));
-        int unionIndex654 = (decoder.readIndex());
-        if (unionIndex654 == 0) {
+        decoder.readFixed(testFixed0);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(null, testFixed0));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex654 == 1) {
-            byte[] testFixed655;
+        if (unionIndex0 == 1) {
+            byte[] testFixed1;
             if ((FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1) instanceof GenericFixed)&&(((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes().length == (2))) {
-                testFixed655 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
+                testFixed1 = ((GenericFixed) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(1)).bytes();
             } else {
-                testFixed655 = ( new byte[2]);
+                testFixed1 = ( new byte[2]);
             }
-            decoder.readFixed(testFixed655);
-            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(null, testFixed655));
+            decoder.readFixed(testFixed1);
+            FastGenericDeserializerGeneratorTest_shouldReadFixed.put(1, new org.apache.avro.generic.GenericData.Fixed(null, testFixed1));
         }
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray657 = null;
-        long chunkLen658 = (decoder.readArrayStart());
-        if (chunkLen658 > 0) {
-            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse659 = null;
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
-                testFixedArrayReuse659 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+                testFixedArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
             }
-            if (testFixedArrayReuse659 != (null)) {
-                testFixedArrayReuse659 .clear();
-                testFixedArray657 = testFixedArrayReuse659;
+            if (testFixedArrayReuse0 != (null)) {
+                testFixedArrayReuse0 .clear();
+                testFixedArray1 = testFixedArrayReuse0;
             } else {
-                testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen658), testFixedArray656);
+                testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
             }
             do {
-                for (int counter660 = 0; (counter660 <chunkLen658); counter660 ++) {
-                    Object testFixedArrayArrayElementReuseVar661 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testFixedArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
-                        testFixedArrayArrayElementReuseVar661 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                        testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
                     }
-                    byte[] testFixed662;
-                    if ((testFixedArrayArrayElementReuseVar661 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes().length == (2))) {
-                        testFixed662 = ((GenericFixed) testFixedArrayArrayElementReuseVar661).bytes();
+                    byte[] testFixed2;
+                    if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
+                        testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
                     } else {
-                        testFixed662 = ( new byte[2]);
+                        testFixed2 = ( new byte[2]);
                     }
-                    decoder.readFixed(testFixed662);
-                    testFixedArray657 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed662));
+                    decoder.readFixed(testFixed2);
+                    testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed2));
                 }
-                chunkLen658 = (decoder.arrayNext());
-            } while (chunkLen658 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testFixedArray657 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray656);
+            testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray657);
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray664 = null;
-        long chunkLen665 = (decoder.readArrayStart());
-        if (chunkLen665 > 0) {
-            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse666 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
-                testFixedUnionArrayReuse666 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+                testFixedUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
             }
-            if (testFixedUnionArrayReuse666 != (null)) {
-                testFixedUnionArrayReuse666 .clear();
-                testFixedUnionArray664 = testFixedUnionArrayReuse666;
+            if (testFixedUnionArrayReuse0 != (null)) {
+                testFixedUnionArrayReuse0 .clear();
+                testFixedUnionArray1 = testFixedUnionArrayReuse0;
             } else {
-                testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen665), testFixedUnionArray663);
+                testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
             }
             do {
-                for (int counter667 = 0; (counter667 <chunkLen665); counter667 ++) {
-                    Object testFixedUnionArrayArrayElementReuseVar669 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testFixedUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
-                        testFixedUnionArrayArrayElementReuseVar669 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                        testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
                     }
-                    int unionIndex670 = (decoder.readIndex());
-                    if (unionIndex670 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex670 == 1) {
-                        byte[] testFixed671;
-                        if ((testFixedUnionArrayArrayElementReuseVar669 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes().length == (2))) {
-                            testFixed671 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar669).bytes();
+                    if (unionIndex1 == 1) {
+                        byte[] testFixed3;
+                        if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
+                            testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
                         } else {
-                            testFixed671 = ( new byte[2]);
+                            testFixed3 = ( new byte[2]);
                         }
-                        decoder.readFixed(testFixed671);
-                        testFixedUnionArray664 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed671));
+                        decoder.readFixed(testFixed3);
+                        testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed3));
                     }
                 }
-                chunkLen665 = (decoder.arrayNext());
-            } while (chunkLen665 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testFixedUnionArray664 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray663);
+            testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(0, testFixedUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray664);
+        FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
@@ -13,24 +13,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
 {
 
     private final Schema readerSchema;
-    private final Schema union729;
-    private final Schema unionOptionSchema731;
-    private final Schema subField733;
+    private final Schema union0;
+    private final Schema unionOptionSchema0;
+    private final Schema subField0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.union729 = readerSchema.getField("union").schema();
-        this.unionOptionSchema731 = union729 .getTypes().get(1);
-        this.subField733 = unionOptionSchema731 .getField("subField").schema();
+        this.union0 = readerSchema.getField("union").schema();
+        this.unionOptionSchema0 = union0 .getTypes().get(1);
+        this.subField0 = unionOptionSchema0 .getField("subField").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion728(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
@@ -39,21 +39,21 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex730 = (decoder.readIndex());
-        if (unionIndex730 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex730 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord732(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
         } else {
-            if (unionIndex730 == 2) {
+            if (unionIndex0 == 2) {
                 if (FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0) instanceof Utf8) {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0))));
                 } else {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder).readString(null));
                 }
             } else {
-                if (unionIndex730 == 3) {
+                if (unionIndex0 == 3) {
                     FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
                 }
             }
@@ -61,20 +61,20 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
     }
 
-    public IndexedRecord deserializesubRecord732(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema731)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema731);
+            subRecord = new org.apache.avro.generic.GenericData.Record(unionOptionSchema0);
         }
-        int unionIndex734 = (decoder.readIndex());
-        if (unionIndex734 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex734 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -18,24 +18,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
 {
 
     private final Schema readerSchema;
-    private final Schema mapField736;
-    private final Schema mapFieldMapValueSchema742;
-    private final Schema mapFieldValueMapValueSchema748;
+    private final Schema mapField0;
+    private final Schema mapFieldMapValueSchema0;
+    private final Schema mapFieldValueMapValueSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapField736 = readerSchema.getField("mapField").schema();
-        this.mapFieldMapValueSchema742 = mapField736 .getValueType();
-        this.mapFieldValueMapValueSchema748 = mapFieldMapValueSchema742 .getValueType();
+        this.mapField0 = readerSchema.getField("mapField").schema();
+        this.mapFieldMapValueSchema0 = mapField0 .getValueType();
+        this.mapFieldValueMapValueSchema0 = mapFieldMapValueSchema0 .getValueType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap735(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
@@ -44,79 +44,79 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadNestedMap = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        Map<Utf8, Map<Utf8, List<Integer>>> mapField737 = null;
-        long chunkLen738 = (decoder.readMapStart());
-        if (chunkLen738 > 0) {
-            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse739 = null;
+        Map<Utf8, Map<Utf8, List<Integer>>> mapField1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0) instanceof Map) {
-                mapFieldReuse739 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
+                mapFieldReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0));
             }
-            if (mapFieldReuse739 != (null)) {
-                mapFieldReuse739 .clear();
-                mapField737 = mapFieldReuse739;
+            if (mapFieldReuse0 != (null)) {
+                mapFieldReuse0 .clear();
+                mapField1 = mapFieldReuse0;
             } else {
-                mapField737 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
+                mapField1 = new HashMap<Utf8, Map<Utf8, List<Integer>>>();
             }
             do {
-                for (int counter740 = 0; (counter740 <chunkLen738); counter740 ++) {
-                    Utf8 key741 = (decoder.readString(null));
-                    Map<Utf8, List<Integer>> mapFieldValue743 = null;
-                    long chunkLen744 = (decoder.readMapStart());
-                    if (chunkLen744 > 0) {
-                        Map<Utf8, List<Integer>> mapFieldValueReuse745 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    Map<Utf8, List<Integer>> mapFieldValue0 = null;
+                    long chunkLen1 = (decoder.readMapStart());
+                    if (chunkLen1 > 0) {
+                        Map<Utf8, List<Integer>> mapFieldValueReuse0 = null;
                         if (null instanceof Map) {
-                            mapFieldValueReuse745 = ((Map) null);
+                            mapFieldValueReuse0 = ((Map) null);
                         }
-                        if (mapFieldValueReuse745 != (null)) {
-                            mapFieldValueReuse745 .clear();
-                            mapFieldValue743 = mapFieldValueReuse745;
+                        if (mapFieldValueReuse0 != (null)) {
+                            mapFieldValueReuse0 .clear();
+                            mapFieldValue0 = mapFieldValueReuse0;
                         } else {
-                            mapFieldValue743 = new HashMap<Utf8, List<Integer>>();
+                            mapFieldValue0 = new HashMap<Utf8, List<Integer>>();
                         }
                         do {
-                            for (int counter746 = 0; (counter746 <chunkLen744); counter746 ++) {
-                                Utf8 key747 = (decoder.readString(null));
-                                List<Integer> mapFieldValueValue749 = null;
-                                long chunkLen750 = (decoder.readArrayStart());
-                                if (chunkLen750 > 0) {
-                                    List<Integer> mapFieldValueValueReuse751 = null;
+                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                                Utf8 key1 = (decoder.readString(null));
+                                List<Integer> mapFieldValueValue0 = null;
+                                long chunkLen2 = (decoder.readArrayStart());
+                                if (chunkLen2 > 0) {
+                                    List<Integer> mapFieldValueValueReuse0 = null;
                                     if (null instanceof List) {
-                                        mapFieldValueValueReuse751 = ((List) null);
+                                        mapFieldValueValueReuse0 = ((List) null);
                                     }
-                                    if (mapFieldValueValueReuse751 != (null)) {
-                                        mapFieldValueValueReuse751 .clear();
-                                        mapFieldValueValue749 = mapFieldValueValueReuse751;
+                                    if (mapFieldValueValueReuse0 != (null)) {
+                                        mapFieldValueValueReuse0 .clear();
+                                        mapFieldValueValue0 = mapFieldValueValueReuse0;
                                     } else {
-                                        mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen750), mapFieldValueMapValueSchema748);
+                                        mapFieldValueValue0 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen2), mapFieldValueMapValueSchema0);
                                     }
                                     do {
-                                        for (int counter752 = 0; (counter752 <chunkLen750); counter752 ++) {
-                                            Object mapFieldValueValueArrayElementReuseVar753 = null;
+                                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                                            Object mapFieldValueValueArrayElementReuseVar0 = null;
                                             if (null instanceof GenericArray) {
-                                                mapFieldValueValueArrayElementReuseVar753 = ((GenericArray) null).peek();
+                                                mapFieldValueValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                             }
-                                            mapFieldValueValue749 .add((decoder.readInt()));
+                                            mapFieldValueValue0 .add((decoder.readInt()));
                                         }
-                                        chunkLen750 = (decoder.arrayNext());
-                                    } while (chunkLen750 > 0);
+                                        chunkLen2 = (decoder.arrayNext());
+                                    } while (chunkLen2 > 0);
                                 } else {
-                                    mapFieldValueValue749 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema748);
+                                    mapFieldValueValue0 = new org.apache.avro.generic.GenericData.Array<Integer>(0, mapFieldValueMapValueSchema0);
                                 }
-                                mapFieldValue743 .put(key747, mapFieldValueValue749);
+                                mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }
-                            chunkLen744 = (decoder.mapNext());
-                        } while (chunkLen744 > 0);
+                            chunkLen1 = (decoder.mapNext());
+                        } while (chunkLen1 > 0);
                     } else {
-                        mapFieldValue743 = Collections.emptyMap();
+                        mapFieldValue0 = Collections.emptyMap();
                     }
-                    mapField737 .put(key741, mapFieldValue743);
+                    mapField1 .put(key0, mapFieldValue0);
                 }
-                chunkLen738 = (decoder.mapNext());
-            } while (chunkLen738 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            mapField737 = Collections.emptyMap();
+            mapField1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField737);
+        FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField1);
         return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -14,28 +14,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
 {
 
     private final Schema readerSchema;
-    private final Schema testEnum755;
-    private final Schema testEnumUnion758;
-    private final Schema testEnumArray762;
-    private final Schema testEnumUnionArray770;
-    private final Schema testEnumUnionArrayArrayElemSchema775;
+    private final Schema testEnum0;
+    private final Schema testEnumUnion0;
+    private final Schema testEnumArray0;
+    private final Schema testEnumUnionArray0;
+    private final Schema testEnumUnionArrayArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testEnum755 = readerSchema.getField("testEnum").schema();
-        this.testEnumUnion758 = readerSchema.getField("testEnumUnion").schema();
-        this.testEnumArray762 = readerSchema.getField("testEnumArray").schema();
-        this.testEnumUnionArray770 = readerSchema.getField("testEnumUnionArray").schema();
-        this.testEnumUnionArrayArrayElemSchema775 = testEnumUnionArray770 .getElementType();
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+        this.testEnumUnion0 = readerSchema.getField("testEnumUnion").schema();
+        this.testEnumArray0 = readerSchema.getField("testEnumArray").schema();
+        this.testEnumUnionArray0 = readerSchema.getField("testEnumUnionArray").schema();
+        this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum754(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
@@ -44,142 +44,142 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int enumIndex756 = (decoder.readEnum());
-        org.apache.avro.generic.GenericData.EnumSymbol enumValue757 = null;
-        if (enumIndex756 == 0) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        if (enumIndex0 == 0) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
         }
-        if (enumIndex756 == 1) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+        if (enumIndex0 == 1) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
         }
-        if (enumIndex756 == 2) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+        if (enumIndex0 == 2) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
         }
-        if (enumIndex756 == 3) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+        if (enumIndex0 == 3) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
         }
-        if (enumIndex756 == 4) {
-            enumValue757 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+        if (enumIndex0 == 4) {
+            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue757);
-        int unionIndex759 = (decoder.readIndex());
-        if (unionIndex759 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex759 == 1) {
-            int enumIndex760 = (decoder.readEnum());
-            org.apache.avro.generic.GenericData.EnumSymbol enumValue761 = null;
-            if (enumIndex760 == 0) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+        if (unionIndex0 == 1) {
+            int enumIndex1 = (decoder.readEnum());
+            org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
+            if (enumIndex1 == 0) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
             }
-            if (enumIndex760 == 1) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+            if (enumIndex1 == 1) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
             }
-            if (enumIndex760 == 2) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+            if (enumIndex1 == 2) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
             }
-            if (enumIndex760 == 3) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+            if (enumIndex1 == 3) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
             }
-            if (enumIndex760 == 4) {
-                enumValue761 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+            if (enumIndex1 == 4) {
+                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
             }
-            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue761);
+            FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray763 = null;
-        long chunkLen764 = (decoder.readArrayStart());
-        if (chunkLen764 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse765 = null;
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
-                testEnumArrayReuse765 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+                testEnumArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
             }
-            if (testEnumArrayReuse765 != (null)) {
-                testEnumArrayReuse765 .clear();
-                testEnumArray763 = testEnumArrayReuse765;
+            if (testEnumArrayReuse0 != (null)) {
+                testEnumArrayReuse0 .clear();
+                testEnumArray1 = testEnumArrayReuse0;
             } else {
-                testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen764), testEnumArray762);
+                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
             }
             do {
-                for (int counter766 = 0; (counter766 <chunkLen764); counter766 ++) {
-                    Object testEnumArrayArrayElementReuseVar767 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object testEnumArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof GenericArray) {
-                        testEnumArrayArrayElementReuseVar767 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
+                        testEnumArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2)).peek();
                     }
-                    int enumIndex768 = (decoder.readEnum());
-                    org.apache.avro.generic.GenericData.EnumSymbol enumValue769 = null;
-                    if (enumIndex768 == 0) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                    int enumIndex2 = (decoder.readEnum());
+                    org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
+                    if (enumIndex2 == 0) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
                     }
-                    if (enumIndex768 == 1) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                    if (enumIndex2 == 1) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                     }
-                    if (enumIndex768 == 2) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                    if (enumIndex2 == 2) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                     }
-                    if (enumIndex768 == 3) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                    if (enumIndex2 == 3) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                     }
-                    if (enumIndex768 == 4) {
-                        enumValue769 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                    if (enumIndex2 == 4) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                     }
-                    testEnumArray763 .add(enumValue769);
+                    testEnumArray1 .add(enumValue2);
                 }
-                chunkLen764 = (decoder.arrayNext());
-            } while (chunkLen764 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            testEnumArray763 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray762);
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray763);
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray771 = null;
-        long chunkLen772 = (decoder.readArrayStart());
-        if (chunkLen772 > 0) {
-            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse773 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
-                testEnumUnionArrayReuse773 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+                testEnumUnionArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
             }
-            if (testEnumUnionArrayReuse773 != (null)) {
-                testEnumUnionArrayReuse773 .clear();
-                testEnumUnionArray771 = testEnumUnionArrayReuse773;
+            if (testEnumUnionArrayReuse0 != (null)) {
+                testEnumUnionArrayReuse0 .clear();
+                testEnumUnionArray1 = testEnumUnionArrayReuse0;
             } else {
-                testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen772), testEnumUnionArray770);
+                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
             }
             do {
-                for (int counter774 = 0; (counter774 <chunkLen772); counter774 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar776 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar776 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
                     }
-                    int unionIndex777 = (decoder.readIndex());
-                    if (unionIndex777 == 0) {
+                    int unionIndex1 = (decoder.readIndex());
+                    if (unionIndex1 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex777 == 1) {
-                        int enumIndex778 = (decoder.readEnum());
-                        org.apache.avro.generic.GenericData.EnumSymbol enumValue779 = null;
-                        if (enumIndex778 == 0) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(1));
+                    if (unionIndex1 == 1) {
+                        int enumIndex3 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
+                        if (enumIndex3 == 0) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
                         }
-                        if (enumIndex778 == 1) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(0));
+                        if (enumIndex3 == 1) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                         }
-                        if (enumIndex778 == 2) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(4));
+                        if (enumIndex3 == 2) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                         }
-                        if (enumIndex778 == 3) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(2));
+                        if (enumIndex3 == 3) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                         }
-                        if (enumIndex778 == 4) {
-                            enumValue779 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum755, testEnum755 .getEnumSymbols().get(3));
+                        if (enumIndex3 == 4) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                         }
-                        testEnumUnionArray771 .add(enumValue779);
+                        testEnumUnionArray1 .add(enumValue3);
                     }
                 }
-                chunkLen772 = (decoder.arrayNext());
-            } while (chunkLen772 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            testEnumUnionArray771 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray770);
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(0, testEnumUnionArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray771);
+        FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
@@ -14,32 +14,32 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
 {
 
     private final Schema readerSchema;
-    private final Schema testIntUnion781;
-    private final Schema testStringUnion783;
-    private final Schema testLongUnion785;
-    private final Schema testDoubleUnion787;
-    private final Schema testFloatUnion789;
-    private final Schema testBooleanUnion791;
-    private final Schema testBytesUnion793;
+    private final Schema testIntUnion0;
+    private final Schema testStringUnion0;
+    private final Schema testLongUnion0;
+    private final Schema testDoubleUnion0;
+    private final Schema testFloatUnion0;
+    private final Schema testBooleanUnion0;
+    private final Schema testBytesUnion0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testIntUnion781 = readerSchema.getField("testIntUnion").schema();
-        this.testStringUnion783 = readerSchema.getField("testStringUnion").schema();
-        this.testLongUnion785 = readerSchema.getField("testLongUnion").schema();
-        this.testDoubleUnion787 = readerSchema.getField("testDoubleUnion").schema();
-        this.testFloatUnion789 = readerSchema.getField("testFloatUnion").schema();
-        this.testBooleanUnion791 = readerSchema.getField("testBooleanUnion").schema();
-        this.testBytesUnion793 = readerSchema.getField("testBytesUnion").schema();
+        this.testIntUnion0 = readerSchema.getField("testIntUnion").schema();
+        this.testStringUnion0 = readerSchema.getField("testStringUnion").schema();
+        this.testLongUnion0 = readerSchema.getField("testLongUnion").schema();
+        this.testDoubleUnion0 = readerSchema.getField("testDoubleUnion").schema();
+        this.testFloatUnion0 = readerSchema.getField("testFloatUnion").schema();
+        this.testBooleanUnion0 = readerSchema.getField("testBooleanUnion").schema();
+        this.testBytesUnion0 = readerSchema.getField("testBytesUnion").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives780(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
@@ -49,11 +49,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
-        int unionIndex782 = (decoder.readIndex());
-        if (unionIndex782 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex782 == 1) {
+        if (unionIndex0 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
         }
         if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2) instanceof Utf8) {
@@ -61,11 +61,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, (decoder).readString(null));
         }
-        int unionIndex784 = (decoder.readIndex());
-        if (unionIndex784 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex784 == 1) {
+        if (unionIndex1 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(3, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(3))));
             } else {
@@ -73,35 +73,35 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             }
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
-        int unionIndex786 = (decoder.readIndex());
-        if (unionIndex786 == 0) {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex786 == 1) {
+        if (unionIndex2 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
-        int unionIndex788 = (decoder.readIndex());
-        if (unionIndex788 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex788 == 1) {
+        if (unionIndex3 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
-        int unionIndex790 = (decoder.readIndex());
-        if (unionIndex790 == 0) {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
             decoder.readNull();
         }
-        if (unionIndex790 == 1) {
+        if (unionIndex4 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
-        int unionIndex792 = (decoder.readIndex());
-        if (unionIndex792 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex792 == 1) {
+        if (unionIndex5 == 1) {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
         }
         if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12) instanceof ByteBuffer) {
@@ -109,11 +109,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, (decoder).readBytes((null)));
         }
-        int unionIndex794 = (decoder.readIndex());
-        if (unionIndex794 == 0) {
+        int unionIndex6 = (decoder.readIndex());
+        if (unionIndex6 == 0) {
             decoder.readNull();
         }
-        if (unionIndex794 == 1) {
+        if (unionIndex6 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13) instanceof ByteBuffer) {
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(13, (decoder).readBytes(((ByteBuffer) FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(13))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -18,38 +18,38 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
 {
 
     private final Schema readerSchema;
-    private final Schema recordsArray799;
-    private final Schema recordsArrayArrayElemSchema804;
-    private final Schema subField807;
-    private final Schema recordsMap809;
-    private final Schema recordsArrayUnion815;
-    private final Schema recordsArrayUnionOptionSchema817;
-    private final Schema recordsArrayUnionOptionArrayElemSchema822;
-    private final Schema recordsMapUnion825;
-    private final Schema recordsMapUnionOptionSchema827;
-    private final Schema recordsMapUnionOptionMapValueSchema833;
+    private final Schema recordsArray0;
+    private final Schema recordsArrayArrayElemSchema0;
+    private final Schema subField0;
+    private final Schema recordsMap0;
+    private final Schema recordsArrayUnion0;
+    private final Schema recordsArrayUnionOptionSchema0;
+    private final Schema recordsArrayUnionOptionArrayElemSchema0;
+    private final Schema recordsMapUnion0;
+    private final Schema recordsMapUnionOptionSchema0;
+    private final Schema recordsMapUnionOptionMapValueSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.recordsArray799 = readerSchema.getField("recordsArray").schema();
-        this.recordsArrayArrayElemSchema804 = recordsArray799 .getElementType();
-        this.subField807 = recordsArrayArrayElemSchema804 .getField("subField").schema();
-        this.recordsMap809 = readerSchema.getField("recordsMap").schema();
-        this.recordsArrayUnion815 = readerSchema.getField("recordsArrayUnion").schema();
-        this.recordsArrayUnionOptionSchema817 = recordsArrayUnion815 .getTypes().get(1);
-        this.recordsArrayUnionOptionArrayElemSchema822 = recordsArrayUnionOptionSchema817 .getElementType();
-        this.recordsMapUnion825 = readerSchema.getField("recordsMapUnion").schema();
-        this.recordsMapUnionOptionSchema827 = recordsMapUnion825 .getTypes().get(1);
-        this.recordsMapUnionOptionMapValueSchema833 = recordsMapUnionOptionSchema827 .getValueType();
+        this.recordsArray0 = readerSchema.getField("recordsArray").schema();
+        this.recordsArrayArrayElemSchema0 = recordsArray0 .getElementType();
+        this.subField0 = recordsArrayArrayElemSchema0 .getField("subField").schema();
+        this.recordsMap0 = readerSchema.getField("recordsMap").schema();
+        this.recordsArrayUnion0 = readerSchema.getField("recordsArrayUnion").schema();
+        this.recordsArrayUnionOptionSchema0 = recordsArrayUnion0 .getTypes().get(1);
+        this.recordsArrayUnionOptionArrayElemSchema0 = recordsArrayUnionOptionSchema0 .getElementType();
+        this.recordsMapUnion0 = readerSchema.getField("recordsMapUnion").schema();
+        this.recordsMapUnionOptionSchema0 = recordsMapUnion0 .getTypes().get(1);
+        this.recordsMapUnionOptionMapValueSchema0 = recordsMapUnionOptionSchema0 .getValueType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField798(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
@@ -58,149 +58,149 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        List<IndexedRecord> recordsArray800 = null;
-        long chunkLen801 = (decoder.readArrayStart());
-        if (chunkLen801 > 0) {
-            List<IndexedRecord> recordsArrayReuse802 = null;
+        List<IndexedRecord> recordsArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<IndexedRecord> recordsArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
-                recordsArrayReuse802 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+                recordsArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
             }
-            if (recordsArrayReuse802 != (null)) {
-                recordsArrayReuse802 .clear();
-                recordsArray800 = recordsArrayReuse802;
+            if (recordsArrayReuse0 != (null)) {
+                recordsArrayReuse0 .clear();
+                recordsArray1 = recordsArrayReuse0;
             } else {
-                recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen801), recordsArray799);
+                recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
             }
             do {
-                for (int counter803 = 0; (counter803 <chunkLen801); counter803 ++) {
-                    Object recordsArrayArrayElementReuseVar805 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object recordsArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayArrayElementReuseVar805 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                        recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
                     }
-                    recordsArray800 .add(deserializesubRecord806(recordsArrayArrayElementReuseVar805, (decoder)));
+                    recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen801 = (decoder.arrayNext());
-            } while (chunkLen801 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            recordsArray800 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray799);
+            recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray800);
-        Map<Utf8, IndexedRecord> recordsMap810 = null;
-        long chunkLen811 = (decoder.readMapStart());
-        if (chunkLen811 > 0) {
-            Map<Utf8, IndexedRecord> recordsMapReuse812 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
+        Map<Utf8, IndexedRecord> recordsMap1 = null;
+        long chunkLen1 = (decoder.readMapStart());
+        if (chunkLen1 > 0) {
+            Map<Utf8, IndexedRecord> recordsMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1) instanceof Map) {
-                recordsMapReuse812 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
+                recordsMapReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1));
             }
-            if (recordsMapReuse812 != (null)) {
-                recordsMapReuse812 .clear();
-                recordsMap810 = recordsMapReuse812;
+            if (recordsMapReuse0 != (null)) {
+                recordsMapReuse0 .clear();
+                recordsMap1 = recordsMapReuse0;
             } else {
-                recordsMap810 = new HashMap<Utf8, IndexedRecord>();
+                recordsMap1 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter813 = 0; (counter813 <chunkLen811); counter813 ++) {
-                    Utf8 key814 = (decoder.readString(null));
-                    recordsMap810 .put(key814, deserializesubRecord806(null, (decoder)));
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    recordsMap1 .put(key0, deserializesubRecord0(null, (decoder)));
                 }
-                chunkLen811 = (decoder.mapNext());
-            } while (chunkLen811 > 0);
+                chunkLen1 = (decoder.mapNext());
+            } while (chunkLen1 > 0);
         } else {
-            recordsMap810 = Collections.emptyMap();
+            recordsMap1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap810);
-        int unionIndex816 = (decoder.readIndex());
-        if (unionIndex816 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap1);
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex816 == 1) {
-            List<IndexedRecord> recordsArrayUnionOption818 = null;
-            long chunkLen819 = (decoder.readArrayStart());
-            if (chunkLen819 > 0) {
-                List<IndexedRecord> recordsArrayUnionOptionReuse820 = null;
+        if (unionIndex1 == 1) {
+            List<IndexedRecord> recordsArrayUnionOption0 = null;
+            long chunkLen2 = (decoder.readArrayStart());
+            if (chunkLen2 > 0) {
+                List<IndexedRecord> recordsArrayUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
-                    recordsArrayUnionOptionReuse820 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                    recordsArrayUnionOptionReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
                 }
-                if (recordsArrayUnionOptionReuse820 != (null)) {
-                    recordsArrayUnionOptionReuse820 .clear();
-                    recordsArrayUnionOption818 = recordsArrayUnionOptionReuse820;
+                if (recordsArrayUnionOptionReuse0 != (null)) {
+                    recordsArrayUnionOptionReuse0 .clear();
+                    recordsArrayUnionOption0 = recordsArrayUnionOptionReuse0;
                 } else {
-                    recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen819), recordsArrayUnionOptionSchema817);
+                    recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
                 }
                 do {
-                    for (int counter821 = 0; (counter821 <chunkLen819); counter821 ++) {
-                        Object recordsArrayUnionOptionArrayElementReuseVar823 = null;
+                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
                         if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
-                            recordsArrayUnionOptionArrayElementReuseVar823 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                            recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
                         }
-                        int unionIndex824 = (decoder.readIndex());
-                        if (unionIndex824 == 0) {
+                        int unionIndex2 = (decoder.readIndex());
+                        if (unionIndex2 == 0) {
                             decoder.readNull();
                         }
-                        if (unionIndex824 == 1) {
-                            recordsArrayUnionOption818 .add(deserializesubRecord806(recordsArrayUnionOptionArrayElementReuseVar823, (decoder)));
+                        if (unionIndex2 == 1) {
+                            recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
                         }
                     }
-                    chunkLen819 = (decoder.arrayNext());
-                } while (chunkLen819 > 0);
+                    chunkLen2 = (decoder.arrayNext());
+                } while (chunkLen2 > 0);
             } else {
-                recordsArrayUnionOption818 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema817);
+                recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsArrayUnionOptionSchema0);
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption818);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption0);
         }
-        int unionIndex826 = (decoder.readIndex());
-        if (unionIndex826 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex826 == 1) {
-            Map<Utf8, IndexedRecord> recordsMapUnionOption828 = null;
-            long chunkLen829 = (decoder.readMapStart());
-            if (chunkLen829 > 0) {
-                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse830 = null;
+        if (unionIndex3 == 1) {
+            Map<Utf8, IndexedRecord> recordsMapUnionOption0 = null;
+            long chunkLen3 = (decoder.readMapStart());
+            if (chunkLen3 > 0) {
+                Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3) instanceof Map) {
-                    recordsMapUnionOptionReuse830 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
+                    recordsMapUnionOptionReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3));
                 }
-                if (recordsMapUnionOptionReuse830 != (null)) {
-                    recordsMapUnionOptionReuse830 .clear();
-                    recordsMapUnionOption828 = recordsMapUnionOptionReuse830;
+                if (recordsMapUnionOptionReuse0 != (null)) {
+                    recordsMapUnionOptionReuse0 .clear();
+                    recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
                 } else {
-                    recordsMapUnionOption828 = new HashMap<Utf8, IndexedRecord>();
+                    recordsMapUnionOption0 = new HashMap<Utf8, IndexedRecord>();
                 }
                 do {
-                    for (int counter831 = 0; (counter831 <chunkLen829); counter831 ++) {
-                        Utf8 key832 = (decoder.readString(null));
-                        int unionIndex834 = (decoder.readIndex());
-                        if (unionIndex834 == 0) {
+                    for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                        Utf8 key1 = (decoder.readString(null));
+                        int unionIndex4 = (decoder.readIndex());
+                        if (unionIndex4 == 0) {
                             decoder.readNull();
                         }
-                        if (unionIndex834 == 1) {
-                            recordsMapUnionOption828 .put(key832, deserializesubRecord806(null, (decoder)));
+                        if (unionIndex4 == 1) {
+                            recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder)));
                         }
                     }
-                    chunkLen829 = (decoder.mapNext());
-                } while (chunkLen829 > 0);
+                    chunkLen3 = (decoder.mapNext());
+                } while (chunkLen3 > 0);
             } else {
-                recordsMapUnionOption828 = Collections.emptyMap();
+                recordsMapUnionOption0 = Collections.emptyMap();
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption828);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption0);
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord806(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema804)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayArrayElemSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema804);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayArrayElemSchema0);
         }
-        int unionIndex808 = (decoder.readIndex());
-        if (unionIndex808 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex808 == 1) {
+        if (unionIndex0 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -18,46 +18,46 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
 {
 
     private final Schema readerSchema;
-    private final Schema recordsArrayMap836;
-    private final Schema recordsArrayMapArrayElemSchema841;
-    private final Schema recordsArrayMapElemMapValueSchema848;
-    private final Schema recordsArrayMapElemValueOptionSchema850;
-    private final Schema subField852;
-    private final Schema recordsMapArray854;
-    private final Schema recordsMapArrayMapValueSchema860;
-    private final Schema recordsMapArrayValueArrayElemSchema865;
-    private final Schema recordsArrayMapUnion868;
-    private final Schema recordsArrayMapUnionOptionArrayElemSchema874;
-    private final Schema recordsArrayMapUnionOptionElemMapValueSchema881;
-    private final Schema recordsMapArrayUnion883;
-    private final Schema recordsMapArrayUnionOptionSchema885;
-    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema895;
+    private final Schema recordsArrayMap0;
+    private final Schema recordsArrayMapArrayElemSchema0;
+    private final Schema recordsArrayMapElemMapValueSchema0;
+    private final Schema recordsArrayMapElemValueOptionSchema0;
+    private final Schema subField0;
+    private final Schema recordsMapArray0;
+    private final Schema recordsMapArrayMapValueSchema0;
+    private final Schema recordsMapArrayValueArrayElemSchema0;
+    private final Schema recordsArrayMapUnion0;
+    private final Schema recordsArrayMapUnionOptionArrayElemSchema0;
+    private final Schema recordsArrayMapUnionOptionElemMapValueSchema0;
+    private final Schema recordsMapArrayUnion0;
+    private final Schema recordsMapArrayUnionOptionSchema0;
+    private final Schema recordsMapArrayUnionOptionValueArrayElemSchema0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.recordsArrayMap836 = readerSchema.getField("recordsArrayMap").schema();
-        this.recordsArrayMapArrayElemSchema841 = recordsArrayMap836 .getElementType();
-        this.recordsArrayMapElemMapValueSchema848 = recordsArrayMapArrayElemSchema841 .getValueType();
-        this.recordsArrayMapElemValueOptionSchema850 = recordsArrayMapElemMapValueSchema848 .getTypes().get(1);
-        this.subField852 = recordsArrayMapElemValueOptionSchema850 .getField("subField").schema();
-        this.recordsMapArray854 = readerSchema.getField("recordsMapArray").schema();
-        this.recordsMapArrayMapValueSchema860 = recordsMapArray854 .getValueType();
-        this.recordsMapArrayValueArrayElemSchema865 = recordsMapArrayMapValueSchema860 .getElementType();
-        this.recordsArrayMapUnion868 = readerSchema.getField("recordsArrayMapUnion").schema();
-        this.recordsArrayMapUnionOptionArrayElemSchema874 = recordsArrayMap836 .getElementType();
-        this.recordsArrayMapUnionOptionElemMapValueSchema881 = recordsArrayMapUnionOptionArrayElemSchema874 .getValueType();
-        this.recordsMapArrayUnion883 = readerSchema.getField("recordsMapArrayUnion").schema();
-        this.recordsMapArrayUnionOptionSchema885 = recordsMapArrayUnion883 .getTypes().get(1);
-        this.recordsMapArrayUnionOptionValueArrayElemSchema895 = recordsMapArrayMapValueSchema860 .getElementType();
+        this.recordsArrayMap0 = readerSchema.getField("recordsArrayMap").schema();
+        this.recordsArrayMapArrayElemSchema0 = recordsArrayMap0 .getElementType();
+        this.recordsArrayMapElemMapValueSchema0 = recordsArrayMapArrayElemSchema0 .getValueType();
+        this.recordsArrayMapElemValueOptionSchema0 = recordsArrayMapElemMapValueSchema0 .getTypes().get(1);
+        this.subField0 = recordsArrayMapElemValueOptionSchema0 .getField("subField").schema();
+        this.recordsMapArray0 = readerSchema.getField("recordsMapArray").schema();
+        this.recordsMapArrayMapValueSchema0 = recordsMapArray0 .getValueType();
+        this.recordsMapArrayValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
+        this.recordsArrayMapUnion0 = readerSchema.getField("recordsArrayMapUnion").schema();
+        this.recordsArrayMapUnionOptionArrayElemSchema0 = recordsArrayMap0 .getElementType();
+        this.recordsArrayMapUnionOptionElemMapValueSchema0 = recordsArrayMapUnionOptionArrayElemSchema0 .getValueType();
+        this.recordsMapArrayUnion0 = readerSchema.getField("recordsMapArrayUnion").schema();
+        this.recordsMapArrayUnionOptionSchema0 = recordsMapArrayUnion0 .getTypes().get(1);
+        this.recordsMapArrayUnionOptionValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField835(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
@@ -66,259 +66,259 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        List<Map<Utf8, IndexedRecord>> recordsArrayMap837 = null;
-        long chunkLen838 = (decoder.readArrayStart());
-        if (chunkLen838 > 0) {
-            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse839 = null;
+        List<Map<Utf8, IndexedRecord>> recordsArrayMap1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if (chunkLen0 > 0) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
-                recordsArrayMapReuse839 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+                recordsArrayMapReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
             }
-            if (recordsArrayMapReuse839 != (null)) {
-                recordsArrayMapReuse839 .clear();
-                recordsArrayMap837 = recordsArrayMapReuse839;
+            if (recordsArrayMapReuse0 != (null)) {
+                recordsArrayMapReuse0 .clear();
+                recordsArrayMap1 = recordsArrayMapReuse0;
             } else {
-                recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen838), recordsArrayMap836);
+                recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
             }
             do {
-                for (int counter840 = 0; (counter840 <chunkLen838); counter840 ++) {
-                    Object recordsArrayMapArrayElementReuseVar842 = null;
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Object recordsArrayMapArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayMapArrayElementReuseVar842 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                        recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
                     }
-                    Map<Utf8, IndexedRecord> recordsArrayMapElem843 = null;
-                    long chunkLen844 = (decoder.readMapStart());
-                    if (chunkLen844 > 0) {
-                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse845 = null;
-                        if (recordsArrayMapArrayElementReuseVar842 instanceof Map) {
-                            recordsArrayMapElemReuse845 = ((Map) recordsArrayMapArrayElementReuseVar842);
+                    Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
+                    long chunkLen1 = (decoder.readMapStart());
+                    if (chunkLen1 > 0) {
+                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
+                        if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
+                            recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
                         }
-                        if (recordsArrayMapElemReuse845 != (null)) {
-                            recordsArrayMapElemReuse845 .clear();
-                            recordsArrayMapElem843 = recordsArrayMapElemReuse845;
+                        if (recordsArrayMapElemReuse0 != (null)) {
+                            recordsArrayMapElemReuse0 .clear();
+                            recordsArrayMapElem0 = recordsArrayMapElemReuse0;
                         } else {
-                            recordsArrayMapElem843 = new HashMap<Utf8, IndexedRecord>();
+                            recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
                         }
                         do {
-                            for (int counter846 = 0; (counter846 <chunkLen844); counter846 ++) {
-                                Utf8 key847 = (decoder.readString(null));
-                                int unionIndex849 = (decoder.readIndex());
-                                if (unionIndex849 == 0) {
+                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                                Utf8 key0 = (decoder.readString(null));
+                                int unionIndex0 = (decoder.readIndex());
+                                if (unionIndex0 == 0) {
                                     decoder.readNull();
                                 }
-                                if (unionIndex849 == 1) {
-                                    recordsArrayMapElem843 .put(key847, deserializesubRecord851(null, (decoder)));
+                                if (unionIndex0 == 1) {
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
                                 }
                             }
-                            chunkLen844 = (decoder.mapNext());
-                        } while (chunkLen844 > 0);
+                            chunkLen1 = (decoder.mapNext());
+                        } while (chunkLen1 > 0);
                     } else {
-                        recordsArrayMapElem843 = Collections.emptyMap();
+                        recordsArrayMapElem0 = Collections.emptyMap();
                     }
-                    recordsArrayMap837 .add(recordsArrayMapElem843);
+                    recordsArrayMap1 .add(recordsArrayMapElem0);
                 }
-                chunkLen838 = (decoder.arrayNext());
-            } while (chunkLen838 > 0);
+                chunkLen0 = (decoder.arrayNext());
+            } while (chunkLen0 > 0);
         } else {
-            recordsArrayMap837 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+            recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap0);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap837);
-        Map<Utf8, List<IndexedRecord>> recordsMapArray855 = null;
-        long chunkLen856 = (decoder.readMapStart());
-        if (chunkLen856 > 0) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse857 = null;
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
+        Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
+        long chunkLen2 = (decoder.readMapStart());
+        if (chunkLen2 > 0) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1) instanceof Map) {
-                recordsMapArrayReuse857 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
+                recordsMapArrayReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1));
             }
-            if (recordsMapArrayReuse857 != (null)) {
-                recordsMapArrayReuse857 .clear();
-                recordsMapArray855 = recordsMapArrayReuse857;
+            if (recordsMapArrayReuse0 != (null)) {
+                recordsMapArrayReuse0 .clear();
+                recordsMapArray1 = recordsMapArrayReuse0;
             } else {
-                recordsMapArray855 = new HashMap<Utf8, List<IndexedRecord>>();
+                recordsMapArray1 = new HashMap<Utf8, List<IndexedRecord>>();
             }
             do {
-                for (int counter858 = 0; (counter858 <chunkLen856); counter858 ++) {
-                    Utf8 key859 = (decoder.readString(null));
-                    List<IndexedRecord> recordsMapArrayValue861 = null;
-                    long chunkLen862 = (decoder.readArrayStart());
-                    if (chunkLen862 > 0) {
-                        List<IndexedRecord> recordsMapArrayValueReuse863 = null;
+                for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                    Utf8 key1 = (decoder.readString(null));
+                    List<IndexedRecord> recordsMapArrayValue0 = null;
+                    long chunkLen3 = (decoder.readArrayStart());
+                    if (chunkLen3 > 0) {
+                        List<IndexedRecord> recordsMapArrayValueReuse0 = null;
                         if (null instanceof List) {
-                            recordsMapArrayValueReuse863 = ((List) null);
+                            recordsMapArrayValueReuse0 = ((List) null);
                         }
-                        if (recordsMapArrayValueReuse863 != (null)) {
-                            recordsMapArrayValueReuse863 .clear();
-                            recordsMapArrayValue861 = recordsMapArrayValueReuse863;
+                        if (recordsMapArrayValueReuse0 != (null)) {
+                            recordsMapArrayValueReuse0 .clear();
+                            recordsMapArrayValue0 = recordsMapArrayValueReuse0;
                         } else {
-                            recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen862), recordsMapArrayMapValueSchema860);
+                            recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
                         }
                         do {
-                            for (int counter864 = 0; (counter864 <chunkLen862); counter864 ++) {
-                                Object recordsMapArrayValueArrayElementReuseVar866 = null;
+                            for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                                Object recordsMapArrayValueArrayElementReuseVar0 = null;
                                 if (null instanceof GenericArray) {
-                                    recordsMapArrayValueArrayElementReuseVar866 = ((GenericArray) null).peek();
+                                    recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                 }
-                                int unionIndex867 = (decoder.readIndex());
-                                if (unionIndex867 == 0) {
+                                int unionIndex2 = (decoder.readIndex());
+                                if (unionIndex2 == 0) {
                                     decoder.readNull();
                                 }
-                                if (unionIndex867 == 1) {
-                                    recordsMapArrayValue861 .add(deserializesubRecord851(recordsMapArrayValueArrayElementReuseVar866, (decoder)));
+                                if (unionIndex2 == 1) {
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
                                 }
                             }
-                            chunkLen862 = (decoder.arrayNext());
-                        } while (chunkLen862 > 0);
+                            chunkLen3 = (decoder.arrayNext());
+                        } while (chunkLen3 > 0);
                     } else {
-                        recordsMapArrayValue861 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                        recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema0);
                     }
-                    recordsMapArray855 .put(key859, recordsMapArrayValue861);
+                    recordsMapArray1 .put(key1, recordsMapArrayValue0);
                 }
-                chunkLen856 = (decoder.mapNext());
-            } while (chunkLen856 > 0);
+                chunkLen2 = (decoder.mapNext());
+            } while (chunkLen2 > 0);
         } else {
-            recordsMapArray855 = Collections.emptyMap();
+            recordsMapArray1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray855);
-        int unionIndex869 = (decoder.readIndex());
-        if (unionIndex869 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray1);
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex869 == 1) {
-            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption870 = null;
-            long chunkLen871 = (decoder.readArrayStart());
-            if (chunkLen871 > 0) {
-                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse872 = null;
+        if (unionIndex3 == 1) {
+            List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption0 = null;
+            long chunkLen4 = (decoder.readArrayStart());
+            if (chunkLen4 > 0) {
+                List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
-                    recordsArrayMapUnionOptionReuse872 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                    recordsArrayMapUnionOptionReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
                 }
-                if (recordsArrayMapUnionOptionReuse872 != (null)) {
-                    recordsArrayMapUnionOptionReuse872 .clear();
-                    recordsArrayMapUnionOption870 = recordsArrayMapUnionOptionReuse872;
+                if (recordsArrayMapUnionOptionReuse0 != (null)) {
+                    recordsArrayMapUnionOptionReuse0 .clear();
+                    recordsArrayMapUnionOption0 = recordsArrayMapUnionOptionReuse0;
                 } else {
-                    recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen871), recordsArrayMap836);
+                    recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
                 }
                 do {
-                    for (int counter873 = 0; (counter873 <chunkLen871); counter873 ++) {
-                        Object recordsArrayMapUnionOptionArrayElementReuseVar875 = null;
+                    for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
                         if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
-                            recordsArrayMapUnionOptionArrayElementReuseVar875 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                            recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
                         }
-                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem876 = null;
-                        long chunkLen877 = (decoder.readMapStart());
-                        if (chunkLen877 > 0) {
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse878 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar875 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse878 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar875);
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
+                        long chunkLen5 = (decoder.readMapStart());
+                        if (chunkLen5 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
                             }
-                            if (recordsArrayMapUnionOptionElemReuse878 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse878 .clear();
-                                recordsArrayMapUnionOptionElem876 = recordsArrayMapUnionOptionElemReuse878;
+                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse0 .clear();
+                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
                             } else {
-                                recordsArrayMapUnionOptionElem876 = new HashMap<Utf8, IndexedRecord>();
+                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
                             }
                             do {
-                                for (int counter879 = 0; (counter879 <chunkLen877); counter879 ++) {
-                                    Utf8 key880 = (decoder.readString(null));
-                                    int unionIndex882 = (decoder.readIndex());
-                                    if (unionIndex882 == 0) {
+                                for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
+                                    Utf8 key2 = (decoder.readString(null));
+                                    int unionIndex4 = (decoder.readIndex());
+                                    if (unionIndex4 == 0) {
                                         decoder.readNull();
                                     }
-                                    if (unionIndex882 == 1) {
-                                        recordsArrayMapUnionOptionElem876 .put(key880, deserializesubRecord851(null, (decoder)));
+                                    if (unionIndex4 == 1) {
+                                        recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
                                     }
                                 }
-                                chunkLen877 = (decoder.mapNext());
-                            } while (chunkLen877 > 0);
+                                chunkLen5 = (decoder.mapNext());
+                            } while (chunkLen5 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem876 = Collections.emptyMap();
+                            recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
                         }
-                        recordsArrayMapUnionOption870 .add(recordsArrayMapUnionOptionElem876);
+                        recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
-                    chunkLen871 = (decoder.arrayNext());
-                } while (chunkLen871 > 0);
+                    chunkLen4 = (decoder.arrayNext());
+                } while (chunkLen4 > 0);
             } else {
-                recordsArrayMapUnionOption870 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap836);
+                recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(0, recordsArrayMap0);
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption870);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption0);
         }
-        int unionIndex884 = (decoder.readIndex());
-        if (unionIndex884 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex884 == 1) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption886 = null;
-            long chunkLen887 = (decoder.readMapStart());
-            if (chunkLen887 > 0) {
-                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse888 = null;
+        if (unionIndex5 == 1) {
+            Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption0 = null;
+            long chunkLen6 = (decoder.readMapStart());
+            if (chunkLen6 > 0) {
+                Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse0 = null;
                 if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3) instanceof Map) {
-                    recordsMapArrayUnionOptionReuse888 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
+                    recordsMapArrayUnionOptionReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3));
                 }
-                if (recordsMapArrayUnionOptionReuse888 != (null)) {
-                    recordsMapArrayUnionOptionReuse888 .clear();
-                    recordsMapArrayUnionOption886 = recordsMapArrayUnionOptionReuse888;
+                if (recordsMapArrayUnionOptionReuse0 != (null)) {
+                    recordsMapArrayUnionOptionReuse0 .clear();
+                    recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
                 } else {
-                    recordsMapArrayUnionOption886 = new HashMap<Utf8, List<IndexedRecord>>();
+                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<IndexedRecord>>();
                 }
                 do {
-                    for (int counter889 = 0; (counter889 <chunkLen887); counter889 ++) {
-                        Utf8 key890 = (decoder.readString(null));
-                        List<IndexedRecord> recordsMapArrayUnionOptionValue891 = null;
-                        long chunkLen892 = (decoder.readArrayStart());
-                        if (chunkLen892 > 0) {
-                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse893 = null;
+                    for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
+                        Utf8 key3 = (decoder.readString(null));
+                        List<IndexedRecord> recordsMapArrayUnionOptionValue0 = null;
+                        long chunkLen7 = (decoder.readArrayStart());
+                        if (chunkLen7 > 0) {
+                            List<IndexedRecord> recordsMapArrayUnionOptionValueReuse0 = null;
                             if (null instanceof List) {
-                                recordsMapArrayUnionOptionValueReuse893 = ((List) null);
+                                recordsMapArrayUnionOptionValueReuse0 = ((List) null);
                             }
-                            if (recordsMapArrayUnionOptionValueReuse893 != (null)) {
-                                recordsMapArrayUnionOptionValueReuse893 .clear();
-                                recordsMapArrayUnionOptionValue891 = recordsMapArrayUnionOptionValueReuse893;
+                            if (recordsMapArrayUnionOptionValueReuse0 != (null)) {
+                                recordsMapArrayUnionOptionValueReuse0 .clear();
+                                recordsMapArrayUnionOptionValue0 = recordsMapArrayUnionOptionValueReuse0;
                             } else {
-                                recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen892), recordsMapArrayMapValueSchema860);
+                                recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
                             }
                             do {
-                                for (int counter894 = 0; (counter894 <chunkLen892); counter894 ++) {
-                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar896 = null;
+                                for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
                                     if (null instanceof GenericArray) {
-                                        recordsMapArrayUnionOptionValueArrayElementReuseVar896 = ((GenericArray) null).peek();
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
                                     }
-                                    int unionIndex897 = (decoder.readIndex());
-                                    if (unionIndex897 == 0) {
+                                    int unionIndex6 = (decoder.readIndex());
+                                    if (unionIndex6 == 0) {
                                         decoder.readNull();
                                     }
-                                    if (unionIndex897 == 1) {
-                                        recordsMapArrayUnionOptionValue891 .add(deserializesubRecord851(recordsMapArrayUnionOptionValueArrayElementReuseVar896, (decoder)));
+                                    if (unionIndex6 == 1) {
+                                        recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
                                     }
                                 }
-                                chunkLen892 = (decoder.arrayNext());
-                            } while (chunkLen892 > 0);
+                                chunkLen7 = (decoder.arrayNext());
+                            } while (chunkLen7 > 0);
                         } else {
-                            recordsMapArrayUnionOptionValue891 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema860);
+                            recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, recordsMapArrayMapValueSchema0);
                         }
-                        recordsMapArrayUnionOption886 .put(key890, recordsMapArrayUnionOptionValue891);
+                        recordsMapArrayUnionOption0 .put(key3, recordsMapArrayUnionOptionValue0);
                     }
-                    chunkLen887 = (decoder.mapNext());
-                } while (chunkLen887 > 0);
+                    chunkLen6 = (decoder.mapNext());
+                } while (chunkLen6 > 0);
             } else {
-                recordsMapArrayUnionOption886 = Collections.emptyMap();
+                recordsMapArrayUnionOption0 = Collections.emptyMap();
             }
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption886);
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption0);
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord851(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema850)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordsArrayMapElemValueOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema850);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordsArrayMapElemValueOptionSchema0);
         }
-        int unionIndex853 = (decoder.readIndex());
-        if (unionIndex853 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex853 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
@@ -13,26 +13,26 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
 {
 
     private final Schema readerSchema;
-    private final Schema record899;
-    private final Schema recordOptionSchema901;
-    private final Schema subField903;
-    private final Schema field905;
+    private final Schema record0;
+    private final Schema recordOptionSchema0;
+    private final Schema subField0;
+    private final Schema field0;
 
     public FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.record899 = readerSchema.getField("record").schema();
-        this.recordOptionSchema901 = record899 .getTypes().get(1);
-        this.subField903 = recordOptionSchema901 .getField("subField").schema();
-        this.field905 = readerSchema.getField("field").schema();
+        this.record0 = readerSchema.getField("record").schema();
+        this.recordOptionSchema0 = record0 .getTypes().get(1);
+        this.subField0 = recordOptionSchema0 .getField("subField").schema();
+        this.field0 = readerSchema.getField("field").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField898(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
@@ -41,19 +41,19 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex900 = (decoder.readIndex());
-        if (unionIndex900 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex900 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+        if (unionIndex0 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord902(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
-        int unionIndex906 = (decoder.readIndex());
-        if (unionIndex906 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex906 == 1) {
+        if (unionIndex2 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(2, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(2))));
             } else {
@@ -63,20 +63,20 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
     }
 
-    public IndexedRecord deserializesubRecord902(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema901)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema901);
+            subRecord = new org.apache.avro.generic.GenericData.Record(recordOptionSchema0);
         }
-        int unionIndex904 = (decoder.readIndex());
-        if (unionIndex904 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex904 == 1) {
+        if (unionIndex1 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -18,34 +18,34 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
 {
 
     private final Schema readerSchema;
-    private final Schema testNotRemoved908;
-    private final Schema testNotRemoved2911;
-    private final Schema subRecord913;
-    private final Schema subRecordOptionSchema915;
-    private final Schema testNotRemoved917;
-    private final Schema testNotRemoved2920;
-    private final Schema subRecordMap922;
-    private final Schema subRecordArray928;
+    private final Schema testNotRemoved0;
+    private final Schema testNotRemoved20;
+    private final Schema subRecord0;
+    private final Schema subRecordOptionSchema0;
+    private final Schema testNotRemoved1;
+    private final Schema testNotRemoved21;
+    private final Schema subRecordMap0;
+    private final Schema subRecordArray0;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.testNotRemoved908 = readerSchema.getField("testNotRemoved").schema();
-        this.testNotRemoved2911 = readerSchema.getField("testNotRemoved2").schema();
-        this.subRecord913 = readerSchema.getField("subRecord").schema();
-        this.subRecordOptionSchema915 = subRecord913 .getTypes().get(1);
-        this.testNotRemoved917 = subRecordOptionSchema915 .getField("testNotRemoved").schema();
-        this.testNotRemoved2920 = subRecordOptionSchema915 .getField("testNotRemoved2").schema();
-        this.subRecordMap922 = readerSchema.getField("subRecordMap").schema();
-        this.subRecordArray928 = readerSchema.getField("subRecordArray").schema();
+        this.testNotRemoved0 = readerSchema.getField("testNotRemoved").schema();
+        this.testNotRemoved20 = readerSchema.getField("testNotRemoved2").schema();
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordOptionSchema0 = subRecord0 .getTypes().get(1);
+        this.testNotRemoved1 = subRecordOptionSchema0 .getField("testNotRemoved").schema();
+        this.testNotRemoved21 = subRecordOptionSchema0 .getField("testNotRemoved2").schema();
+        this.subRecordMap0 = readerSchema.getField("subRecordMap").schema();
+        this.subRecordArray0 = readerSchema.getField("subRecordArray").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField907(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
@@ -54,128 +54,128 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedField = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        int unionIndex909 = (decoder.readIndex());
-        if (unionIndex909 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex909 == 1) {
+        if (unionIndex0 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(0))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex910 = (decoder.readIndex());
-        if (unionIndex910 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex910 == 1) {
+        if (unionIndex1 == 1) {
             decoder.skipString();
         }
-        int unionIndex912 = (decoder.readIndex());
-        if (unionIndex912 == 0) {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
             decoder.readNull();
         }
-        if (unionIndex912 == 1) {
+        if (unionIndex2 == 1) {
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1) instanceof Utf8) {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(1))));
             } else {
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(1, (decoder).readString(null));
             }
         }
-        int unionIndex914 = (decoder.readIndex());
-        if (unionIndex914 == 0) {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
             decoder.readNull();
         }
-        if (unionIndex914 == 1) {
-            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord916(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+        if (unionIndex3 == 1) {
+            FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
         }
-        Map<Utf8, IndexedRecord> subRecordMap923 = null;
-        long chunkLen924 = (decoder.readMapStart());
-        if (chunkLen924 > 0) {
-            Map<Utf8, IndexedRecord> subRecordMapReuse925 = null;
+        Map<Utf8, IndexedRecord> subRecordMap1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> subRecordMapReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3) instanceof Map) {
-                subRecordMapReuse925 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
+                subRecordMapReuse0 = ((Map) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3));
             }
-            if (subRecordMapReuse925 != (null)) {
-                subRecordMapReuse925 .clear();
-                subRecordMap923 = subRecordMapReuse925;
+            if (subRecordMapReuse0 != (null)) {
+                subRecordMapReuse0 .clear();
+                subRecordMap1 = subRecordMapReuse0;
             } else {
-                subRecordMap923 = new HashMap<Utf8, IndexedRecord>();
+                subRecordMap1 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter926 = 0; (counter926 <chunkLen924); counter926 ++) {
-                    Utf8 key927 = (decoder.readString(null));
-                    subRecordMap923 .put(key927, deserializesubRecord916(null, (decoder)));
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    subRecordMap1 .put(key0, deserializesubRecord0(null, (decoder)));
                 }
-                chunkLen924 = (decoder.mapNext());
-            } while (chunkLen924 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            subRecordMap923 = Collections.emptyMap();
+            subRecordMap1 = Collections.emptyMap();
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap923);
-        List<IndexedRecord> subRecordArray929 = null;
-        long chunkLen930 = (decoder.readArrayStart());
-        if (chunkLen930 > 0) {
-            List<IndexedRecord> subRecordArrayReuse931 = null;
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
+        List<IndexedRecord> subRecordArray1 = null;
+        long chunkLen1 = (decoder.readArrayStart());
+        if (chunkLen1 > 0) {
+            List<IndexedRecord> subRecordArrayReuse0 = null;
             if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
-                subRecordArrayReuse931 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+                subRecordArrayReuse0 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
             }
-            if (subRecordArrayReuse931 != (null)) {
-                subRecordArrayReuse931 .clear();
-                subRecordArray929 = subRecordArrayReuse931;
+            if (subRecordArrayReuse0 != (null)) {
+                subRecordArrayReuse0 .clear();
+                subRecordArray1 = subRecordArrayReuse0;
             } else {
-                subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen930), subRecordArray928);
+                subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
             }
             do {
-                for (int counter932 = 0; (counter932 <chunkLen930); counter932 ++) {
-                    Object subRecordArrayArrayElementReuseVar933 = null;
+                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                    Object subRecordArrayArrayElementReuseVar0 = null;
                     if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
-                        subRecordArrayArrayElementReuseVar933 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                        subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
                     }
-                    subRecordArray929 .add(deserializesubRecord916(subRecordArrayArrayElementReuseVar933, (decoder)));
+                    subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
                 }
-                chunkLen930 = (decoder.arrayNext());
-            } while (chunkLen930 > 0);
+                chunkLen1 = (decoder.arrayNext());
+            } while (chunkLen1 > 0);
         } else {
-            subRecordArray929 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray928);
+            subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(0, subRecordArray0);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray929);
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1);
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
     }
 
-    public IndexedRecord deserializesubRecord916(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema915)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordOptionSchema0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema915);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordOptionSchema0);
         }
-        int unionIndex918 = (decoder.readIndex());
-        if (unionIndex918 == 0) {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
             decoder.readNull();
         }
-        if (unionIndex918 == 1) {
+        if (unionIndex4 == 1) {
             if (subRecord.get(0) instanceof Utf8) {
                 subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
             } else {
                 subRecord.put(0, (decoder).readString(null));
             }
         }
-        int unionIndex919 = (decoder.readIndex());
-        if (unionIndex919 == 0) {
+        int unionIndex5 = (decoder.readIndex());
+        if (unionIndex5 == 0) {
             decoder.readNull();
         }
-        if (unionIndex919 == 1) {
+        if (unionIndex5 == 1) {
             decoder.skipString();
         }
-        int unionIndex921 = (decoder.readIndex());
-        if (unionIndex921 == 0) {
+        int unionIndex6 = (decoder.readIndex());
+        if (unionIndex6 == 0) {
             decoder.readNull();
         }
-        if (unionIndex921 == 1) {
+        if (unionIndex6 == 1) {
             if (subRecord.get(1) instanceof Utf8) {
                 subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
@@ -13,20 +13,20 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
 {
 
     private final Schema readerSchema;
-    private final Schema subRecord935;
+    private final Schema subRecord0;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.subRecord935 = readerSchema.getField("subRecord").schema();
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord934(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
@@ -35,31 +35,31 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord936(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
     }
 
-    public IndexedRecord deserializesubRecord936(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord935)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord935);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
         }
         if (subRecord.get(0) instanceof Utf8) {
             subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
         } else {
             subRecord.put(0, (decoder).readString(null));
         }
-        deserializesubSubRecord937(null, (decoder));
-        int unionIndex938 = (decoder.readIndex());
-        if (unionIndex938 == 0) {
+        deserializesubSubRecord0(null, (decoder));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex938 == 1) {
-            deserializesubSubRecord937(null, (decoder));
+        if (unionIndex0 == 1) {
+            deserializesubSubRecord0(null, (decoder));
         }
         if (subRecord.get(1) instanceof Utf8) {
             subRecord.put(1, (decoder).readString(((Utf8) subRecord.get(1))));
@@ -69,7 +69,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         return subRecord;
     }
 
-    public void deserializesubSubRecord937(Object reuse, Decoder decoder)
+    public void deserializesubSubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
@@ -13,20 +13,20 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
 {
 
     private final Schema readerSchema;
-    private final Schema subRecord1940;
+    private final Schema subRecord10;
 
     public FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.subRecord1940 = readerSchema.getField("subRecord1").schema();
+        this.subRecord10 = readerSchema.getField("subRecord1").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord939(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
@@ -35,27 +35,27 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
-        deserializesubRecord2942(null, (decoder));
-        int unionIndex943 = (decoder.readIndex());
-        if (unionIndex943 == 0) {
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
+        deserializesubRecord20(null, (decoder));
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex943 == 1) {
-            deserializesubRecord2942(null, (decoder));
+        if (unionIndex0 == 1) {
+            deserializesubRecord20(null, (decoder));
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord941(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
     }
 
-    public IndexedRecord deserializesubRecord941(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord subRecord;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord1940)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord10)) {
             subRecord = ((IndexedRecord)(reuse));
         } else {
-            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord1940);
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord10);
         }
         if (subRecord.get(0) instanceof Utf8) {
             subRecord.put(0, (decoder).readString(((Utf8) subRecord.get(0))));
@@ -70,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         return subRecord;
     }
 
-    public void deserializesubRecord2942(Object reuse, Decoder decoder)
+    public void deserializesubRecord20(Object reuse, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -16,66 +16,66 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
 {
 
     private final Schema readerSchema;
-    private final Schema mapMapValueSchema708;
-    private final Schema mapValueOptionSchema710;
-    private final Schema field712;
+    private final Schema mapMapValueSchema0;
+    private final Schema mapValueOptionSchema0;
+    private final Schema field0;
 
     public Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapMapValueSchema708 = readerSchema.getValueType();
-        this.mapValueOptionSchema710 = mapMapValueSchema708 .getTypes().get(1);
-        this.field712 = mapValueOptionSchema710 .getField("field").schema();
+        this.mapMapValueSchema0 = readerSchema.getValueType();
+        this.mapValueOptionSchema0 = mapMapValueSchema0 .getTypes().get(1);
+        this.field0 = mapValueOptionSchema0 .getField("field").schema();
     }
 
     public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        Map<Utf8, IndexedRecord> map703 = null;
-        long chunkLen704 = (decoder.readMapStart());
-        if (chunkLen704 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse705 = null;
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
             if ((reuse) instanceof Map) {
-                mapReuse705 = ((Map)(reuse));
+                mapReuse0 = ((Map)(reuse));
             }
-            if (mapReuse705 != (null)) {
-                mapReuse705 .clear();
-                map703 = mapReuse705;
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
             } else {
-                map703 = new HashMap<Utf8, IndexedRecord>();
+                map0 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter706 = 0; (counter706 <chunkLen704); counter706 ++) {
-                    Utf8 key707 = (decoder.readString(null));
-                    int unionIndex709 = (decoder.readIndex());
-                    if (unionIndex709 == 0) {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    int unionIndex0 = (decoder.readIndex());
+                    if (unionIndex0 == 0) {
                         decoder.readNull();
                     }
-                    if (unionIndex709 == 1) {
-                        map703 .put(key707, deserializerecord711(null, (decoder)));
+                    if (unionIndex0 == 1) {
+                        map0 .put(key0, deserializerecord0(null, (decoder)));
                     }
                 }
-                chunkLen704 = (decoder.mapNext());
-            } while (chunkLen704 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            map703 = Collections.emptyMap();
+            map0 = Collections.emptyMap();
         }
-        return map703;
+        return map0;
     }
 
-    public IndexedRecord deserializerecord711(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema710)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapValueOptionSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema710);
+            record = new org.apache.avro.generic.GenericData.Record(mapValueOptionSchema0);
         }
-        int unionIndex713 = (decoder.readIndex());
-        if (unionIndex713 == 0) {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
             decoder.readNull();
         }
-        if (unionIndex713 == 1) {
+        if (unionIndex1 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -16,58 +16,58 @@ public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969
 {
 
     private final Schema readerSchema;
-    private final Schema mapMapValueSchema699;
-    private final Schema field701;
+    private final Schema mapMapValueSchema0;
+    private final Schema field0;
 
     public Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.mapMapValueSchema699 = readerSchema.getValueType();
-        this.field701 = mapMapValueSchema699 .getField("field").schema();
+        this.mapMapValueSchema0 = readerSchema.getValueType();
+        this.field0 = mapMapValueSchema0 .getField("field").schema();
     }
 
     public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
         throws IOException
     {
-        Map<Utf8, IndexedRecord> map694 = null;
-        long chunkLen695 = (decoder.readMapStart());
-        if (chunkLen695 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse696 = null;
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
             if ((reuse) instanceof Map) {
-                mapReuse696 = ((Map)(reuse));
+                mapReuse0 = ((Map)(reuse));
             }
-            if (mapReuse696 != (null)) {
-                mapReuse696 .clear();
-                map694 = mapReuse696;
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
             } else {
-                map694 = new HashMap<Utf8, IndexedRecord>();
+                map0 = new HashMap<Utf8, IndexedRecord>();
             }
             do {
-                for (int counter697 = 0; (counter697 <chunkLen695); counter697 ++) {
-                    Utf8 key698 = (decoder.readString(null));
-                    map694 .put(key698, deserializerecord700(null, (decoder)));
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
                 }
-                chunkLen695 = (decoder.mapNext());
-            } while (chunkLen695 > 0);
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
         } else {
-            map694 = Collections.emptyMap();
+            map0 = Collections.emptyMap();
         }
-        return map694;
+        return map0;
     }
 
-    public IndexedRecord deserializerecord700(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord record;
-        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema699)) {
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
             record = ((IndexedRecord)(reuse));
         } else {
-            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema699);
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
         }
-        int unionIndex702 = (decoder.readIndex());
-        if (unionIndex702 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex702 == 1) {
+        if (unionIndex0 == 1) {
             if (record.get(0) instanceof Utf8) {
                 record.put(0, (decoder).readString(((Utf8) record.get(0))));
             } else {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -13,20 +13,20 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
 {
 
     private final Schema readerSchema;
-    private final Schema unionField796;
+    private final Schema unionField0;
 
     public recordName_GenericDeserializer_6897301803194779359_6897301803194779359(Schema readerSchema) {
         this.readerSchema = readerSchema;
-        this.unionField796 = readerSchema.getField("unionField").schema();
+        this.unionField0 = readerSchema.getField("unionField").schema();
     }
 
     public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
         throws IOException
     {
-        return deserializerecordName795((reuse), (decoder));
+        return deserializerecordName0((reuse), (decoder));
     }
 
-    public IndexedRecord deserializerecordName795(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecordName0(Object reuse, Decoder decoder)
         throws IOException
     {
         IndexedRecord recordName;
@@ -40,12 +40,12 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
         } else {
             recordName.put(0, (decoder).readString(null));
         }
-        int unionIndex797 = (decoder.readIndex());
-        if (unionIndex797 == 0) {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
             decoder.readNull();
         }
-        if (unionIndex797 == 1) {
-            recordName.put(1, deserializerecordName795(recordName.get(1), (decoder)));
+        if (unionIndex0 == 1) {
+            recordName.put(1, deserializerecordName0(recordName.get(1), (decoder)));
         }
         return recordName;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -21,17 +21,17 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter64 = 0; (counter64 <((List<IndexedRecord> ) data).size()); counter64 ++) {
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) data).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord union65 = null;
-                union65 = ((List<IndexedRecord> ) data).get(counter64);
-                if (union65 == null) {
+                IndexedRecord union0 = null;
+                union0 = ((List<IndexedRecord> ) data).get(counter0);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union65 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union65).getSchema().getFullName())) {
+                    if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializerecord66(((IndexedRecord) union65), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder));
                     }
                 }
             }
@@ -40,20 +40,20 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord66(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field67 = ((CharSequence) data.get(0));
-        if (field67 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field67 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field67 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field67));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field67 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -21,31 +21,31 @@ public class Array_of_record_GenericSerializer_1629046702287533603
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter60 = 0; (counter60 <((List<IndexedRecord> ) data).size()); counter60 ++) {
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) data).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord record61 = null;
-                record61 = ((List<IndexedRecord> ) data).get(counter60);
-                serializerecord62(record61, (encoder));
+                IndexedRecord record0 = null;
+                record0 = ((List<IndexedRecord> ) data).get(counter0);
+                serializeRecord0(record0, (encoder));
             }
         }
         (encoder).writeArrayEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord62(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field63 = ((CharSequence) data.get(0));
-        if (field63 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field63 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field63 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field63));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field63 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_6137374763587019173.java
@@ -12,58 +12,58 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
     implements FastSerializer<IndexedRecord>
 {
 
-    private final Schema testEnumEnumSchema69 = Schema.parse("{\"type\":\"enum\",\"name\":\"testEnum\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"symbols\":[\"A\",\"B\"]}");
+    private final Schema testEnumEnumSchema0 = Schema.parse("{\"type\":\"enum\",\"name\":\"testEnum\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"symbols\":[\"A\",\"B\"]}");
 
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
-        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion70 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
-        if (testEnumUnion70 == null) {
+        (encoder).writeEnum(testEnumEnumSchema0 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
+        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion0 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
+        if (testEnumUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testEnumUnion70 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
+            if (testEnumUnion0 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
                 (encoder).writeIndex(1);
-                (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion70).toString()));
+                (encoder).writeEnum(testEnumEnumSchema0 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).toString()));
             }
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray71 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
         (encoder).writeArrayStart();
-        if ((testEnumArray71 == null)||testEnumArray71 .isEmpty()) {
+        if ((testEnumArray0 == null)||testEnumArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testEnumArray71 .size());
-            for (int counter72 = 0; (counter72 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray71).size()); counter72 ++) {
+            (encoder).setItemCount(testEnumArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray71 .get(counter72)).toString()));
+                (encoder).writeEnum(testEnumEnumSchema0 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray0 .get(counter0)).toString()));
             }
         }
         (encoder).writeArrayEnd();
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray73 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
         (encoder).writeArrayStart();
-        if ((testEnumUnionArray73 == null)||testEnumUnionArray73 .isEmpty()) {
+        if ((testEnumUnionArray0 == null)||testEnumUnionArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testEnumUnionArray73 .size());
-            for (int counter74 = 0; (counter74 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray73).size()); counter74 ++) {
+            (encoder).setItemCount(testEnumUnionArray0 .size());
+            for (int counter1 = 0; (counter1 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray0).size()); counter1 ++) {
                 (encoder).startItem();
-                org.apache.avro.generic.GenericData.EnumSymbol union75 = null;
-                union75 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray73).get(counter74);
-                if (union75 == null) {
+                org.apache.avro.generic.GenericData.EnumSymbol union0 = null;
+                union0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray0).get(counter1);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if (union75 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
+                    if (union0 instanceof org.apache.avro.generic.GenericData.EnumSymbol) {
                         (encoder).writeIndex(1);
-                        (encoder).writeEnum(testEnumEnumSchema69 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union75).toString()));
+                        (encoder).writeEnum(testEnumEnumSchema0 .getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union0).toString()));
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_8889056593487745201.java
@@ -15,53 +15,53 @@ public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializ
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed76(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed76(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) data.get(0)).bytes());
-        org.apache.avro.generic.GenericData.Fixed testFixedUnion77 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
-        if (testFixedUnion77 == null) {
+        org.apache.avro.generic.GenericData.Fixed testFixedUnion0 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
+        if (testFixedUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testFixedUnion77 instanceof org.apache.avro.generic.GenericData.Fixed) {
+            if (testFixedUnion0 instanceof org.apache.avro.generic.GenericData.Fixed) {
                 (encoder).writeIndex(1);
-                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion77).bytes());
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion0).bytes());
             }
         }
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray78 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
         (encoder).writeArrayStart();
-        if ((testFixedArray78 == null)||testFixedArray78 .isEmpty()) {
+        if ((testFixedArray0 == null)||testFixedArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testFixedArray78 .size());
-            for (int counter79 = 0; (counter79 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray78).size()); counter79 ++) {
+            (encoder).setItemCount(testFixedArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray78 .get(counter79)).bytes());
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray0 .get(counter0)).bytes());
             }
         }
         (encoder).writeArrayEnd();
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray80 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
         (encoder).writeArrayStart();
-        if ((testFixedUnionArray80 == null)||testFixedUnionArray80 .isEmpty()) {
+        if ((testFixedUnionArray0 == null)||testFixedUnionArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testFixedUnionArray80 .size());
-            for (int counter81 = 0; (counter81 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray80).size()); counter81 ++) {
+            (encoder).setItemCount(testFixedUnionArray0 .size());
+            for (int counter1 = 0; (counter1 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray0).size()); counter1 ++) {
                 (encoder).startItem();
-                org.apache.avro.generic.GenericData.Fixed union82 = null;
-                union82 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray80).get(counter81);
-                if (union82 == null) {
+                org.apache.avro.generic.GenericData.Fixed union0 = null;
+                union0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray0).get(counter1);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if (union82 instanceof org.apache.avro.generic.GenericData.Fixed) {
+                    if (union0 instanceof org.apache.avro.generic.GenericData.Fixed) {
                         (encoder).writeIndex(1);
-                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union82).bytes());
+                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union0).bytes());
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_4388851848367235159.java
@@ -15,33 +15,33 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion99(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion99(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Object union100 = ((Object) data.get(0));
-        if (union100 == null) {
+        Object union0 = ((Object) data.get(0));
+        if (union0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((union100 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union100).getSchema().getFullName())) {
+            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializesubRecord101(((IndexedRecord) union100), (encoder));
+                serializeSubRecord0(((IndexedRecord) union0), (encoder));
             } else {
-                if (union100 instanceof CharSequence) {
+                if (union0 instanceof CharSequence) {
                     (encoder).writeIndex(2);
-                    if (union100 instanceof Utf8) {
-                        (encoder).writeString(((Utf8) union100));
+                    if (union0 instanceof Utf8) {
+                        (encoder).writeString(((Utf8) union0));
                     } else {
-                        (encoder).writeString(union100 .toString());
+                        (encoder).writeString(union0 .toString());
                     }
                 } else {
-                    if (union100 instanceof Integer) {
+                    if (union0 instanceof Integer) {
                         (encoder).writeIndex(3);
-                        (encoder).writeInt(((Integer) union100));
+                        (encoder).writeInt(((Integer) union0));
                     }
                 }
             }
@@ -49,20 +49,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord101(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField102 = ((CharSequence) data.get(0));
-        if (subField102 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField102 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField102 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField102));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField102 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_5300080091170871849.java
@@ -16,22 +16,22 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives103(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives103(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        Integer testIntUnion104 = ((Integer) data.get(1));
-        if (testIntUnion104 == null) {
+        Integer testIntUnion0 = ((Integer) data.get(1));
+        if (testIntUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testIntUnion104 instanceof Integer) {
+            if (testIntUnion0 instanceof Integer) {
                 (encoder).writeIndex(1);
-                (encoder).writeInt(((Integer) testIntUnion104));
+                (encoder).writeInt(((Integer) testIntUnion0));
             }
         }
         if (data.get(2) instanceof Utf8) {
@@ -39,73 +39,73 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
         } else {
             (encoder).writeString(data.get(2).toString());
         }
-        CharSequence testStringUnion105 = ((CharSequence) data.get(3));
-        if (testStringUnion105 == null) {
+        CharSequence testStringUnion0 = ((CharSequence) data.get(3));
+        if (testStringUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testStringUnion105 instanceof CharSequence) {
+            if (testStringUnion0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (testStringUnion105 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) testStringUnion105));
+                if (testStringUnion0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) testStringUnion0));
                 } else {
-                    (encoder).writeString(testStringUnion105 .toString());
+                    (encoder).writeString(testStringUnion0 .toString());
                 }
             }
         }
         (encoder).writeLong(((Long) data.get(4)));
-        Long testLongUnion106 = ((Long) data.get(5));
-        if (testLongUnion106 == null) {
+        Long testLongUnion0 = ((Long) data.get(5));
+        if (testLongUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testLongUnion106 instanceof Long) {
+            if (testLongUnion0 instanceof Long) {
                 (encoder).writeIndex(1);
-                (encoder).writeLong(((Long) testLongUnion106));
+                (encoder).writeLong(((Long) testLongUnion0));
             }
         }
         (encoder).writeDouble(((Double) data.get(6)));
-        Double testDoubleUnion107 = ((Double) data.get(7));
-        if (testDoubleUnion107 == null) {
+        Double testDoubleUnion0 = ((Double) data.get(7));
+        if (testDoubleUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testDoubleUnion107 instanceof Double) {
+            if (testDoubleUnion0 instanceof Double) {
                 (encoder).writeIndex(1);
-                (encoder).writeDouble(((Double) testDoubleUnion107));
+                (encoder).writeDouble(((Double) testDoubleUnion0));
             }
         }
         (encoder).writeFloat(((Float) data.get(8)));
-        Float testFloatUnion108 = ((Float) data.get(9));
-        if (testFloatUnion108 == null) {
+        Float testFloatUnion0 = ((Float) data.get(9));
+        if (testFloatUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testFloatUnion108 instanceof Float) {
+            if (testFloatUnion0 instanceof Float) {
                 (encoder).writeIndex(1);
-                (encoder).writeFloat(((Float) testFloatUnion108));
+                (encoder).writeFloat(((Float) testFloatUnion0));
             }
         }
         (encoder).writeBoolean(((Boolean) data.get(10)));
-        Boolean testBooleanUnion109 = ((Boolean) data.get(11));
-        if (testBooleanUnion109 == null) {
+        Boolean testBooleanUnion0 = ((Boolean) data.get(11));
+        if (testBooleanUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testBooleanUnion109 instanceof Boolean) {
+            if (testBooleanUnion0 instanceof Boolean) {
                 (encoder).writeIndex(1);
-                (encoder).writeBoolean(((Boolean) testBooleanUnion109));
+                (encoder).writeBoolean(((Boolean) testBooleanUnion0));
             }
         }
         (encoder).writeBytes(((ByteBuffer) data.get(12)));
-        ByteBuffer testBytesUnion110 = ((ByteBuffer) data.get(13));
-        if (testBytesUnion110 == null) {
+        ByteBuffer testBytesUnion0 = ((ByteBuffer) data.get(13));
+        if (testBytesUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testBytesUnion110 instanceof ByteBuffer) {
+            if (testBytesUnion0 instanceof ByteBuffer) {
                 (encoder).writeIndex(1);
-                (encoder).writeBytes(((ByteBuffer) testBytesUnion110));
+                (encoder).writeBytes(((ByteBuffer) testBytesUnion0));
             }
         }
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_5485438821003579903.java
@@ -15,32 +15,32 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex111(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex111(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Object union_field112 = ((Object) data.get(0));
-        if (union_field112 == null) {
+        Object union_field0 = ((Object) data.get(0));
+        if (union_field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((union_field112 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field112).getSchema().getFullName())) {
+            if ((union_field0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializerecord1113(((IndexedRecord) union_field112), (encoder));
+                serializeRecord10(((IndexedRecord) union_field0), (encoder));
             } else {
-                if ((union_field112 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field112).getSchema().getFullName())) {
+                if ((union_field0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                     (encoder).writeIndex(2);
-                    serializerecord2114(((IndexedRecord) union_field112), (encoder));
+                    serializeRecord20(((IndexedRecord) union_field0), (encoder));
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord1113(IndexedRecord data, Encoder encoder)
+    public void serializeRecord10(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         if (data.get(0) instanceof Utf8) {
@@ -51,7 +51,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord2114(IndexedRecord data, Encoder encoder)
+    public void serializeRecord20(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         if (data.get(0) instanceof Utf8) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_4869519538077502381.java
@@ -17,65 +17,65 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField115(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField115(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        List<IndexedRecord> recordsArray116 = ((List<IndexedRecord> ) data.get(0));
+        List<IndexedRecord> recordsArray0 = ((List<IndexedRecord> ) data.get(0));
         (encoder).writeArrayStart();
-        if ((recordsArray116 == null)||recordsArray116 .isEmpty()) {
+        if ((recordsArray0 == null)||recordsArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsArray116 .size());
-            for (int counter117 = 0; (counter117 <((List<IndexedRecord> ) recordsArray116).size()); counter117 ++) {
+            (encoder).setItemCount(recordsArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) recordsArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord subRecord118 = null;
-                subRecord118 = ((List<IndexedRecord> ) recordsArray116).get(counter117);
-                serializesubRecord119(subRecord118, (encoder));
+                IndexedRecord subRecord0 = null;
+                subRecord0 = ((List<IndexedRecord> ) recordsArray0).get(counter0);
+                serializeSubRecord0(subRecord0, (encoder));
             }
         }
         (encoder).writeArrayEnd();
-        Map<CharSequence, IndexedRecord> recordsMap121 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        Map<CharSequence, IndexedRecord> recordsMap0 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
         (encoder).writeMapStart();
-        if ((recordsMap121 == null)||recordsMap121 .isEmpty()) {
+        if ((recordsMap0 == null)||recordsMap0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsMap121 .size());
-            for (CharSequence key122 : ((Map<CharSequence, IndexedRecord> ) recordsMap121).keySet()) {
+            (encoder).setItemCount(recordsMap0 .size());
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) recordsMap0).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key122);
-                IndexedRecord subRecord123 = null;
-                subRecord123 = ((Map<CharSequence, IndexedRecord> ) recordsMap121).get(key122);
-                serializesubRecord119(subRecord123, (encoder));
+                (encoder).writeString(key0);
+                IndexedRecord subRecord1 = null;
+                subRecord1 = ((Map<CharSequence, IndexedRecord> ) recordsMap0).get(key0);
+                serializeSubRecord0(subRecord1, (encoder));
             }
         }
         (encoder).writeMapEnd();
-        List<IndexedRecord> recordsArrayUnion124 = ((List<IndexedRecord> ) data.get(2));
-        if (recordsArrayUnion124 == null) {
+        List<IndexedRecord> recordsArrayUnion0 = ((List<IndexedRecord> ) data.get(2));
+        if (recordsArrayUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsArrayUnion124 instanceof List) {
+            if (recordsArrayUnion0 instanceof List) {
                 (encoder).writeIndex(1);
                 (encoder).writeArrayStart();
-                if ((((List<IndexedRecord> ) recordsArrayUnion124) == null)||((List<IndexedRecord> ) recordsArrayUnion124).isEmpty()) {
+                if ((((List<IndexedRecord> ) recordsArrayUnion0) == null)||((List<IndexedRecord> ) recordsArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion124).size());
-                    for (int counter125 = 0; (counter125 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion124)).size()); counter125 ++) {
+                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion0).size());
+                    for (int counter1 = 0; (counter1 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union126 = null;
-                        union126 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion124)).get(counter125);
-                        if (union126 == null) {
+                        IndexedRecord union0 = null;
+                        union0 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).get(counter1);
+                        if (union0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union126 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union126).getSchema().getFullName())) {
+                            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord119(((IndexedRecord) union126), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
                             }
                         }
                     }
@@ -83,30 +83,30 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                 (encoder).writeArrayEnd();
             }
         }
-        Map<CharSequence, IndexedRecord> recordsMapUnion127 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
-        if (recordsMapUnion127 == null) {
+        Map<CharSequence, IndexedRecord> recordsMapUnion0 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
+        if (recordsMapUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsMapUnion127 instanceof Map) {
+            if (recordsMapUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
                 (encoder).writeMapStart();
-                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion127) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion127).isEmpty()) {
+                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion0) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion127).size());
-                    for (CharSequence key128 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion127)).keySet()) {
+                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).size());
+                    for (CharSequence key1 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key128);
-                        IndexedRecord union129 = null;
-                        union129 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion127)).get(key128);
-                        if (union129 == null) {
+                        (encoder).writeString(key1);
+                        IndexedRecord union1 = null;
+                        union1 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).get(key1);
+                        if (union1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union129 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union129).getSchema().getFullName())) {
+                            if ((union1 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord119(((IndexedRecord) union129), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
                             }
                         }
                     }
@@ -117,20 +117,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord119(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField120 = ((CharSequence) data.get(0));
-        if (subField120 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField120 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField120 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField120));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField120 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_6532465341493029871.java
@@ -17,40 +17,40 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField130(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField130(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        List<Map<CharSequence, IndexedRecord>> recordsArrayMap131 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMap0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
         (encoder).writeArrayStart();
-        if ((recordsArrayMap131 == null)||recordsArrayMap131 .isEmpty()) {
+        if ((recordsArrayMap0 == null)||recordsArrayMap0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsArrayMap131 .size());
-            for (int counter132 = 0; (counter132 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap131).size()); counter132 ++) {
+            (encoder).setItemCount(recordsArrayMap0 .size());
+            for (int counter0 = 0; (counter0 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).size()); counter0 ++) {
                 (encoder).startItem();
-                Map<CharSequence, IndexedRecord> map133 = null;
-                map133 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap131).get(counter132);
+                Map<CharSequence, IndexedRecord> map0 = null;
+                map0 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).get(counter0);
                 (encoder).writeMapStart();
-                if ((map133 == null)||map133 .isEmpty()) {
+                if ((map0 == null)||map0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(map133 .size());
-                    for (CharSequence key134 : ((Map<CharSequence, IndexedRecord> ) map133).keySet()) {
+                    (encoder).setItemCount(map0 .size());
+                    for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) map0).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key134);
-                        IndexedRecord union135 = null;
-                        union135 = ((Map<CharSequence, IndexedRecord> ) map133).get(key134);
-                        if (union135 == null) {
+                        (encoder).writeString(key0);
+                        IndexedRecord union0 = null;
+                        union0 = ((Map<CharSequence, IndexedRecord> ) map0).get(key0);
+                        if (union0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union135 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union135).getSchema().getFullName())) {
+                            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord136(((IndexedRecord) union135), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
                             }
                         }
                     }
@@ -59,33 +59,33 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeArrayEnd();
-        Map<CharSequence, List<IndexedRecord>> recordsMapArray138 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        Map<CharSequence, List<IndexedRecord>> recordsMapArray0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
         (encoder).writeMapStart();
-        if ((recordsMapArray138 == null)||recordsMapArray138 .isEmpty()) {
+        if ((recordsMapArray0 == null)||recordsMapArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsMapArray138 .size());
-            for (CharSequence key139 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray138).keySet()) {
+            (encoder).setItemCount(recordsMapArray0 .size());
+            for (CharSequence key1 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key139);
-                List<IndexedRecord> array140 = null;
-                array140 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray138).get(key139);
+                (encoder).writeString(key1);
+                List<IndexedRecord> array0 = null;
+                array0 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).get(key1);
                 (encoder).writeArrayStart();
-                if ((array140 == null)||array140 .isEmpty()) {
+                if ((array0 == null)||array0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(array140 .size());
-                    for (int counter141 = 0; (counter141 <((List<IndexedRecord> ) array140).size()); counter141 ++) {
+                    (encoder).setItemCount(array0 .size());
+                    for (int counter1 = 0; (counter1 <((List<IndexedRecord> ) array0).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union142 = null;
-                        union142 = ((List<IndexedRecord> ) array140).get(counter141);
-                        if (union142 == null) {
+                        IndexedRecord union1 = null;
+                        union1 = ((List<IndexedRecord> ) array0).get(counter1);
+                        if (union1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union142 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union142).getSchema().getFullName())) {
+                            if ((union1 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord136(((IndexedRecord) union142), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
                             }
                         }
                     }
@@ -94,39 +94,39 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeMapEnd();
-        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion143 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
-        if (recordsArrayMapUnion143 == null) {
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
+        if (recordsArrayMapUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsArrayMapUnion143 instanceof List) {
+            if (recordsArrayMapUnion0 instanceof List) {
                 (encoder).writeIndex(1);
                 (encoder).writeArrayStart();
-                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143).isEmpty()) {
+                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143).size());
-                    for (int counter144 = 0; (counter144 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143)).size()); counter144 ++) {
+                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).size());
+                    for (int counter2 = 0; (counter2 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).size()); counter2 ++) {
                         (encoder).startItem();
-                        Map<CharSequence, IndexedRecord> map145 = null;
-                        map145 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion143)).get(counter144);
+                        Map<CharSequence, IndexedRecord> map1 = null;
+                        map1 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).get(counter2);
                         (encoder).writeMapStart();
-                        if ((map145 == null)||map145 .isEmpty()) {
+                        if ((map1 == null)||map1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(map145 .size());
-                            for (CharSequence key146 : ((Map<CharSequence, IndexedRecord> ) map145).keySet()) {
+                            (encoder).setItemCount(map1 .size());
+                            for (CharSequence key2 : ((Map<CharSequence, IndexedRecord> ) map1).keySet()) {
                                 (encoder).startItem();
-                                (encoder).writeString(key146);
-                                IndexedRecord union147 = null;
-                                union147 = ((Map<CharSequence, IndexedRecord> ) map145).get(key146);
-                                if (union147 == null) {
+                                (encoder).writeString(key2);
+                                IndexedRecord union2 = null;
+                                union2 = ((Map<CharSequence, IndexedRecord> ) map1).get(key2);
+                                if (union2 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union147 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union147).getSchema().getFullName())) {
+                                    if ((union2 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union2).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializesubRecord136(((IndexedRecord) union147), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union2), (encoder));
                                     }
                                 }
                             }
@@ -137,39 +137,39 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                 (encoder).writeArrayEnd();
             }
         }
-        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion148 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
-        if (recordsMapArrayUnion148 == null) {
+        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
+        if (recordsMapArrayUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsMapArrayUnion148 instanceof Map) {
+            if (recordsMapArrayUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
                 (encoder).writeMapStart();
-                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148).isEmpty()) {
+                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148).size());
-                    for (CharSequence key149 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148)).keySet()) {
+                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).size());
+                    for (CharSequence key3 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key149);
-                        List<IndexedRecord> array150 = null;
-                        array150 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion148)).get(key149);
+                        (encoder).writeString(key3);
+                        List<IndexedRecord> array1 = null;
+                        array1 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).get(key3);
                         (encoder).writeArrayStart();
-                        if ((array150 == null)||array150 .isEmpty()) {
+                        if ((array1 == null)||array1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(array150 .size());
-                            for (int counter151 = 0; (counter151 <((List<IndexedRecord> ) array150).size()); counter151 ++) {
+                            (encoder).setItemCount(array1 .size());
+                            for (int counter3 = 0; (counter3 <((List<IndexedRecord> ) array1).size()); counter3 ++) {
                                 (encoder).startItem();
-                                IndexedRecord union152 = null;
-                                union152 = ((List<IndexedRecord> ) array150).get(counter151);
-                                if (union152 == null) {
+                                IndexedRecord union3 = null;
+                                union3 = ((List<IndexedRecord> ) array1).get(counter3);
+                                if (union3 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union152 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union152).getSchema().getFullName())) {
+                                    if ((union3 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union3).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializesubRecord136(((IndexedRecord) union152), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union3), (encoder));
                                     }
                                 }
                             }
@@ -183,20 +183,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord136(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField137 = ((CharSequence) data.get(0));
-        if (subField137 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField137 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField137 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField137));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField137 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_1161833140095035747.java
@@ -15,56 +15,56 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField153(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField153(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        IndexedRecord record154 = ((IndexedRecord) data.get(0));
-        if (record154 == null) {
+        IndexedRecord record0 = ((IndexedRecord) data.get(0));
+        if (record0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((record154 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record154).getSchema().getFullName())) {
+            if ((record0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializesubRecord155(((IndexedRecord) record154), (encoder));
+                serializeSubRecord0(((IndexedRecord) record0), (encoder));
             }
         }
-        IndexedRecord record1157 = ((IndexedRecord) data.get(1));
-        serializesubRecord155(record1157, (encoder));
-        CharSequence field158 = ((CharSequence) data.get(2));
-        if (field158 == null) {
+        IndexedRecord record10 = ((IndexedRecord) data.get(1));
+        serializeSubRecord0(record10, (encoder));
+        CharSequence field0 = ((CharSequence) data.get(2));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field158 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field158 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field158));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field158 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord155(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField156 = ((CharSequence) data.get(0));
-        if (subField156 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField156 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField156 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField156));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField156 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -21,18 +21,18 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key87 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key87);
-                IndexedRecord union88 = null;
-                union88 = ((Map<CharSequence, IndexedRecord> ) data).get(key87);
-                if (union88 == null) {
+                (encoder).writeString(key0);
+                IndexedRecord union0 = null;
+                union0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union88 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union88).getSchema().getFullName())) {
+                    if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializerecord89(((IndexedRecord) union88), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder));
                     }
                 }
             }
@@ -41,20 +41,20 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord89(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field90 = ((CharSequence) data.get(0));
-        if (field90 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field90 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field90 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field90));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field90 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_4/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -21,32 +21,32 @@ public class Map_of_record_GenericSerializer_2141121767969292399
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key83 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key83);
-                IndexedRecord record84 = null;
-                record84 = ((Map<CharSequence, IndexedRecord> ) data).get(key83);
-                serializerecord85(record84, (encoder));
+                (encoder).writeString(key0);
+                IndexedRecord record0 = null;
+                record0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                serializeRecord0(record0, (encoder));
             }
         }
         (encoder).writeMapEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord85(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field86 = ((CharSequence) data.get(0));
-        if (field86 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field86 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field86 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field86));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field86 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -21,17 +21,17 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter64 = 0; (counter64 <((List<IndexedRecord> ) data).size()); counter64 ++) {
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) data).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord union65 = null;
-                union65 = ((List<IndexedRecord> ) data).get(counter64);
-                if (union65 == null) {
+                IndexedRecord union0 = null;
+                union0 = ((List<IndexedRecord> ) data).get(counter0);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union65 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union65).getSchema().getFullName())) {
+                    if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializerecord66(((IndexedRecord) union65), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder));
                     }
                 }
             }
@@ -40,20 +40,20 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord66(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field67 = ((CharSequence) data.get(0));
-        if (field67 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field67 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field67 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field67));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field67 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -21,31 +21,31 @@ public class Array_of_record_GenericSerializer_1629046702287533603
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter60 = 0; (counter60 <((List<IndexedRecord> ) data).size()); counter60 ++) {
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) data).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord record61 = null;
-                record61 = ((List<IndexedRecord> ) data).get(counter60);
-                serializerecord62(record61, (encoder));
+                IndexedRecord record0 = null;
+                record0 = ((List<IndexedRecord> ) data).get(counter0);
+                serializeRecord0(record0, (encoder));
             }
         }
         (encoder).writeArrayEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord62(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field63 = ((CharSequence) data.get(0));
-        if (field63 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field63 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field63 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field63));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field63 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
@@ -15,53 +15,53 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
-        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion69 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
-        if (testEnumUnion69 == null) {
+        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion0 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
+        if (testEnumUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((testEnumUnion69 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getFullName())) {
+            if ((testEnumUnion0 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).toString()));
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).toString()));
             }
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray70 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
         (encoder).writeArrayStart();
-        if ((testEnumArray70 == null)||testEnumArray70 .isEmpty()) {
+        if ((testEnumArray0 == null)||testEnumArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testEnumArray70 .size());
-            for (int counter71 = 0; (counter71 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray70).size()); counter71 ++) {
+            (encoder).setItemCount(testEnumArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).toString()));
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray0 .get(counter0)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray0 .get(counter0)).toString()));
             }
         }
         (encoder).writeArrayEnd();
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray72 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
         (encoder).writeArrayStart();
-        if ((testEnumUnionArray72 == null)||testEnumUnionArray72 .isEmpty()) {
+        if ((testEnumUnionArray0 == null)||testEnumUnionArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testEnumUnionArray72 .size());
-            for (int counter73 = 0; (counter73 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).size()); counter73 ++) {
+            (encoder).setItemCount(testEnumUnionArray0 .size());
+            for (int counter1 = 0; (counter1 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray0).size()); counter1 ++) {
                 (encoder).startItem();
-                org.apache.avro.generic.GenericData.EnumSymbol union74 = null;
-                union74 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).get(counter73);
-                if (union74 == null) {
+                org.apache.avro.generic.GenericData.EnumSymbol union0 = null;
+                union0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray0).get(counter1);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union74 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getFullName())) {
+                    if ((union0 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union74).toString()));
+                        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) union0).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union0).toString()));
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
@@ -15,53 +15,53 @@ public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializ
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) data.get(0)).bytes());
-        org.apache.avro.generic.GenericData.Fixed testFixedUnion76 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
-        if (testFixedUnion76 == null) {
+        org.apache.avro.generic.GenericData.Fixed testFixedUnion0 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
+        if (testFixedUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((testFixedUnion76 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).getSchema().getFullName())) {
+            if ((testFixedUnion0 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).bytes());
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion0).bytes());
             }
         }
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray77 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
         (encoder).writeArrayStart();
-        if ((testFixedArray77 == null)||testFixedArray77 .isEmpty()) {
+        if ((testFixedArray0 == null)||testFixedArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testFixedArray77 .size());
-            for (int counter78 = 0; (counter78 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray77).size()); counter78 ++) {
+            (encoder).setItemCount(testFixedArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray77 .get(counter78)).bytes());
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray0 .get(counter0)).bytes());
             }
         }
         (encoder).writeArrayEnd();
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray79 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
         (encoder).writeArrayStart();
-        if ((testFixedUnionArray79 == null)||testFixedUnionArray79 .isEmpty()) {
+        if ((testFixedUnionArray0 == null)||testFixedUnionArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testFixedUnionArray79 .size());
-            for (int counter80 = 0; (counter80 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).size()); counter80 ++) {
+            (encoder).setItemCount(testFixedUnionArray0 .size());
+            for (int counter1 = 0; (counter1 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray0).size()); counter1 ++) {
                 (encoder).startItem();
-                org.apache.avro.generic.GenericData.Fixed union81 = null;
-                union81 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).get(counter80);
-                if (union81 == null) {
+                org.apache.avro.generic.GenericData.Fixed union0 = null;
+                union0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray0).get(counter1);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union81 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) union81).getSchema().getFullName())) {
+                    if ((union0 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union81).bytes());
+                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union0).bytes());
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
@@ -15,33 +15,33 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Object union99 = ((Object) data.get(0));
-        if (union99 == null) {
+        Object union0 = ((Object) data.get(0));
+        if (union0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((union99 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union99).getSchema().getFullName())) {
+            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializesubRecord100(((IndexedRecord) union99), (encoder));
+                serializeSubRecord0(((IndexedRecord) union0), (encoder));
             } else {
-                if (union99 instanceof CharSequence) {
+                if (union0 instanceof CharSequence) {
                     (encoder).writeIndex(2);
-                    if (union99 instanceof Utf8) {
-                        (encoder).writeString(((Utf8) union99));
+                    if (union0 instanceof Utf8) {
+                        (encoder).writeString(((Utf8) union0));
                     } else {
-                        (encoder).writeString(union99 .toString());
+                        (encoder).writeString(union0 .toString());
                     }
                 } else {
-                    if (union99 instanceof Integer) {
+                    if (union0 instanceof Integer) {
                         (encoder).writeIndex(3);
-                        (encoder).writeInt(((Integer) union99));
+                        (encoder).writeInt(((Integer) union0));
                     }
                 }
             }
@@ -49,20 +49,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord100(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField101 = ((CharSequence) data.get(0));
-        if (subField101 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField101 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField101 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField101));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField101 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
@@ -16,22 +16,22 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        Integer testIntUnion103 = ((Integer) data.get(1));
-        if (testIntUnion103 == null) {
+        Integer testIntUnion0 = ((Integer) data.get(1));
+        if (testIntUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testIntUnion103 instanceof Integer) {
+            if (testIntUnion0 instanceof Integer) {
                 (encoder).writeIndex(1);
-                (encoder).writeInt(((Integer) testIntUnion103));
+                (encoder).writeInt(((Integer) testIntUnion0));
             }
         }
         if (data.get(2) instanceof Utf8) {
@@ -39,73 +39,73 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
         } else {
             (encoder).writeString(data.get(2).toString());
         }
-        CharSequence testStringUnion104 = ((CharSequence) data.get(3));
-        if (testStringUnion104 == null) {
+        CharSequence testStringUnion0 = ((CharSequence) data.get(3));
+        if (testStringUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testStringUnion104 instanceof CharSequence) {
+            if (testStringUnion0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (testStringUnion104 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) testStringUnion104));
+                if (testStringUnion0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) testStringUnion0));
                 } else {
-                    (encoder).writeString(testStringUnion104 .toString());
+                    (encoder).writeString(testStringUnion0 .toString());
                 }
             }
         }
         (encoder).writeLong(((Long) data.get(4)));
-        Long testLongUnion105 = ((Long) data.get(5));
-        if (testLongUnion105 == null) {
+        Long testLongUnion0 = ((Long) data.get(5));
+        if (testLongUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testLongUnion105 instanceof Long) {
+            if (testLongUnion0 instanceof Long) {
                 (encoder).writeIndex(1);
-                (encoder).writeLong(((Long) testLongUnion105));
+                (encoder).writeLong(((Long) testLongUnion0));
             }
         }
         (encoder).writeDouble(((Double) data.get(6)));
-        Double testDoubleUnion106 = ((Double) data.get(7));
-        if (testDoubleUnion106 == null) {
+        Double testDoubleUnion0 = ((Double) data.get(7));
+        if (testDoubleUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testDoubleUnion106 instanceof Double) {
+            if (testDoubleUnion0 instanceof Double) {
                 (encoder).writeIndex(1);
-                (encoder).writeDouble(((Double) testDoubleUnion106));
+                (encoder).writeDouble(((Double) testDoubleUnion0));
             }
         }
         (encoder).writeFloat(((Float) data.get(8)));
-        Float testFloatUnion107 = ((Float) data.get(9));
-        if (testFloatUnion107 == null) {
+        Float testFloatUnion0 = ((Float) data.get(9));
+        if (testFloatUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testFloatUnion107 instanceof Float) {
+            if (testFloatUnion0 instanceof Float) {
                 (encoder).writeIndex(1);
-                (encoder).writeFloat(((Float) testFloatUnion107));
+                (encoder).writeFloat(((Float) testFloatUnion0));
             }
         }
         (encoder).writeBoolean(((Boolean) data.get(10)));
-        Boolean testBooleanUnion108 = ((Boolean) data.get(11));
-        if (testBooleanUnion108 == null) {
+        Boolean testBooleanUnion0 = ((Boolean) data.get(11));
+        if (testBooleanUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testBooleanUnion108 instanceof Boolean) {
+            if (testBooleanUnion0 instanceof Boolean) {
                 (encoder).writeIndex(1);
-                (encoder).writeBoolean(((Boolean) testBooleanUnion108));
+                (encoder).writeBoolean(((Boolean) testBooleanUnion0));
             }
         }
         (encoder).writeBytes(((ByteBuffer) data.get(12)));
-        ByteBuffer testBytesUnion109 = ((ByteBuffer) data.get(13));
-        if (testBytesUnion109 == null) {
+        ByteBuffer testBytesUnion0 = ((ByteBuffer) data.get(13));
+        if (testBytesUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testBytesUnion109 instanceof ByteBuffer) {
+            if (testBytesUnion0 instanceof ByteBuffer) {
                 (encoder).writeIndex(1);
-                (encoder).writeBytes(((ByteBuffer) testBytesUnion109));
+                (encoder).writeBytes(((ByteBuffer) testBytesUnion0));
             }
         }
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
@@ -15,32 +15,32 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Object union_field111 = ((Object) data.get(0));
-        if (union_field111 == null) {
+        Object union_field0 = ((Object) data.get(0));
+        if (union_field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+            if ((union_field0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializerecord1112(((IndexedRecord) union_field111), (encoder));
+                serializeRecord10(((IndexedRecord) union_field0), (encoder));
             } else {
-                if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+                if ((union_field0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                     (encoder).writeIndex(2);
-                    serializerecord2113(((IndexedRecord) union_field111), (encoder));
+                    serializeRecord20(((IndexedRecord) union_field0), (encoder));
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord1112(IndexedRecord data, Encoder encoder)
+    public void serializeRecord10(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         if (data.get(0) instanceof Utf8) {
@@ -51,7 +51,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord2113(IndexedRecord data, Encoder encoder)
+    public void serializeRecord20(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         if (data.get(0) instanceof Utf8) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
@@ -17,65 +17,65 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        List<IndexedRecord> recordsArray115 = ((List<IndexedRecord> ) data.get(0));
+        List<IndexedRecord> recordsArray0 = ((List<IndexedRecord> ) data.get(0));
         (encoder).writeArrayStart();
-        if ((recordsArray115 == null)||recordsArray115 .isEmpty()) {
+        if ((recordsArray0 == null)||recordsArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsArray115 .size());
-            for (int counter116 = 0; (counter116 <((List<IndexedRecord> ) recordsArray115).size()); counter116 ++) {
+            (encoder).setItemCount(recordsArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) recordsArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord subRecord117 = null;
-                subRecord117 = ((List<IndexedRecord> ) recordsArray115).get(counter116);
-                serializesubRecord118(subRecord117, (encoder));
+                IndexedRecord subRecord0 = null;
+                subRecord0 = ((List<IndexedRecord> ) recordsArray0).get(counter0);
+                serializeSubRecord0(subRecord0, (encoder));
             }
         }
         (encoder).writeArrayEnd();
-        Map<CharSequence, IndexedRecord> recordsMap120 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        Map<CharSequence, IndexedRecord> recordsMap0 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
         (encoder).writeMapStart();
-        if ((recordsMap120 == null)||recordsMap120 .isEmpty()) {
+        if ((recordsMap0 == null)||recordsMap0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsMap120 .size());
-            for (CharSequence key121 : ((Map<CharSequence, IndexedRecord> ) recordsMap120).keySet()) {
+            (encoder).setItemCount(recordsMap0 .size());
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) recordsMap0).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key121);
-                IndexedRecord subRecord122 = null;
-                subRecord122 = ((Map<CharSequence, IndexedRecord> ) recordsMap120).get(key121);
-                serializesubRecord118(subRecord122, (encoder));
+                (encoder).writeString(key0);
+                IndexedRecord subRecord1 = null;
+                subRecord1 = ((Map<CharSequence, IndexedRecord> ) recordsMap0).get(key0);
+                serializeSubRecord0(subRecord1, (encoder));
             }
         }
         (encoder).writeMapEnd();
-        List<IndexedRecord> recordsArrayUnion123 = ((List<IndexedRecord> ) data.get(2));
-        if (recordsArrayUnion123 == null) {
+        List<IndexedRecord> recordsArrayUnion0 = ((List<IndexedRecord> ) data.get(2));
+        if (recordsArrayUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsArrayUnion123 instanceof List) {
+            if (recordsArrayUnion0 instanceof List) {
                 (encoder).writeIndex(1);
                 (encoder).writeArrayStart();
-                if ((((List<IndexedRecord> ) recordsArrayUnion123) == null)||((List<IndexedRecord> ) recordsArrayUnion123).isEmpty()) {
+                if ((((List<IndexedRecord> ) recordsArrayUnion0) == null)||((List<IndexedRecord> ) recordsArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion123).size());
-                    for (int counter124 = 0; (counter124 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).size()); counter124 ++) {
+                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion0).size());
+                    for (int counter1 = 0; (counter1 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union125 = null;
-                        union125 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).get(counter124);
-                        if (union125 == null) {
+                        IndexedRecord union0 = null;
+                        union0 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).get(counter1);
+                        if (union0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union125 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union125).getSchema().getFullName())) {
+                            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord118(((IndexedRecord) union125), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
                             }
                         }
                     }
@@ -83,30 +83,30 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                 (encoder).writeArrayEnd();
             }
         }
-        Map<CharSequence, IndexedRecord> recordsMapUnion126 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
-        if (recordsMapUnion126 == null) {
+        Map<CharSequence, IndexedRecord> recordsMapUnion0 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
+        if (recordsMapUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsMapUnion126 instanceof Map) {
+            if (recordsMapUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
                 (encoder).writeMapStart();
-                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion126) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).isEmpty()) {
+                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion0) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).size());
-                    for (CharSequence key127 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).keySet()) {
+                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).size());
+                    for (CharSequence key1 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key127);
-                        IndexedRecord union128 = null;
-                        union128 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).get(key127);
-                        if (union128 == null) {
+                        (encoder).writeString(key1);
+                        IndexedRecord union1 = null;
+                        union1 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).get(key1);
+                        if (union1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union128 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union128).getSchema().getFullName())) {
+                            if ((union1 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord118(((IndexedRecord) union128), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
                             }
                         }
                     }
@@ -117,20 +117,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord118(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField119 = ((CharSequence) data.get(0));
-        if (subField119 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField119 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField119 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField119));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField119 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
@@ -17,40 +17,40 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        List<Map<CharSequence, IndexedRecord>> recordsArrayMap130 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMap0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
         (encoder).writeArrayStart();
-        if ((recordsArrayMap130 == null)||recordsArrayMap130 .isEmpty()) {
+        if ((recordsArrayMap0 == null)||recordsArrayMap0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsArrayMap130 .size());
-            for (int counter131 = 0; (counter131 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).size()); counter131 ++) {
+            (encoder).setItemCount(recordsArrayMap0 .size());
+            for (int counter0 = 0; (counter0 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).size()); counter0 ++) {
                 (encoder).startItem();
-                Map<CharSequence, IndexedRecord> map132 = null;
-                map132 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).get(counter131);
+                Map<CharSequence, IndexedRecord> map0 = null;
+                map0 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).get(counter0);
                 (encoder).writeMapStart();
-                if ((map132 == null)||map132 .isEmpty()) {
+                if ((map0 == null)||map0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(map132 .size());
-                    for (CharSequence key133 : ((Map<CharSequence, IndexedRecord> ) map132).keySet()) {
+                    (encoder).setItemCount(map0 .size());
+                    for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) map0).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key133);
-                        IndexedRecord union134 = null;
-                        union134 = ((Map<CharSequence, IndexedRecord> ) map132).get(key133);
-                        if (union134 == null) {
+                        (encoder).writeString(key0);
+                        IndexedRecord union0 = null;
+                        union0 = ((Map<CharSequence, IndexedRecord> ) map0).get(key0);
+                        if (union0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union134 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union134).getSchema().getFullName())) {
+                            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord135(((IndexedRecord) union134), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
                             }
                         }
                     }
@@ -59,33 +59,33 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeArrayEnd();
-        Map<CharSequence, List<IndexedRecord>> recordsMapArray137 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        Map<CharSequence, List<IndexedRecord>> recordsMapArray0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
         (encoder).writeMapStart();
-        if ((recordsMapArray137 == null)||recordsMapArray137 .isEmpty()) {
+        if ((recordsMapArray0 == null)||recordsMapArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsMapArray137 .size());
-            for (CharSequence key138 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).keySet()) {
+            (encoder).setItemCount(recordsMapArray0 .size());
+            for (CharSequence key1 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key138);
-                List<IndexedRecord> array139 = null;
-                array139 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).get(key138);
+                (encoder).writeString(key1);
+                List<IndexedRecord> array0 = null;
+                array0 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).get(key1);
                 (encoder).writeArrayStart();
-                if ((array139 == null)||array139 .isEmpty()) {
+                if ((array0 == null)||array0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(array139 .size());
-                    for (int counter140 = 0; (counter140 <((List<IndexedRecord> ) array139).size()); counter140 ++) {
+                    (encoder).setItemCount(array0 .size());
+                    for (int counter1 = 0; (counter1 <((List<IndexedRecord> ) array0).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union141 = null;
-                        union141 = ((List<IndexedRecord> ) array139).get(counter140);
-                        if (union141 == null) {
+                        IndexedRecord union1 = null;
+                        union1 = ((List<IndexedRecord> ) array0).get(counter1);
+                        if (union1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union141 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union141).getSchema().getFullName())) {
+                            if ((union1 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord135(((IndexedRecord) union141), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
                             }
                         }
                     }
@@ -94,39 +94,39 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeMapEnd();
-        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion142 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
-        if (recordsArrayMapUnion142 == null) {
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
+        if (recordsArrayMapUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsArrayMapUnion142 instanceof List) {
+            if (recordsArrayMapUnion0 instanceof List) {
                 (encoder).writeIndex(1);
                 (encoder).writeArrayStart();
-                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).isEmpty()) {
+                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).size());
-                    for (int counter143 = 0; (counter143 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).size()); counter143 ++) {
+                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).size());
+                    for (int counter2 = 0; (counter2 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).size()); counter2 ++) {
                         (encoder).startItem();
-                        Map<CharSequence, IndexedRecord> map144 = null;
-                        map144 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).get(counter143);
+                        Map<CharSequence, IndexedRecord> map1 = null;
+                        map1 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).get(counter2);
                         (encoder).writeMapStart();
-                        if ((map144 == null)||map144 .isEmpty()) {
+                        if ((map1 == null)||map1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(map144 .size());
-                            for (CharSequence key145 : ((Map<CharSequence, IndexedRecord> ) map144).keySet()) {
+                            (encoder).setItemCount(map1 .size());
+                            for (CharSequence key2 : ((Map<CharSequence, IndexedRecord> ) map1).keySet()) {
                                 (encoder).startItem();
-                                (encoder).writeString(key145);
-                                IndexedRecord union146 = null;
-                                union146 = ((Map<CharSequence, IndexedRecord> ) map144).get(key145);
-                                if (union146 == null) {
+                                (encoder).writeString(key2);
+                                IndexedRecord union2 = null;
+                                union2 = ((Map<CharSequence, IndexedRecord> ) map1).get(key2);
+                                if (union2 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union146 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union146).getSchema().getFullName())) {
+                                    if ((union2 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union2).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializesubRecord135(((IndexedRecord) union146), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union2), (encoder));
                                     }
                                 }
                             }
@@ -137,39 +137,39 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                 (encoder).writeArrayEnd();
             }
         }
-        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion147 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
-        if (recordsMapArrayUnion147 == null) {
+        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
+        if (recordsMapArrayUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsMapArrayUnion147 instanceof Map) {
+            if (recordsMapArrayUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
                 (encoder).writeMapStart();
-                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).isEmpty()) {
+                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).size());
-                    for (CharSequence key148 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).keySet()) {
+                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).size());
+                    for (CharSequence key3 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key148);
-                        List<IndexedRecord> array149 = null;
-                        array149 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).get(key148);
+                        (encoder).writeString(key3);
+                        List<IndexedRecord> array1 = null;
+                        array1 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).get(key3);
                         (encoder).writeArrayStart();
-                        if ((array149 == null)||array149 .isEmpty()) {
+                        if ((array1 == null)||array1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(array149 .size());
-                            for (int counter150 = 0; (counter150 <((List<IndexedRecord> ) array149).size()); counter150 ++) {
+                            (encoder).setItemCount(array1 .size());
+                            for (int counter3 = 0; (counter3 <((List<IndexedRecord> ) array1).size()); counter3 ++) {
                                 (encoder).startItem();
-                                IndexedRecord union151 = null;
-                                union151 = ((List<IndexedRecord> ) array149).get(counter150);
-                                if (union151 == null) {
+                                IndexedRecord union3 = null;
+                                union3 = ((List<IndexedRecord> ) array1).get(counter3);
+                                if (union3 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union151 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union151).getSchema().getFullName())) {
+                                    if ((union3 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union3).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializesubRecord135(((IndexedRecord) union151), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union3), (encoder));
                                     }
                                 }
                             }
@@ -183,20 +183,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord135(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField136 = ((CharSequence) data.get(0));
-        if (subField136 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField136 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField136 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField136));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField136 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
@@ -15,56 +15,56 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        IndexedRecord record153 = ((IndexedRecord) data.get(0));
-        if (record153 == null) {
+        IndexedRecord record0 = ((IndexedRecord) data.get(0));
+        if (record0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((record153 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record153).getSchema().getFullName())) {
+            if ((record0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializesubRecord154(((IndexedRecord) record153), (encoder));
+                serializeSubRecord0(((IndexedRecord) record0), (encoder));
             }
         }
-        IndexedRecord record1156 = ((IndexedRecord) data.get(1));
-        serializesubRecord154(record1156, (encoder));
-        CharSequence field157 = ((CharSequence) data.get(2));
-        if (field157 == null) {
+        IndexedRecord record10 = ((IndexedRecord) data.get(1));
+        serializeSubRecord0(record10, (encoder));
+        CharSequence field0 = ((CharSequence) data.get(2));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field157 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field157 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field157));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field157 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord154(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField155 = ((CharSequence) data.get(0));
-        if (subField155 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField155 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField155 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField155));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField155 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -21,18 +21,18 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key86 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key86);
-                IndexedRecord union87 = null;
-                union87 = ((Map<CharSequence, IndexedRecord> ) data).get(key86);
-                if (union87 == null) {
+                (encoder).writeString(key0);
+                IndexedRecord union0 = null;
+                union0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union87 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union87).getSchema().getFullName())) {
+                    if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializerecord88(((IndexedRecord) union87), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder));
                     }
                 }
             }
@@ -41,20 +41,20 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord88(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field89 = ((CharSequence) data.get(0));
-        if (field89 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field89 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field89 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field89));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field89 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_7/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -21,32 +21,32 @@ public class Map_of_record_GenericSerializer_2141121767969292399
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key82 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key82);
-                IndexedRecord record83 = null;
-                record83 = ((Map<CharSequence, IndexedRecord> ) data).get(key82);
-                serializerecord84(record83, (encoder));
+                (encoder).writeString(key0);
+                IndexedRecord record0 = null;
+                record0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                serializeRecord0(record0, (encoder));
             }
         }
         (encoder).writeMapEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord84(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field85 = ((CharSequence) data.get(0));
-        if (field85 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field85 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field85 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field85));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field85 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_UNION_GenericSerializer_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_UNION_GenericSerializer_585074122056792963.java
@@ -21,17 +21,17 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter64 = 0; (counter64 <((List<IndexedRecord> ) data).size()); counter64 ++) {
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) data).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord union65 = null;
-                union65 = ((List<IndexedRecord> ) data).get(counter64);
-                if (union65 == null) {
+                IndexedRecord union0 = null;
+                union0 = ((List<IndexedRecord> ) data).get(counter0);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union65 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union65).getSchema().getFullName())) {
+                    if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializerecord66(((IndexedRecord) union65), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder));
                     }
                 }
             }
@@ -40,20 +40,20 @@ public class Array_of_UNION_GenericSerializer_585074122056792963
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord66(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field67 = ((CharSequence) data.get(0));
-        if (field67 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field67 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field67 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field67));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field67 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_record_GenericSerializer_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Array_of_record_GenericSerializer_1629046702287533603.java
@@ -21,31 +21,31 @@ public class Array_of_record_GenericSerializer_1629046702287533603
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter60 = 0; (counter60 <((List<IndexedRecord> ) data).size()); counter60 ++) {
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) data).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord record61 = null;
-                record61 = ((List<IndexedRecord> ) data).get(counter60);
-                serializerecord62(record61, (encoder));
+                IndexedRecord record0 = null;
+                record0 = ((List<IndexedRecord> ) data).get(counter0);
+                serializeRecord0(record0, (encoder));
             }
         }
         (encoder).writeArrayEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord62(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field63 = ((CharSequence) data.get(0));
-        if (field63 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field63 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field63 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field63));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field63 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerializer_2284596792420879769.java
@@ -15,53 +15,53 @@ public class FastGenericSerializerGeneratorTest_shouldWriteEnum_GenericSerialize
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteEnum0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum68(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteEnum0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) data.get(0)).toString()));
-        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion69 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
-        if (testEnumUnion69 == null) {
+        org.apache.avro.generic.GenericData.EnumSymbol testEnumUnion0 = ((org.apache.avro.generic.GenericData.EnumSymbol) data.get(1));
+        if (testEnumUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((testEnumUnion69 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getFullName())) {
+            if ((testEnumUnion0 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion69).toString()));
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumUnion0).toString()));
             }
         }
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray70 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(2));
         (encoder).writeArrayStart();
-        if ((testEnumArray70 == null)||testEnumArray70 .isEmpty()) {
+        if ((testEnumArray0 == null)||testEnumArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testEnumArray70 .size());
-            for (int counter71 = 0; (counter71 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray70).size()); counter71 ++) {
+            (encoder).setItemCount(testEnumArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray70 .get(counter71)).toString()));
+                (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray0 .get(counter0)).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) testEnumArray0 .get(counter0)).toString()));
             }
         }
         (encoder).writeArrayEnd();
-        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray72 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
+        List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) data.get(3));
         (encoder).writeArrayStart();
-        if ((testEnumUnionArray72 == null)||testEnumUnionArray72 .isEmpty()) {
+        if ((testEnumUnionArray0 == null)||testEnumUnionArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testEnumUnionArray72 .size());
-            for (int counter73 = 0; (counter73 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).size()); counter73 ++) {
+            (encoder).setItemCount(testEnumUnionArray0 .size());
+            for (int counter1 = 0; (counter1 <((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray0).size()); counter1 ++) {
                 (encoder).startItem();
-                org.apache.avro.generic.GenericData.EnumSymbol union74 = null;
-                union74 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray72).get(counter73);
-                if (union74 == null) {
+                org.apache.avro.generic.GenericData.EnumSymbol union0 = null;
+                union0 = ((List<org.apache.avro.generic.GenericData.EnumSymbol> ) testEnumUnionArray0).get(counter1);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union74 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getFullName())) {
+                    if ((union0 instanceof org.apache.avro.generic.GenericData.EnumSymbol)&&"com.adpilot.utils.generated.avro.testEnum".equals(((org.apache.avro.generic.GenericData.EnumSymbol) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) union74).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union74).toString()));
+                        (encoder).writeEnum(((org.apache.avro.generic.GenericData.EnumSymbol) union0).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) union0).toString()));
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializer_3335671775395101159.java
@@ -15,53 +15,53 @@ public class FastGenericSerializerGeneratorTest_shouldWriteFixed_GenericSerializ
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteFixed0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed75(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteFixed0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) data.get(0)).bytes());
-        org.apache.avro.generic.GenericData.Fixed testFixedUnion76 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
-        if (testFixedUnion76 == null) {
+        org.apache.avro.generic.GenericData.Fixed testFixedUnion0 = ((org.apache.avro.generic.GenericData.Fixed) data.get(1));
+        if (testFixedUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((testFixedUnion76 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).getSchema().getFullName())) {
+            if ((testFixedUnion0 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion76).bytes());
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedUnion0).bytes());
             }
         }
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray77 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedArray0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(2));
         (encoder).writeArrayStart();
-        if ((testFixedArray77 == null)||testFixedArray77 .isEmpty()) {
+        if ((testFixedArray0 == null)||testFixedArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testFixedArray77 .size());
-            for (int counter78 = 0; (counter78 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray77).size()); counter78 ++) {
+            (encoder).setItemCount(testFixedArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray77 .get(counter78)).bytes());
+                (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) testFixedArray0 .get(counter0)).bytes());
             }
         }
         (encoder).writeArrayEnd();
-        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray79 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
+        List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) data.get(3));
         (encoder).writeArrayStart();
-        if ((testFixedUnionArray79 == null)||testFixedUnionArray79 .isEmpty()) {
+        if ((testFixedUnionArray0 == null)||testFixedUnionArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(testFixedUnionArray79 .size());
-            for (int counter80 = 0; (counter80 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).size()); counter80 ++) {
+            (encoder).setItemCount(testFixedUnionArray0 .size());
+            for (int counter1 = 0; (counter1 <((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray0).size()); counter1 ++) {
                 (encoder).startItem();
-                org.apache.avro.generic.GenericData.Fixed union81 = null;
-                union81 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray79).get(counter80);
-                if (union81 == null) {
+                org.apache.avro.generic.GenericData.Fixed union0 = null;
+                union0 = ((List<org.apache.avro.generic.GenericData.Fixed> ) testFixedUnionArray0).get(counter1);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union81 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) union81).getSchema().getFullName())) {
+                    if ((union0 instanceof org.apache.avro.generic.GenericData.Fixed)&&"com.adpilot.utils.generated.avro.testFixed".equals(((org.apache.avro.generic.GenericData.Fixed) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union81).bytes());
+                        (encoder).writeFixed(((org.apache.avro.generic.GenericData.Fixed) union0).bytes());
                     }
                 }
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_94676278194882652.java
@@ -15,33 +15,33 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion98(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Object union99 = ((Object) data.get(0));
-        if (union99 == null) {
+        Object union0 = ((Object) data.get(0));
+        if (union0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((union99 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union99).getSchema().getFullName())) {
+            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializesubRecord100(((IndexedRecord) union99), (encoder));
+                serializeSubRecord0(((IndexedRecord) union0), (encoder));
             } else {
-                if (union99 instanceof CharSequence) {
+                if (union0 instanceof CharSequence) {
                     (encoder).writeIndex(2);
-                    if (union99 instanceof Utf8) {
-                        (encoder).writeString(((Utf8) union99));
+                    if (union0 instanceof Utf8) {
+                        (encoder).writeString(((Utf8) union0));
                     } else {
-                        (encoder).writeString(union99 .toString());
+                        (encoder).writeString(union0 .toString());
                     }
                 } else {
-                    if (union99 instanceof Integer) {
+                    if (union0 instanceof Integer) {
                         (encoder).writeIndex(3);
-                        (encoder).writeInt(((Integer) union99));
+                        (encoder).writeInt(((Integer) union0));
                     }
                 }
             }
@@ -49,20 +49,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord100(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField101 = ((CharSequence) data.get(0));
-        if (subField101 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField101 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField101 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField101));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField101 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_6474991426940668474.java
@@ -16,22 +16,22 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives102(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        Integer testIntUnion103 = ((Integer) data.get(1));
-        if (testIntUnion103 == null) {
+        Integer testIntUnion0 = ((Integer) data.get(1));
+        if (testIntUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testIntUnion103 instanceof Integer) {
+            if (testIntUnion0 instanceof Integer) {
                 (encoder).writeIndex(1);
-                (encoder).writeInt(((Integer) testIntUnion103));
+                (encoder).writeInt(((Integer) testIntUnion0));
             }
         }
         if (data.get(2) instanceof Utf8) {
@@ -39,73 +39,73 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
         } else {
             (encoder).writeString(data.get(2).toString());
         }
-        CharSequence testStringUnion104 = ((CharSequence) data.get(3));
-        if (testStringUnion104 == null) {
+        CharSequence testStringUnion0 = ((CharSequence) data.get(3));
+        if (testStringUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testStringUnion104 instanceof CharSequence) {
+            if (testStringUnion0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (testStringUnion104 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) testStringUnion104));
+                if (testStringUnion0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) testStringUnion0));
                 } else {
-                    (encoder).writeString(testStringUnion104 .toString());
+                    (encoder).writeString(testStringUnion0 .toString());
                 }
             }
         }
         (encoder).writeLong(((Long) data.get(4)));
-        Long testLongUnion105 = ((Long) data.get(5));
-        if (testLongUnion105 == null) {
+        Long testLongUnion0 = ((Long) data.get(5));
+        if (testLongUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testLongUnion105 instanceof Long) {
+            if (testLongUnion0 instanceof Long) {
                 (encoder).writeIndex(1);
-                (encoder).writeLong(((Long) testLongUnion105));
+                (encoder).writeLong(((Long) testLongUnion0));
             }
         }
         (encoder).writeDouble(((Double) data.get(6)));
-        Double testDoubleUnion106 = ((Double) data.get(7));
-        if (testDoubleUnion106 == null) {
+        Double testDoubleUnion0 = ((Double) data.get(7));
+        if (testDoubleUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testDoubleUnion106 instanceof Double) {
+            if (testDoubleUnion0 instanceof Double) {
                 (encoder).writeIndex(1);
-                (encoder).writeDouble(((Double) testDoubleUnion106));
+                (encoder).writeDouble(((Double) testDoubleUnion0));
             }
         }
         (encoder).writeFloat(((Float) data.get(8)));
-        Float testFloatUnion107 = ((Float) data.get(9));
-        if (testFloatUnion107 == null) {
+        Float testFloatUnion0 = ((Float) data.get(9));
+        if (testFloatUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testFloatUnion107 instanceof Float) {
+            if (testFloatUnion0 instanceof Float) {
                 (encoder).writeIndex(1);
-                (encoder).writeFloat(((Float) testFloatUnion107));
+                (encoder).writeFloat(((Float) testFloatUnion0));
             }
         }
         (encoder).writeBoolean(((Boolean) data.get(10)));
-        Boolean testBooleanUnion108 = ((Boolean) data.get(11));
-        if (testBooleanUnion108 == null) {
+        Boolean testBooleanUnion0 = ((Boolean) data.get(11));
+        if (testBooleanUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testBooleanUnion108 instanceof Boolean) {
+            if (testBooleanUnion0 instanceof Boolean) {
                 (encoder).writeIndex(1);
-                (encoder).writeBoolean(((Boolean) testBooleanUnion108));
+                (encoder).writeBoolean(((Boolean) testBooleanUnion0));
             }
         }
         (encoder).writeBytes(((ByteBuffer) data.get(12)));
-        ByteBuffer testBytesUnion109 = ((ByteBuffer) data.get(13));
-        if (testBytesUnion109 == null) {
+        ByteBuffer testBytesUnion0 = ((ByteBuffer) data.get(13));
+        if (testBytesUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (testBytesUnion109 instanceof ByteBuffer) {
+            if (testBytesUnion0 instanceof ByteBuffer) {
                 (encoder).writeIndex(1);
-                (encoder).writeBytes(((ByteBuffer) testBytesUnion109));
+                (encoder).writeBytes(((ByteBuffer) testBytesUnion0));
             }
         }
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_6156249609272244185.java
@@ -15,32 +15,32 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex110(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        Object union_field111 = ((Object) data.get(0));
-        if (union_field111 == null) {
+        Object union_field0 = ((Object) data.get(0));
+        if (union_field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+            if ((union_field0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record1".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializerecord1112(((IndexedRecord) union_field111), (encoder));
+                serializeRecord10(((IndexedRecord) union_field0), (encoder));
             } else {
-                if ((union_field111 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field111).getSchema().getFullName())) {
+                if ((union_field0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record2".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                     (encoder).writeIndex(2);
-                    serializerecord2113(((IndexedRecord) union_field111), (encoder));
+                    serializeRecord20(((IndexedRecord) union_field0), (encoder));
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord1112(IndexedRecord data, Encoder encoder)
+    public void serializeRecord10(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         if (data.get(0) instanceof Utf8) {
@@ -51,7 +51,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord2113(IndexedRecord data, Encoder encoder)
+    public void serializeRecord20(IndexedRecord data, Encoder encoder)
         throws IOException
     {
         if (data.get(0) instanceof Utf8) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_7124257652769599022.java
@@ -17,65 +17,65 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField114(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        List<IndexedRecord> recordsArray115 = ((List<IndexedRecord> ) data.get(0));
+        List<IndexedRecord> recordsArray0 = ((List<IndexedRecord> ) data.get(0));
         (encoder).writeArrayStart();
-        if ((recordsArray115 == null)||recordsArray115 .isEmpty()) {
+        if ((recordsArray0 == null)||recordsArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsArray115 .size());
-            for (int counter116 = 0; (counter116 <((List<IndexedRecord> ) recordsArray115).size()); counter116 ++) {
+            (encoder).setItemCount(recordsArray0 .size());
+            for (int counter0 = 0; (counter0 <((List<IndexedRecord> ) recordsArray0).size()); counter0 ++) {
                 (encoder).startItem();
-                IndexedRecord subRecord117 = null;
-                subRecord117 = ((List<IndexedRecord> ) recordsArray115).get(counter116);
-                serializesubRecord118(subRecord117, (encoder));
+                IndexedRecord subRecord0 = null;
+                subRecord0 = ((List<IndexedRecord> ) recordsArray0).get(counter0);
+                serializeSubRecord0(subRecord0, (encoder));
             }
         }
         (encoder).writeArrayEnd();
-        Map<CharSequence, IndexedRecord> recordsMap120 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        Map<CharSequence, IndexedRecord> recordsMap0 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
         (encoder).writeMapStart();
-        if ((recordsMap120 == null)||recordsMap120 .isEmpty()) {
+        if ((recordsMap0 == null)||recordsMap0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsMap120 .size());
-            for (CharSequence key121 : ((Map<CharSequence, IndexedRecord> ) recordsMap120).keySet()) {
+            (encoder).setItemCount(recordsMap0 .size());
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) recordsMap0).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key121);
-                IndexedRecord subRecord122 = null;
-                subRecord122 = ((Map<CharSequence, IndexedRecord> ) recordsMap120).get(key121);
-                serializesubRecord118(subRecord122, (encoder));
+                (encoder).writeString(key0);
+                IndexedRecord subRecord1 = null;
+                subRecord1 = ((Map<CharSequence, IndexedRecord> ) recordsMap0).get(key0);
+                serializeSubRecord0(subRecord1, (encoder));
             }
         }
         (encoder).writeMapEnd();
-        List<IndexedRecord> recordsArrayUnion123 = ((List<IndexedRecord> ) data.get(2));
-        if (recordsArrayUnion123 == null) {
+        List<IndexedRecord> recordsArrayUnion0 = ((List<IndexedRecord> ) data.get(2));
+        if (recordsArrayUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsArrayUnion123 instanceof List) {
+            if (recordsArrayUnion0 instanceof List) {
                 (encoder).writeIndex(1);
                 (encoder).writeArrayStart();
-                if ((((List<IndexedRecord> ) recordsArrayUnion123) == null)||((List<IndexedRecord> ) recordsArrayUnion123).isEmpty()) {
+                if ((((List<IndexedRecord> ) recordsArrayUnion0) == null)||((List<IndexedRecord> ) recordsArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion123).size());
-                    for (int counter124 = 0; (counter124 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).size()); counter124 ++) {
+                    (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion0).size());
+                    for (int counter1 = 0; (counter1 <((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union125 = null;
-                        union125 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion123)).get(counter124);
-                        if (union125 == null) {
+                        IndexedRecord union0 = null;
+                        union0 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).get(counter1);
+                        if (union0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union125 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union125).getSchema().getFullName())) {
+                            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord118(((IndexedRecord) union125), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
                             }
                         }
                     }
@@ -83,30 +83,30 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                 (encoder).writeArrayEnd();
             }
         }
-        Map<CharSequence, IndexedRecord> recordsMapUnion126 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
-        if (recordsMapUnion126 == null) {
+        Map<CharSequence, IndexedRecord> recordsMapUnion0 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
+        if (recordsMapUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsMapUnion126 instanceof Map) {
+            if (recordsMapUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
                 (encoder).writeMapStart();
-                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion126) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).isEmpty()) {
+                if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion0) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion126).size());
-                    for (CharSequence key127 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).keySet()) {
+                    (encoder).setItemCount(((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).size());
+                    for (CharSequence key1 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key127);
-                        IndexedRecord union128 = null;
-                        union128 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion126)).get(key127);
-                        if (union128 == null) {
+                        (encoder).writeString(key1);
+                        IndexedRecord union1 = null;
+                        union1 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).get(key1);
+                        if (union1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union128 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union128).getSchema().getFullName())) {
+                            if ((union1 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord118(((IndexedRecord) union128), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
                             }
                         }
                     }
@@ -117,20 +117,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord118(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField119 = ((CharSequence) data.get(0));
-        if (subField119 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField119 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField119 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField119));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField119 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_7914368223999287780.java
@@ -17,40 +17,40 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField129(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        List<Map<CharSequence, IndexedRecord>> recordsArrayMap130 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMap0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
         (encoder).writeArrayStart();
-        if ((recordsArrayMap130 == null)||recordsArrayMap130 .isEmpty()) {
+        if ((recordsArrayMap0 == null)||recordsArrayMap0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsArrayMap130 .size());
-            for (int counter131 = 0; (counter131 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).size()); counter131 ++) {
+            (encoder).setItemCount(recordsArrayMap0 .size());
+            for (int counter0 = 0; (counter0 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).size()); counter0 ++) {
                 (encoder).startItem();
-                Map<CharSequence, IndexedRecord> map132 = null;
-                map132 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap130).get(counter131);
+                Map<CharSequence, IndexedRecord> map0 = null;
+                map0 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).get(counter0);
                 (encoder).writeMapStart();
-                if ((map132 == null)||map132 .isEmpty()) {
+                if ((map0 == null)||map0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(map132 .size());
-                    for (CharSequence key133 : ((Map<CharSequence, IndexedRecord> ) map132).keySet()) {
+                    (encoder).setItemCount(map0 .size());
+                    for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) map0).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key133);
-                        IndexedRecord union134 = null;
-                        union134 = ((Map<CharSequence, IndexedRecord> ) map132).get(key133);
-                        if (union134 == null) {
+                        (encoder).writeString(key0);
+                        IndexedRecord union0 = null;
+                        union0 = ((Map<CharSequence, IndexedRecord> ) map0).get(key0);
+                        if (union0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union134 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union134).getSchema().getFullName())) {
+                            if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord135(((IndexedRecord) union134), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
                             }
                         }
                     }
@@ -59,33 +59,33 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeArrayEnd();
-        Map<CharSequence, List<IndexedRecord>> recordsMapArray137 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        Map<CharSequence, List<IndexedRecord>> recordsMapArray0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
         (encoder).writeMapStart();
-        if ((recordsMapArray137 == null)||recordsMapArray137 .isEmpty()) {
+        if ((recordsMapArray0 == null)||recordsMapArray0 .isEmpty()) {
             (encoder).setItemCount(0);
         } else {
-            (encoder).setItemCount(recordsMapArray137 .size());
-            for (CharSequence key138 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).keySet()) {
+            (encoder).setItemCount(recordsMapArray0 .size());
+            for (CharSequence key1 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key138);
-                List<IndexedRecord> array139 = null;
-                array139 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray137).get(key138);
+                (encoder).writeString(key1);
+                List<IndexedRecord> array0 = null;
+                array0 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).get(key1);
                 (encoder).writeArrayStart();
-                if ((array139 == null)||array139 .isEmpty()) {
+                if ((array0 == null)||array0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(array139 .size());
-                    for (int counter140 = 0; (counter140 <((List<IndexedRecord> ) array139).size()); counter140 ++) {
+                    (encoder).setItemCount(array0 .size());
+                    for (int counter1 = 0; (counter1 <((List<IndexedRecord> ) array0).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union141 = null;
-                        union141 = ((List<IndexedRecord> ) array139).get(counter140);
-                        if (union141 == null) {
+                        IndexedRecord union1 = null;
+                        union1 = ((List<IndexedRecord> ) array0).get(counter1);
+                        if (union1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union141 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union141).getSchema().getFullName())) {
+                            if ((union1 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializesubRecord135(((IndexedRecord) union141), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
                             }
                         }
                     }
@@ -94,39 +94,39 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeMapEnd();
-        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion142 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
-        if (recordsArrayMapUnion142 == null) {
+        List<Map<CharSequence, IndexedRecord>> recordsArrayMapUnion0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(2));
+        if (recordsArrayMapUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsArrayMapUnion142 instanceof List) {
+            if (recordsArrayMapUnion0 instanceof List) {
                 (encoder).writeIndex(1);
                 (encoder).writeArrayStart();
-                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).isEmpty()) {
+                if ((((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0) == null)||((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142).size());
-                    for (int counter143 = 0; (counter143 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).size()); counter143 ++) {
+                    (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).size());
+                    for (int counter2 = 0; (counter2 <((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).size()); counter2 ++) {
                         (encoder).startItem();
-                        Map<CharSequence, IndexedRecord> map144 = null;
-                        map144 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion142)).get(counter143);
+                        Map<CharSequence, IndexedRecord> map1 = null;
+                        map1 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).get(counter2);
                         (encoder).writeMapStart();
-                        if ((map144 == null)||map144 .isEmpty()) {
+                        if ((map1 == null)||map1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(map144 .size());
-                            for (CharSequence key145 : ((Map<CharSequence, IndexedRecord> ) map144).keySet()) {
+                            (encoder).setItemCount(map1 .size());
+                            for (CharSequence key2 : ((Map<CharSequence, IndexedRecord> ) map1).keySet()) {
                                 (encoder).startItem();
-                                (encoder).writeString(key145);
-                                IndexedRecord union146 = null;
-                                union146 = ((Map<CharSequence, IndexedRecord> ) map144).get(key145);
-                                if (union146 == null) {
+                                (encoder).writeString(key2);
+                                IndexedRecord union2 = null;
+                                union2 = ((Map<CharSequence, IndexedRecord> ) map1).get(key2);
+                                if (union2 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union146 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union146).getSchema().getFullName())) {
+                                    if ((union2 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union2).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializesubRecord135(((IndexedRecord) union146), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union2), (encoder));
                                     }
                                 }
                             }
@@ -137,39 +137,39 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                 (encoder).writeArrayEnd();
             }
         }
-        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion147 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
-        if (recordsMapArrayUnion147 == null) {
+        Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
+        if (recordsMapArrayUnion0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (recordsMapArrayUnion147 instanceof Map) {
+            if (recordsMapArrayUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
                 (encoder).writeMapStart();
-                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).isEmpty()) {
+                if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147).size());
-                    for (CharSequence key148 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).keySet()) {
+                    (encoder).setItemCount(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).size());
+                    for (CharSequence key3 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).keySet()) {
                         (encoder).startItem();
-                        (encoder).writeString(key148);
-                        List<IndexedRecord> array149 = null;
-                        array149 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion147)).get(key148);
+                        (encoder).writeString(key3);
+                        List<IndexedRecord> array1 = null;
+                        array1 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).get(key3);
                         (encoder).writeArrayStart();
-                        if ((array149 == null)||array149 .isEmpty()) {
+                        if ((array1 == null)||array1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(array149 .size());
-                            for (int counter150 = 0; (counter150 <((List<IndexedRecord> ) array149).size()); counter150 ++) {
+                            (encoder).setItemCount(array1 .size());
+                            for (int counter3 = 0; (counter3 <((List<IndexedRecord> ) array1).size()); counter3 ++) {
                                 (encoder).startItem();
-                                IndexedRecord union151 = null;
-                                union151 = ((List<IndexedRecord> ) array149).get(counter150);
-                                if (union151 == null) {
+                                IndexedRecord union3 = null;
+                                union3 = ((List<IndexedRecord> ) array1).get(counter3);
+                                if (union3 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union151 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union151).getSchema().getFullName())) {
+                                    if ((union3 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) union3).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializesubRecord135(((IndexedRecord) union151), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union3), (encoder));
                                     }
                                 }
                             }
@@ -183,20 +183,20 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord135(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField136 = ((CharSequence) data.get(0));
-        if (subField136 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField136 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField136 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField136));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField136 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_6522044322942421190.java
@@ -15,56 +15,56 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
     public void serialize(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField152(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        IndexedRecord record153 = ((IndexedRecord) data.get(0));
-        if (record153 == null) {
+        IndexedRecord record0 = ((IndexedRecord) data.get(0));
+        if (record0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if ((record153 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record153).getSchema().getFullName())) {
+            if ((record0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.subRecord".equals(((IndexedRecord) record0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializesubRecord154(((IndexedRecord) record153), (encoder));
+                serializeSubRecord0(((IndexedRecord) record0), (encoder));
             }
         }
-        IndexedRecord record1156 = ((IndexedRecord) data.get(1));
-        serializesubRecord154(record1156, (encoder));
-        CharSequence field157 = ((CharSequence) data.get(2));
-        if (field157 == null) {
+        IndexedRecord record10 = ((IndexedRecord) data.get(1));
+        serializeSubRecord0(record10, (encoder));
+        CharSequence field0 = ((CharSequence) data.get(2));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field157 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field157 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field157));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field157 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializesubRecord154(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence subField155 = ((CharSequence) data.get(0));
-        if (subField155 == null) {
+        CharSequence subField0 = ((CharSequence) data.get(0));
+        if (subField0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (subField155 instanceof CharSequence) {
+            if (subField0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (subField155 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) subField155));
+                if (subField0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) subField0));
                 } else {
-                    (encoder).writeString(subField155 .toString());
+                    (encoder).writeString(subField0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_UNION_GenericSerializer_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_UNION_GenericSerializer_2087096002965517991.java
@@ -21,18 +21,18 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key86 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key86);
-                IndexedRecord union87 = null;
-                union87 = ((Map<CharSequence, IndexedRecord> ) data).get(key86);
-                if (union87 == null) {
+                (encoder).writeString(key0);
+                IndexedRecord union0 = null;
+                union0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                if (union0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union87 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union87).getSchema().getFullName())) {
+                    if ((union0 instanceof IndexedRecord)&&"com.adpilot.utils.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializerecord88(((IndexedRecord) union87), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder));
                     }
                 }
             }
@@ -41,20 +41,20 @@ public class Map_of_UNION_GenericSerializer_2087096002965517991
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord88(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field89 = ((CharSequence) data.get(0));
-        if (field89 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field89 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field89 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field89));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field89 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_record_GenericSerializer_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_8/Map_of_record_GenericSerializer_2141121767969292399.java
@@ -21,32 +21,32 @@ public class Map_of_record_GenericSerializer_2141121767969292399
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key82 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                (encoder).writeString(key82);
-                IndexedRecord record83 = null;
-                record83 = ((Map<CharSequence, IndexedRecord> ) data).get(key82);
-                serializerecord84(record83, (encoder));
+                (encoder).writeString(key0);
+                IndexedRecord record0 = null;
+                record0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                serializeRecord0(record0, (encoder));
             }
         }
         (encoder).writeMapEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializerecord84(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder)
         throws IOException
     {
-        CharSequence field85 = ((CharSequence) data.get(0));
-        if (field85 == null) {
+        CharSequence field0 = ((CharSequence) data.get(0));
+        if (field0 == null) {
             (encoder).writeIndex(0);
             (encoder).writeNull();
         } else {
-            if (field85 instanceof CharSequence) {
+            if (field0 instanceof CharSequence) {
                 (encoder).writeIndex(1);
-                if (field85 instanceof Utf8) {
-                    (encoder).writeString(((Utf8) field85));
+                if (field0 instanceof Utf8) {
+                    (encoder).writeString(((Utf8) field0));
                 } else {
-                    (encoder).writeString(field85 .toString());
+                    (encoder).writeString(field0 .toString());
                 }
             }
         }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -21,12 +21,10 @@ import org.apache.log4j.Logger;
 import static com.linkedin.avro.fastserde.Utils.*;
 
 
-public abstract class FastDeserializerGeneratorBase<T> {
+public abstract class FastDeserializerGeneratorBase<T> extends FastSerdeBase {
   public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.generated.deserialization."
       + AvroCompatibilityHelper.getRuntimeAvroVersion().name();
   public static final String GENERATED_SOURCES_PATH = generateSourcePathFromPackageName(GENERATED_PACKAGE_NAME);
-
-  private static final AtomicInteger UNIQUE_ID_BASE = new AtomicInteger(0);
 
   protected static final Symbol EMPTY_SYMBOL = new Symbol(Symbol.Kind.TERMINAL, new Symbol[]{}) {};
   protected static final Symbol END_SYMBOL = new Symbol(Symbol.Kind.TERMINAL, new Symbol[]{}) {};
@@ -63,13 +61,8 @@ public abstract class FastDeserializerGeneratorBase<T> {
   public static String getClassName(Schema writerSchema, Schema readerSchema, String description) {
     Long writerSchemaId = Math.abs(Utils.getSchemaFingerprint(writerSchema));
     Long readerSchemaId = Math.abs(Utils.getSchemaFingerprint(readerSchema));
-    Schema.Type readerSchemaType = readerSchema.getType();
     String typeName = SchemaAssistant.getTypeName(readerSchema);
     return typeName + SEP + description + "Deserializer" + SEP + writerSchemaId + SEP + readerSchemaId;
-  }
-
-  protected static String getVariableName(String name) {
-    return name + UNIQUE_ID_BASE.getAndIncrement();
   }
 
   protected static String getSymbolPrintName(Symbol symbol) {

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
@@ -1,0 +1,38 @@
+package com.linkedin.avro.fastserde;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.lang3.StringUtils;
+
+
+/**
+ * Utilities used by both serialization and deserialization code.
+ *
+ * TODO: Make {@link FastDeserializerGeneratorBase} and {@link FastSerializerGeneratorBase} more lightweight
+ *       and less redundant by moving more stuff here.
+ */
+public abstract class FastSerdeBase {
+  /**
+   * A repository of how many times a given name was used.
+   *
+   * Does not actually need to be threadsafe, but it is made so just for defensive coding reasons.
+   */
+  private final ConcurrentMap<String, AtomicInteger> COUNTER_PER_NAME = new FastAvroConcurrentHashMap<>();
+
+  /**
+   * A function to generate unique names, such as those of variables and functions, within the scope
+   * of the this class instance (i.e. per serializer of a given schema or deserializer of a given
+   * schema pair).
+   *
+   * @param prefix String to serve as a prefix for the unique name
+   * @return a unique prefix composed of the {@param prefix} appended by a unique number
+   */
+  protected String getUniqueName(String prefix) {
+    String uncapitalizedPrefix = StringUtils.uncapitalize(prefix);
+    return uncapitalizedPrefix + nextUniqueInt(uncapitalizedPrefix);
+  }
+
+  private int nextUniqueInt(String name) {
+    return COUNTER_PER_NAME.computeIfAbsent(name, k -> new AtomicInteger(0)).getAndIncrement();
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGeneratorBase.java
@@ -20,12 +20,11 @@ import static com.linkedin.avro.fastserde.Utils.*;
  * TODO: refactor {@link FastSerializerGeneratorBase} and {@link FastDeserializerGeneratorBase} to eliminate the duplicate code.
  * @param <T> type of Datum to be operated on
  */
-public abstract class FastSerializerGeneratorBase<T> {
+public abstract class FastSerializerGeneratorBase<T> extends FastSerdeBase {
   public static final String GENERATED_PACKAGE_NAME = "com.linkedin.avro.fastserde.generated.serialization."
       + AvroCompatibilityHelper.getRuntimeAvroVersion().name();
   public static final String GENERATED_SOURCES_PATH = generateSourcePathFromPackageName(GENERATED_PACKAGE_NAME);
 
-  private static final AtomicInteger UNIQUE_ID_BASE = new AtomicInteger(0);
   protected static final String SEP = "_";
 
   private static final Logger LOGGER = Logger.getLogger(FastSerializerGeneratorBase.class);
@@ -49,14 +48,6 @@ public abstract class FastSerializerGeneratorBase<T> {
     Long schemaId = Math.abs(Utils.getSchemaFingerprint(schema));
     String typeName = SchemaAssistant.getTypeName(schema);
     return typeName + SEP + description + "Serializer" + SEP + schemaId;
-  }
-
-  protected static String getVariableName(String name) {
-    return StringUtils.uncapitalize(name) + nextUniqueInt();
-  }
-
-  protected static int nextUniqueInt() {
-    return UNIQUE_ID_BASE.getAndIncrement();
   }
 
   public abstract FastSerializer<T> generateSerializer();


### PR DESCRIPTION
This is achieved by altering the unique name generation strategy, such
that it is no longer globally-unique, but rather constrained to being
unique within a given serde class and furthermore within a given name
prefix. This should help remove as much needless jitter as possible in
the codegen output when the meta-code is altered.

Also created a new FastSerdeBase abstract class, extended by both the
FastDeserializerGeneratorBase and FastSerializerGeneratorBase. The
ser and deser meta-code is pretty repetitive, so I'm hoping that we
can move more code to this shared ancestor class later down the line.