### PR TITLE
Array-based implementation of the PrimitiveList APIs

### DIFF
--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -48,6 +48,11 @@ jmh {
 
 sourceSets {
   codegen
+  jmh {
+    java.srcDirs = ['src/jmh/java']
+    compileClasspath += test.output
+    runtimeClasspath += test.output
+  }
 }
 
 dependencies {
@@ -70,8 +75,8 @@ dependencies {
   jmh AVRO_LIB
 
   testCompile 'org.testng:testng:6.14.3'
-  testCompile "org.openjdk.jmh:jmh-core:1.19"
-  testCompile "org.openjdk.jmh:jmh-generator-annprocess:1.19"
+  jmhCompile "org.openjdk.jmh:jmh-core:1.19"
+  jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.19"
 
   avro14 ("org.apache.avro:avro:1.4.1") {
     exclude group: "org.mortbay.jetty"

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveBooleanList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveBooleanList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
                 array0 = ((PrimitiveBooleanList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveBooleanList(((int) chunkLen0));
+                array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveBooleanList(((int) chunkLen0));
+            array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveDoubleList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveDoubleArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
                 array0 = ((PrimitiveDoubleList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveDoubleList(((int) chunkLen0));
+                array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveDoubleList(((int) chunkLen0));
+            array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
                 array0 = ((PrimitiveIntList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveIntList(((int) chunkLen0));
+                array0 = new PrimitiveIntArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveIntList(((int) chunkLen0));
+            array0 = new PrimitiveIntArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveLongList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
                 array0 = ((PrimitiveLongList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveLongList(((int) chunkLen0));
+                array0 = new PrimitiveLongArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveLongList(((int) chunkLen0));
+            array0 = new PrimitiveLongArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -84,7 +84,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                         mapFieldValueValue0 = ((PrimitiveIntList) null);
                                         mapFieldValueValue0 .clear();
                                     } else {
-                                        mapFieldValueValue0 = new ColdPrimitiveIntList(((int) chunkLen2));
+                                        mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
                                     }
                                     do {
                                         for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -93,7 +93,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                         chunkLen2 = (decoder.arrayNext());
                                     } while (chunkLen2 > 0);
                                 } else {
-                                    mapFieldValueValue0 = new ColdPrimitiveIntList(((int) chunkLen2));
+                                    mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
                                 }
                                 mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveBooleanList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveBooleanList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
                 array0 = ((PrimitiveBooleanList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveBooleanList(((int) chunkLen0));
+                array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveBooleanList(((int) chunkLen0));
+            array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveDoubleList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveDoubleArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
                 array0 = ((PrimitiveDoubleList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveDoubleList(((int) chunkLen0));
+                array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveDoubleList(((int) chunkLen0));
+            array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
                 array0 = ((PrimitiveIntList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveIntList(((int) chunkLen0));
+                array0 = new PrimitiveIntArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveIntList(((int) chunkLen0));
+            array0 = new PrimitiveIntArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveLongList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
                 array0 = ((PrimitiveLongList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveLongList(((int) chunkLen0));
+                array0 = new PrimitiveLongArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveLongList(((int) chunkLen0));
+            array0 = new PrimitiveLongArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -84,7 +84,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                         mapFieldValueValue0 = ((PrimitiveIntList) null);
                                         mapFieldValueValue0 .clear();
                                     } else {
-                                        mapFieldValueValue0 = new ColdPrimitiveIntList(((int) chunkLen2));
+                                        mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
                                     }
                                     do {
                                         for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -93,7 +93,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                         chunkLen2 = (decoder.arrayNext());
                                     } while (chunkLen2 > 0);
                                 } else {
-                                    mapFieldValueValue0 = new ColdPrimitiveIntList(((int) chunkLen2));
+                                    mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
                                 }
                                 mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveBooleanList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveBooleanList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
                 array0 = ((PrimitiveBooleanList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveBooleanList(((int) chunkLen0));
+                array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveBooleanList(((int) chunkLen0));
+            array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveDoubleList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveDoubleArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
                 array0 = ((PrimitiveDoubleList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveDoubleList(((int) chunkLen0));
+                array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveDoubleList(((int) chunkLen0));
+            array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
                 array0 = ((PrimitiveIntList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveIntList(((int) chunkLen0));
+                array0 = new PrimitiveIntArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveIntList(((int) chunkLen0));
+            array0 = new PrimitiveIntArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveLongList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -29,7 +29,7 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
                 array0 = ((PrimitiveLongList)(reuse));
                 array0 .clear();
             } else {
-                array0 = new ColdPrimitiveLongList(((int) chunkLen0));
+                array0 = new PrimitiveLongArrayList(((int) chunkLen0));
             }
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -38,7 +38,7 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
                 chunkLen0 = (decoder.arrayNext());
             } while (chunkLen0 > 0);
         } else {
-            array0 = new ColdPrimitiveLongList(((int) chunkLen0));
+            array0 = new PrimitiveLongArrayList(((int) chunkLen0));
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
-import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -84,7 +84,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                         mapFieldValueValue0 = ((PrimitiveIntList) null);
                                         mapFieldValueValue0 .clear();
                                     } else {
-                                        mapFieldValueValue0 = new ColdPrimitiveIntList(((int) chunkLen2));
+                                        mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
                                     }
                                     do {
                                         for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -93,7 +93,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                         chunkLen2 = (decoder.arrayNext());
                                     } while (chunkLen2 > 0);
                                 } else {
-                                    mapFieldValueValue0 = new ColdPrimitiveIntList(((int) chunkLen2));
+                                    mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
                                 }
                                 mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }

--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/FastAvroSerdesBenchmark.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/FastAvroSerdesBenchmark.java
@@ -2,8 +2,9 @@ package com.linkedin.avro.fastserde;
 
 import com.linkedin.avro.fastserde.generated.avro.BenchmarkSchema;
 import com.linkedin.avro.fastserde.generator.AvroRandomDataGenerator;
-import com.linkedin.avro.fastserde.micro.benchmark.AvroGenericDeserializer;
 import com.linkedin.avro.fastserde.micro.benchmark.AvroGenericSerializer;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -12,17 +13,25 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 
 /**
@@ -44,22 +53,24 @@ import org.openjdk.jmh.annotations.Warmup;
 @Fork(1)
 //@Fork(value = 1, jvmArgsAppend = {"-XX:+PrintGCDetails", "-Xms16g", "-Xmx16g"})
 //@Threads(10)
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
 public class FastAvroSerdesBenchmark {
+  private static final int NUMBER_OF_OPERATIONS = 100_000;
+
   private final Random random = new Random();;
   private final Map<Object, Object> properties = new HashMap<>();
 
   private byte[] serializedBytes;
   private GenericData.Record generatedRecord;
 
-  private final Schema benchmarkSchame = BenchmarkSchema.SCHEMA$;
+  private final Schema benchmarkSchema = BenchmarkSchema.SCHEMA$;
   private static AvroRandomDataGenerator generator;
 
   private static AvroGenericSerializer serializer;
   private static AvroGenericSerializer fastSerializer;
-  private static AvroGenericDeserializer<GenericRecord> deserializer;
-  private static AvroGenericDeserializer<GenericRecord> fastDeserializer;
+  private static DatumReader<GenericRecord> deserializer;
+  private static DatumReader<GenericRecord> fastDeserializer;
 
   public FastAvroSerdesBenchmark() {
     // load configuration parameters to avro data generator
@@ -67,11 +78,19 @@ public class FastAvroSerdesBenchmark {
     properties.put(AvroRandomDataGenerator.STRING_LENGTH_PROP, BenchmarkConstants.STRING_SIZE);
     properties.put(AvroRandomDataGenerator.BYTES_LENGTH_PROP, BenchmarkConstants.BYTES_SIZE);
     properties.put(AvroRandomDataGenerator.MAP_LENGTH_PROP, BenchmarkConstants.MAP_SIZE);
-    generator = new AvroRandomDataGenerator(benchmarkSchame, random);
+    generator = new AvroRandomDataGenerator(benchmarkSchema, random);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    org.openjdk.jmh.runner.options.Options opt = new OptionsBuilder()
+        .include(FastAvroSerdesBenchmark.class.getSimpleName())
+        .addProfiler(GCProfiler.class)
+        .build();
+    new Runner(opt).run();
   }
 
   public byte[] serializeGeneratedRecord(GenericData.Record generatedRecord) throws Exception {
-    AvroGenericSerializer serializer = new AvroGenericSerializer(benchmarkSchame);
+    AvroGenericSerializer serializer = new AvroGenericSerializer(benchmarkSchema);
     return serializer.serialize(generatedRecord);
   }
 
@@ -81,30 +100,48 @@ public class FastAvroSerdesBenchmark {
     generatedRecord = (GenericData.Record) generator.generate(properties);
     serializedBytes = serializeGeneratedRecord(generatedRecord);
 
-    serializer = new AvroGenericSerializer(benchmarkSchame);
-    fastSerializer = new AvroGenericSerializer(new FastGenericDatumWriter<>(benchmarkSchame));
-    deserializer = new AvroGenericDeserializer<>(new GenericDatumReader<>(benchmarkSchame));
-    fastDeserializer = new AvroGenericDeserializer<>(new FastGenericDatumReader<>(benchmarkSchame));
+    serializer = new AvroGenericSerializer(benchmarkSchema);
+    fastSerializer = new AvroGenericSerializer(new FastGenericDatumWriter<>(benchmarkSchema));
+    deserializer = new GenericDatumReader<>(benchmarkSchema);
+    fastDeserializer = new FastGenericDatumReader<>(benchmarkSchema);
   }
 
   @Benchmark
-  public void testAvroSerialization() throws Exception {
-    // use vanilla avro 1.4 encoder, do not use buffer binary encoder
-    serializer.serialize(generatedRecord);
+  @OperationsPerInvocation(NUMBER_OF_OPERATIONS)
+  public void testAvroSerialization(Blackhole bh) throws Exception {
+    for (int i = 0; i < NUMBER_OF_OPERATIONS; i++) {
+      // use vanilla avro 1.4 encoder, do not use buffer binary encoder
+      bh.consume(serializer.serialize(generatedRecord));
+    }
   }
 
   @Benchmark
-  public void testFastAvroSerialization() throws Exception {
-    fastSerializer.serialize(generatedRecord);
+  @OperationsPerInvocation(NUMBER_OF_OPERATIONS)
+  public void testFastAvroSerialization(Blackhole bh) throws Exception {
+    for (int i = 0; i < NUMBER_OF_OPERATIONS; i++) {
+      bh.consume(fastSerializer.serialize(generatedRecord));
+    }
   }
 
   @Benchmark
-  public void testAvroDeserialization() throws Exception {
-    deserializer.deserialize(serializedBytes);
+  @OperationsPerInvocation(NUMBER_OF_OPERATIONS)
+  public void testAvroDeserialization(Blackhole bh) throws Exception {
+    testDeserialization(deserializer, bh);
   }
 
   @Benchmark
-  public void testFastAvroDeserialization() throws Exception {
-    fastDeserializer.deserialize(serializedBytes);
+  @OperationsPerInvocation(NUMBER_OF_OPERATIONS)
+  public void testFastAvroDeserialization(Blackhole bh) throws Exception {
+    testDeserialization(fastDeserializer, bh);
+  }
+
+  private void testDeserialization(DatumReader<GenericRecord> datumReader, Blackhole bh) throws Exception {
+    GenericRecord record = null;
+    BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(serializedBytes);
+    for (int i = 0; i < NUMBER_OF_OPERATIONS; i++) {
+      decoder = AvroCompatibilityHelper.newBinaryDecoder(new ByteArrayInputStream(serializedBytes), false, decoder);
+      record = datumReader.read(record, decoder);
+      bh.consume(record);
+    }
   }
 }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -10,6 +10,11 @@ import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveDoubleList;
 import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveFloatList;
 import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
 import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveLongList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveDoubleArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveFloatArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
 import com.sun.codemodel.JBlock;
 import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
@@ -278,15 +283,15 @@ public class SchemaAssistant {
         Class klass = null;
         if (primitiveList) {
           switch (schema.getElementType().getType()) {
-            case BOOLEAN: klass = abstractType ? PrimitiveBooleanList.class : ColdPrimitiveBooleanList.class; break;
-            case DOUBLE: klass = abstractType ? PrimitiveDoubleList.class : ColdPrimitiveDoubleList.class; break;
+            case BOOLEAN: klass = abstractType ? PrimitiveBooleanList.class : PrimitiveBooleanArrayList.class; break;
+            case DOUBLE: klass = abstractType ? PrimitiveDoubleList.class : PrimitiveDoubleArrayList.class; break;
             /**
              * N.B.: FLOAT will get superseded in
              * {@link FastDeserializerGenerator#processArray(JVar, String, Schema, Schema, JBlock, FastDeserializerGeneratorBase.FieldAction, BiConsumer, Supplier)}
              */
-            case FLOAT: klass = abstractType ? PrimitiveFloatList.class : ColdPrimitiveFloatList.class; break;
-            case INT: klass = abstractType ? PrimitiveIntList.class : ColdPrimitiveIntList.class; break;
-            case LONG: klass = abstractType ? PrimitiveLongList.class : ColdPrimitiveLongList.class; break;
+            case FLOAT: klass = abstractType ? PrimitiveFloatList.class : PrimitiveFloatArrayList.class; break;
+            case INT: klass = abstractType ? PrimitiveIntList.class : PrimitiveIntArrayList.class; break;
+            case LONG: klass = abstractType ? PrimitiveLongList.class : PrimitiveLongArrayList.class; break;
             default: // no-op
           }
         }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveArrayList.java
@@ -1,0 +1,189 @@
+package com.linkedin.avro.fastserde.primitive;
+
+import java.util.AbstractList;
+import java.util.Iterator;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericData;
+
+
+public abstract class PrimitiveArrayList<T, L> extends AbstractList<T>
+    implements GenericContainer, Comparable<GenericArray<T>> {
+  private int size = 0;
+
+  // Abstract functions required by child classes
+
+  /**
+   * @return the size of the primitive array maintained by the child class, which could be larger than {@link #size}.
+   */
+  protected abstract int capacity();
+
+  /**
+   * A function used to replace the primitve array instance, in cases where it needs to be resized.
+   *
+   * @param newElements primitive array instance to replace the current one
+   */
+  protected abstract void setElementsArray(Object newElements);
+
+  /**
+   * @return the primitive array instance of the child class
+   */
+  protected abstract Object getElementsArray();
+
+  /**
+   * @param capacity of the new primitive array
+   * @return an instance of the right type of primitive array used by the child class
+   */
+  protected abstract Object newArray(int capacity);
+
+  /**
+   * @param that an instance of primitive list to use for comparison
+   * @param index the index of the element to compare
+   * @return the comparison result between element of this and {@param that} list at the provided {@param index}
+   */
+  protected abstract int compareElementAtIndex(L that, int index);
+
+  /**
+   * @param o instance of an Object that may or may not be a primitive list
+   * @return true if {@param o} instanceof the right type of primitive list for comparison
+   */
+  protected abstract boolean isInstanceOfCorrectPrimitiveList(Object o);
+
+  // Public API
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public void clear() {
+    size = 0;
+  }
+
+  @Override
+  public Iterator<T> iterator() {
+    return new Iterator<T>() {
+      private int position = 0;
+
+      @Override
+      public boolean hasNext() {
+        return position < size;
+      }
+
+      @Override
+      public T next() {
+        return get(position++);
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @Override
+  public T remove(int i) {
+    checkIfLargerThanSize(i);
+    T result = (T) get(i);
+    --size;
+    System.arraycopy(getElementsArray(), i+1, getElementsArray(), i, (size-i));
+    return result;
+  }
+
+  @Override
+  public int compareTo(GenericArray<T> that) {
+    if (isInstanceOfCorrectPrimitiveList(that)) {
+      L thatPrimitiveList = (L) that;
+      if (this.size == that.size()) {
+        for (int i = 0; i < this.size; i++) {
+          int compare = compareElementAtIndex(thatPrimitiveList, i);
+          if (compare != 0) {
+            return compare;
+          }
+        }
+        return 0;
+      } else if (this.size > that.size()) {
+        return 1;
+      } else {
+        return -1;
+      }
+    } else {
+      // Not our own type of primitive list, so we will delegate to the regular implementation, which will do boxing
+      return GenericData.get().compare(this, that, this.getSchema());
+    }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buffer = new StringBuilder();
+    buffer.append("[");
+    int count = 0;
+    for (T e : this) {
+      buffer.append(e==null ? "null" : e.toString());
+      if (++count < size()) {
+        buffer.append(", ");
+      }
+    }
+    buffer.append("]");
+    return buffer.toString();
+  }
+
+  // Utilities for child classes
+
+  /**
+   * A function to check if a requested index is within bound of the list. This is needed because {@link #size}
+   * may be smaller than {@link #capacity()}. This can happen in the case of object reuse, where the previous
+   * instance had a larger number of elements than the new one, in which case, we will reuse the array, but
+   * use the {@link #size} as a boundary within the larger array.
+   *
+   * @param i an index position which may or may not be within bound of the current list
+   * @throws IndexOutOfBoundsException if {@param i} is larger than the index of the last valid element
+   */
+  protected void checkIfLargerThanSize(int i) {
+    if (i >= size) {
+      throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
+    }
+  }
+
+  /**
+   * A function used when appending an element to the end of the list. It increments the size as a side-effect.
+   *
+   * N.B.: Since {@link #size} is private, this is the only size mutation operation allowed for child classes.
+   *
+   * @return the index of the appended element
+   */
+  protected int getAndIncrementSize() {
+    return size++;
+  }
+
+  /** Checks if the primitve array is at capacity, and if so, resizes it to 1.5x + 1. */
+  protected void capacityCheck() {
+    if (size == capacity()) {
+      Object newElements = newArray((size * 3)/2 + 1);
+      System.arraycopy(getElementsArray(), 0, newElements, 0, size);
+      setElementsArray(newElements);
+    }
+  }
+
+  /** Create an empty space in the array at the index specified by {@param location} by shifting the elements to the right */
+  protected void addInternal(int location) {
+    if (location > size || location < 0) {
+      throw new IndexOutOfBoundsException("Index " + location + " out of bounds.");
+    }
+    if (size == capacity()) {
+      Object newElements = newArray((size * 3)/2 + 1);
+      if (location > 0) {
+        // Copy the elements before the insertion location, if any, with same index
+        System.arraycopy(getElementsArray(), 0, newElements, 0, location - 1);
+      }
+      // Copy the elements after the insertion location, with index offset by 1
+      System.arraycopy(getElementsArray(), location, newElements, location + 1, size - location);
+      setElementsArray(newElements);
+    } else {
+      System.arraycopy(getElementsArray(), location, getElementsArray(), location + 1, size - location);
+    }
+    size++;
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveBooleanArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveBooleanArrayList.java
@@ -1,0 +1,91 @@
+package com.linkedin.avro.fastserde.primitive;
+
+import com.linkedin.avro.api.PrimitiveBooleanList;
+import org.apache.avro.Schema;
+
+
+public class PrimitiveBooleanArrayList extends PrimitiveArrayList<Boolean, PrimitiveBooleanList> implements PrimitiveBooleanList {
+  public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.BOOLEAN));
+  boolean[] elementsArray;
+
+  public PrimitiveBooleanArrayList(int capacity) {
+    this.elementsArray = new boolean[capacity];
+  }
+
+  @Override
+  public Boolean get(int index) {
+    return getPrimitive(index);
+  }
+
+  @Override
+  public boolean getPrimitive(int index) {
+    checkIfLargerThanSize(index);
+    return elementsArray[index];
+  }
+
+  @Override
+  public boolean add(Boolean o) {
+    return addPrimitive(o);
+  }
+
+  @Override
+  public boolean addPrimitive(boolean e) {
+    capacityCheck();
+    elementsArray[getAndIncrementSize()] = e;
+    return true;
+  }
+
+  @Override
+  public void add(int position, Boolean e) {
+    addInternal(position);
+    elementsArray[position] = e;
+  }
+
+  @Override
+  public Boolean set(int index, Boolean element) {
+    return setPrimitive(index, element);
+  }
+
+  @Override
+  public boolean setPrimitive(int index, boolean element) {
+    checkIfLargerThanSize(index);
+    boolean response = elementsArray[index];
+    elementsArray[index] = element;
+    return response;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  protected int capacity() {
+    return elementsArray.length;
+  }
+
+  @Override
+  protected void setElementsArray(Object newElements) {
+    this.elementsArray = (boolean[]) newElements;
+  }
+
+  @Override
+  protected Object getElementsArray() {
+    return this.elementsArray;
+  }
+
+  @Override
+  protected Object newArray(int capacity) {
+    return new boolean[capacity];
+  }
+
+  @Override
+  protected int compareElementAtIndex(PrimitiveBooleanList that, int index) {
+    return Boolean.compare(elementsArray[index], that.getPrimitive(index));
+  }
+
+  @Override
+  protected boolean isInstanceOfCorrectPrimitiveList(Object o) {
+    return o instanceof PrimitiveBooleanList;
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveDoubleArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveDoubleArrayList.java
@@ -1,0 +1,92 @@
+package com.linkedin.avro.fastserde.primitive;
+
+import com.linkedin.avro.api.PrimitiveBooleanList;
+import com.linkedin.avro.api.PrimitiveDoubleList;
+import org.apache.avro.Schema;
+
+
+public class PrimitiveDoubleArrayList extends PrimitiveArrayList<Double, PrimitiveDoubleList> implements PrimitiveDoubleList {
+  public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.DOUBLE));
+  double[] elementsArray;
+
+  public PrimitiveDoubleArrayList(int capacity) {
+    this.elementsArray = new double[capacity];
+  }
+
+  @Override
+  public Double get(int index) {
+    return getPrimitive(index);
+  }
+
+  @Override
+  public double getPrimitive(int index) {
+    checkIfLargerThanSize(index);
+    return elementsArray[index];
+  }
+
+  @Override
+  public boolean add(Double o) {
+    return addPrimitive(o);
+  }
+
+  @Override
+  public boolean addPrimitive(double e) {
+    capacityCheck();
+    elementsArray[getAndIncrementSize()] = e;
+    return true;
+  }
+
+  @Override
+  public void add(int position, Double e) {
+    addInternal(position);
+    elementsArray[position] = e;
+  }
+
+  @Override
+  public Double set(int index, Double element) {
+    return setPrimitive(index, element);
+  }
+
+  @Override
+  public double setPrimitive(int index, double element) {
+    checkIfLargerThanSize(index);
+    double response = elementsArray[index];
+    elementsArray[index] = element;
+    return response;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  protected int capacity() {
+    return elementsArray.length;
+  }
+
+  @Override
+  protected void setElementsArray(Object newElements) {
+    this.elementsArray = (double[]) newElements;
+  }
+
+  @Override
+  protected Object getElementsArray() {
+    return this.elementsArray;
+  }
+
+  @Override
+  protected Object newArray(int capacity) {
+    return new double[capacity];
+  }
+
+  @Override
+  protected int compareElementAtIndex(PrimitiveDoubleList that, int index) {
+    return Double.compare(elementsArray[index], that.getPrimitive(index));
+  }
+
+  @Override
+  protected boolean isInstanceOfCorrectPrimitiveList(Object o) {
+    return o instanceof PrimitiveBooleanList;
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveFloatArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveFloatArrayList.java
@@ -1,0 +1,92 @@
+package com.linkedin.avro.fastserde.primitive;
+
+import com.linkedin.avro.api.PrimitiveBooleanList;
+import com.linkedin.avro.api.PrimitiveFloatList;
+import org.apache.avro.Schema;
+
+
+public class PrimitiveFloatArrayList extends PrimitiveArrayList<Float, PrimitiveFloatList> implements PrimitiveFloatList {
+  public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.FLOAT));
+  float[] elementsArray;
+
+  public PrimitiveFloatArrayList(int capacity) {
+    this.elementsArray = new float[capacity];
+  }
+
+  @Override
+  public Float get(int index) {
+    return getPrimitive(index);
+  }
+
+  @Override
+  public float getPrimitive(int index) {
+    checkIfLargerThanSize(index);
+    return elementsArray[index];
+  }
+
+  @Override
+  public boolean add(Float o) {
+    return addPrimitive(o);
+  }
+
+  @Override
+  public boolean addPrimitive(float e) {
+    capacityCheck();
+    elementsArray[getAndIncrementSize()] = e;
+    return true;
+  }
+
+  @Override
+  public void add(int position, Float e) {
+    addInternal(position);
+    elementsArray[position] = e;
+  }
+
+  @Override
+  public Float set(int index, Float element) {
+    return setPrimitive(index, element);
+  }
+
+  @Override
+  public float setPrimitive(int index, float element) {
+    checkIfLargerThanSize(index);
+    float response = elementsArray[index];
+    elementsArray[index] = element;
+    return response;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  protected int capacity() {
+    return elementsArray.length;
+  }
+
+  @Override
+  protected void setElementsArray(Object newElements) {
+    this.elementsArray = (float[]) newElements;
+  }
+
+  @Override
+  protected Object getElementsArray() {
+    return this.elementsArray;
+  }
+
+  @Override
+  protected Object newArray(int capacity) {
+    return new float[capacity];
+  }
+
+  @Override
+  protected int compareElementAtIndex(PrimitiveFloatList that, int index) {
+    return Float.compare(elementsArray[index], that.getPrimitive(index));
+  }
+
+  @Override
+  protected boolean isInstanceOfCorrectPrimitiveList(Object o) {
+    return o instanceof PrimitiveBooleanList;
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveIntArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveIntArrayList.java
@@ -1,0 +1,92 @@
+package com.linkedin.avro.fastserde.primitive;
+
+import com.linkedin.avro.api.PrimitiveBooleanList;
+import com.linkedin.avro.api.PrimitiveIntList;
+import org.apache.avro.Schema;
+
+
+public class PrimitiveIntArrayList extends PrimitiveArrayList<Integer, PrimitiveIntList> implements PrimitiveIntList {
+  public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.INT));
+  int[] elementsArray;
+
+  public PrimitiveIntArrayList(int capacity) {
+    this.elementsArray = new int[capacity];
+  }
+
+  @Override
+  public Integer get(int index) {
+    return getPrimitive(index);
+  }
+
+  @Override
+  public int getPrimitive(int index) {
+    checkIfLargerThanSize(index);
+    return elementsArray[index];
+  }
+
+  @Override
+  public boolean add(Integer o) {
+    return addPrimitive(o);
+  }
+
+  @Override
+  public boolean addPrimitive(int e) {
+    capacityCheck();
+    elementsArray[getAndIncrementSize()] = e;
+    return true;
+  }
+
+  @Override
+  public void add(int position, Integer e) {
+    addInternal(position);
+    elementsArray[position] = e;
+  }
+
+  @Override
+  public Integer set(int index, Integer element) {
+    return setPrimitive(index, element);
+  }
+
+  @Override
+  public int setPrimitive(int index, int element) {
+    checkIfLargerThanSize(index);
+    int response = elementsArray[index];
+    elementsArray[index] = element;
+    return response;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  protected int capacity() {
+    return elementsArray.length;
+  }
+
+  @Override
+  protected void setElementsArray(Object newElements) {
+    this.elementsArray = (int[]) newElements;
+  }
+
+  @Override
+  protected Object getElementsArray() {
+    return this.elementsArray;
+  }
+
+  @Override
+  protected Object newArray(int capacity) {
+    return new int[capacity];
+  }
+
+  @Override
+  protected int compareElementAtIndex(PrimitiveIntList that, int index) {
+    return Integer.compare(elementsArray[index], that.getPrimitive(index));
+  }
+
+  @Override
+  protected boolean isInstanceOfCorrectPrimitiveList(Object o) {
+    return o instanceof PrimitiveBooleanList;
+  }
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveLongArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveLongArrayList.java
@@ -1,0 +1,92 @@
+package com.linkedin.avro.fastserde.primitive;
+
+import com.linkedin.avro.api.PrimitiveBooleanList;
+import com.linkedin.avro.api.PrimitiveLongList;
+import org.apache.avro.Schema;
+
+
+public class PrimitiveLongArrayList extends PrimitiveArrayList<Long, PrimitiveLongList> implements PrimitiveLongList {
+  public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.LONG));
+  long[] elementsArray;
+
+  public PrimitiveLongArrayList(int capacity) {
+    this.elementsArray = new long[capacity];
+  }
+
+  @Override
+  public Long get(int index) {
+    return getPrimitive(index);
+  }
+
+  @Override
+  public long getPrimitive(int index) {
+    checkIfLargerThanSize(index);
+    return elementsArray[index];
+  }
+
+  @Override
+  public boolean add(Long o) {
+    return addPrimitive(o);
+  }
+
+  @Override
+  public boolean addPrimitive(long e) {
+    capacityCheck();
+    elementsArray[getAndIncrementSize()] = e;
+    return true;
+  }
+
+  @Override
+  public void add(int position, Long e) {
+    addInternal(position);
+    elementsArray[position] = e;
+  }
+
+  @Override
+  public Long set(int index, Long element) {
+    return setPrimitive(index, element);
+  }
+
+  @Override
+  public long setPrimitive(int index, long element) {
+    checkIfLargerThanSize(index);
+    long response = elementsArray[index];
+    elementsArray[index] = element;
+    return response;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  protected int capacity() {
+    return elementsArray.length;
+  }
+
+  @Override
+  protected void setElementsArray(Object newElements) {
+    this.elementsArray = (long[]) newElements;
+  }
+
+  @Override
+  protected Object getElementsArray() {
+    return this.elementsArray;
+  }
+
+  @Override
+  protected Object newArray(int capacity) {
+    return new long[capacity];
+  }
+
+  @Override
+  protected int compareElementAtIndex(PrimitiveLongList that, int index) {
+    return Long.compare(elementsArray[index], that.getPrimitive(index));
+  }
+
+  @Override
+  protected boolean isInstanceOfCorrectPrimitiveList(Object o) {
+    return o instanceof PrimitiveBooleanList;
+  }
+}

--- a/avro-fastserde/src/test/avro/benchmarkSchema.avsc
+++ b/avro-fastserde/src/test/avro/benchmarkSchema.avsc
@@ -8,7 +8,7 @@
       "name": "testArray",
       "type": {
         "type": "array",
-        "items": "float"
+        "items": "double"
       }
     }
   ]


### PR DESCRIPTION
On the double array use case, memory allocation of deserialization goes from
288 B/op to 48 B/op. There are more optimized implementations that should be
possible for some of the types.