### PR TITLE
slf4j logging API support in fast-avro (#67)

### DIFF
--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -58,7 +58,7 @@ sourceSets {
 dependencies {
   compile project(":helper:helper")
 
-  compile "org.slf4j:slf4j-log4j12:1.7.14"
+  compile "org.slf4j:slf4j-api:1.7.14"
   compile "org.apache.commons:commons-lang3:3.4"
   compile "com.sun.codemodel:codemodel:2.6"
   compile "com.google.guava:guava:19.0"
@@ -75,6 +75,7 @@ dependencies {
   jmh AVRO_LIB
 
   testCompile 'org.testng:testng:6.14.3'
+  testCompile 'org.slf4j:slf4j-simple:1.7.14'
   jmhCompile "org.openjdk.jmh:jmh-core:1.19"
   jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.19"
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
@@ -4,14 +4,15 @@ import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Generic {@link DatumReader} backed by generated deserialization code.
  */
 public class FastGenericDatumReader<T> implements DatumReader<T> {
-  private static final Logger LOGGER = Logger.getLogger(FastGenericDatumReader.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FastGenericDatumReader.class);
 
   private Schema writerSchema;
   private Schema readerSchema;

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumWriter.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumWriter.java
@@ -4,14 +4,15 @@ import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Generic {@link DatumWriter} backed by generated serialization code.
  */
 public class FastGenericDatumWriter<T> implements DatumWriter<T> {
-  private static final Logger LOGGER = Logger.getLogger(FastGenericDatumWriter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FastGenericDatumWriter.class);
   private final FastSerdeCache cache;
   private Schema writerSchema;
   private FastSerializer<T> cachedFastSerializer;

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
@@ -18,7 +18,8 @@ import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.linkedin.avro.fastserde.Utils.*;
 
@@ -27,7 +28,7 @@ import static com.linkedin.avro.fastserde.Utils.*;
  * Utilities used by both serialization and deserialization code.
  */
 public abstract class FastSerdeBase {
-  private static final Logger LOGGER = Logger.getLogger(FastSerdeBase.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FastSerdeBase.class);
   protected static final String SEP = "_";
   public static final String GENERATED_PACKAGE_NAME_PREFIX = "com.linkedin.avro.fastserde.generated.";
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
@@ -26,7 +26,8 @@ import org.apache.avro.io.Decoder;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -39,7 +40,7 @@ public final class FastSerdeCache {
   public static final String CLASSPATH = "avro.fast.serde.classpath";
   public static final String CLASSPATH_SUPPLIER = "avro.fast.serde.classpath.supplier";
 
-  private static final Logger LOGGER = Logger.getLogger(FastSerdeCache.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(FastSerdeCache.class);
 
   private static volatile FastSerdeCache _INSTANCE;
 


### PR DESCRIPTION
* slf4j APIs are used now in place of log4j APIs
* slf4j-log4j12 binding dropped from dependencies