### PR TITLE
Added specific record tests for primitive arrays.

### DIFF
--- a/avro-fastserde/regenerate_avro.sh
+++ b/avro-fastserde/regenerate_avro.sh
@@ -46,7 +46,7 @@ FULL_CODE_GEN_PATH=(
 )
 FULL_CODE_GEN_ROOT_PATH="${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro"
 
-if [[ $# < 1 ]]; then
+if [[ $# -lt 1 ]]; then
   echo "Usage: $0 avro_tools_path"
   echo ""
   echo "    avro_tools_path: full path to the avro-tools-1.x.x.jar file (required). If you use 'default_avro_140', it will take:"
@@ -93,7 +93,7 @@ for file in `ls ${FULL_CODE_GEN_ROOT_PATH}/*.java`; do
   rm -f ${file}
 done
 
-echo "Finished deleting old files. About to generate new ones..."
+echo "Finished deleting old files. About to generate new ones using $AVRO_TOOLS_JAR..."
 
 for file in `ls ${AVRO_SCHEMAS_ROOT_PATH}/*.avsc`; do
   echo ${file}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -24,21 +24,17 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
     {
         PrimitiveBooleanList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveBooleanList) {
-                array0 = ((PrimitiveBooleanList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readBoolean()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveBooleanList) {
+            array0 = ((PrimitiveBooleanList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readBoolean()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -24,21 +24,17 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
     {
         PrimitiveDoubleList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveDoubleList) {
-                array0 = ((PrimitiveDoubleList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readDouble()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveDoubleList) {
+            array0 = ((PrimitiveDoubleList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readDouble()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -24,21 +24,17 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
     {
         PrimitiveIntList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveIntList) {
-                array0 = ((PrimitiveIntList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveIntArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readInt()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveIntList) {
+            array0 = ((PrimitiveIntList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -24,21 +24,17 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
     {
         PrimitiveLongList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveLongList) {
-                array0 = ((PrimitiveLongList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveLongArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readLong()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveLongList) {
+            array0 = ((PrimitiveLongList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveLongArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readLong()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -31,32 +31,28 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
     {
         List<IndexedRecord> array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof List) {
-                array0 = ((List)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object arrayArrayElementReuseVar0 = null;
-                    if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
-                    }
-                    int unionIndex0 = (decoder.readIndex());
-                    if (unionIndex0 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex0 == 1) {
-                            array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
-                        }
-                    }
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
         } else {
             array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                int unionIndex0 = (decoder.readIndex());
+                if (unionIndex0 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex0 == 1) {
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+                    }
+                }
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -29,25 +29,21 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
     {
         List<IndexedRecord> array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof List) {
-                array0 = ((List)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object arrayArrayElementReuseVar0 = null;
-                    if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
-                    }
-                    array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
         } else {
             array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_7716892313569022782_7716892313569022782.java
@@ -55,51 +55,43 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
-                testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
-                testEnumArray1 .clear();
-            } else {
-                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
+            testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+            testEnumArray1 .clear();
         } else {
             testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
-                testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
-                testEnumUnionArray1 .clear();
-            } else {
-                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-                        }
-                    }
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
+            testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+            testEnumUnionArray1 .clear();
         } else {
             testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testEnumUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
+                    testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+                    }
+                }
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_8811953951139265292_8811953951139265292.java
@@ -68,69 +68,61 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         }
         List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
-                testFixedArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
-                testFixedArray1 .clear();
-            } else {
-                testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object testFixedArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
-                        testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
-                    }
-                    byte[] testFixed2;
-                    if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
-                        testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
-                    } else {
-                        testFixed2 = ( new byte[2]);
-                    }
-                    decoder.readFixed(testFixed2);
-                    testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed2));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
+            testFixedArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+            testFixedArray1 .clear();
         } else {
             testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object testFixedArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
+                    testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                }
+                byte[] testFixed2;
+                if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
+                    testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
+                } else {
+                    testFixed2 = ( new byte[2]);
+                }
+                decoder.readFixed(testFixed2);
+                testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed2));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
         List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
-                testFixedUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
-                testFixedUnionArray1 .clear();
-            } else {
-                testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testFixedUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
-                        testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            byte[] testFixed3;
-                            if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
-                                testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
-                            } else {
-                                testFixed3 = ( new byte[2]);
-                            }
-                            decoder.readFixed(testFixed3);
-                            testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed3));
-                        }
-                    }
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
+            testFixedUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+            testFixedUnionArray1 .clear();
         } else {
             testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testFixedUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
+                    testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        byte[] testFixed3;
+                        if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
+                            testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
+                        } else {
+                            testFixed3 = ( new byte[2]);
+                        }
+                        decoder.readFixed(testFixed3);
+                        testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(testFixed3));
+                    }
+                }
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_8750596110605641040_8750596110605641040.java
@@ -79,21 +79,17 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                 Utf8 key1 = (decoder.readString(null));
                                 PrimitiveIntList mapFieldValueValue0 = null;
                                 long chunkLen2 = (decoder.readArrayStart());
-                                if (chunkLen2 > 0) {
-                                    if (null instanceof PrimitiveIntList) {
-                                        mapFieldValueValue0 = ((PrimitiveIntList) null);
-                                        mapFieldValueValue0 .clear();
-                                    } else {
-                                        mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
-                                    }
-                                    do {
-                                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
-                                            mapFieldValueValue0 .addPrimitive((decoder.readInt()));
-                                        }
-                                        chunkLen2 = (decoder.arrayNext());
-                                    } while (chunkLen2 > 0);
+                                if (null instanceof PrimitiveIntList) {
+                                    mapFieldValueValue0 = ((PrimitiveIntList) null);
+                                    mapFieldValueValue0 .clear();
                                 } else {
                                     mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
+                                }
+                                while (chunkLen2 > 0) {
+                                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                                        mapFieldValueValue0 .addPrimitive((decoder.readInt()));
+                                    }
+                                    chunkLen2 = (decoder.arrayNext());
                                 }
                                 mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
@@ -97,93 +97,85 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
-                testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
-                testEnumArray1 .clear();
-            } else {
-                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    int enumIndex2 = (decoder.readEnum());
-                    org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                    if (enumIndex2 == 0) {
-                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+        if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
+            testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+            testEnumArray1 .clear();
+        } else {
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                int enumIndex2 = (decoder.readEnum());
+                org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
+                if (enumIndex2 == 0) {
+                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                } else {
+                    if (enumIndex2 == 1) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
                     } else {
-                        if (enumIndex2 == 1) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
+                        if (enumIndex2 == 2) {
+                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
                         } else {
-                            if (enumIndex2 == 2) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
+                            if (enumIndex2 == 3) {
+                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
                             } else {
-                                if (enumIndex2 == 3) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
-                                } else {
-                                    if (enumIndex2 == 4) {
-                                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
-                                    }
+                                if (enumIndex2 == 4) {
+                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
                                 }
                             }
                         }
                     }
-                    testEnumArray1 .add(enumValue2);
                 }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
-        } else {
-            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+                testEnumArray1 .add(enumValue2);
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
-                testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
-                testEnumUnionArray1 .clear();
-            } else {
-                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            int enumIndex3 = (decoder.readEnum());
-                            org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                            if (enumIndex3 == 0) {
-                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+        if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
+            testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+            testEnumUnionArray1 .clear();
+        } else {
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testEnumUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
+                    testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        int enumIndex3 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
+                        if (enumIndex3 == 0) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                        } else {
+                            if (enumIndex3 == 1) {
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
                             } else {
-                                if (enumIndex3 == 1) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
+                                if (enumIndex3 == 2) {
+                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
                                 } else {
-                                    if (enumIndex3 == 2) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
+                                    if (enumIndex3 == 3) {
+                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
                                     } else {
-                                        if (enumIndex3 == 3) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
-                                        } else {
-                                            if (enumIndex3 == 4) {
-                                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
-                                            }
+                                        if (enumIndex3 == 4) {
+                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
                                         }
                                     }
                                 }
                             }
-                            testEnumUnionArray1 .add(enumValue3);
                         }
+                        testEnumUnionArray1 .add(enumValue3);
                     }
                 }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
-        } else {
-            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3518250962527328123_3518250962527328123.java
@@ -60,25 +60,21 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         }
         List<IndexedRecord> recordsArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
-                recordsArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
-                recordsArray1 .clear();
-            } else {
-                recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object recordsArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
-                    }
-                    recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
+            recordsArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+            recordsArray1 .clear();
         } else {
             recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordsArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
+                    recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                }
+                recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
         Map<Utf8, IndexedRecord> recordsMap1 = null;
@@ -112,32 +108,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
             if (unionIndex1 == 1) {
                 List<IndexedRecord> recordsArrayUnionOption0 = null;
                 long chunkLen2 = (decoder.readArrayStart());
-                if (chunkLen2 > 0) {
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
-                        recordsArrayUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
-                        recordsArrayUnionOption0 .clear();
-                    } else {
-                        recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
-                    }
-                    do {
-                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
-                            Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
-                            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
-                                recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
-                            }
-                            int unionIndex2 = (decoder.readIndex());
-                            if (unionIndex2 == 0) {
-                                decoder.readNull();
-                            } else {
-                                if (unionIndex2 == 1) {
-                                    recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
-                                }
-                            }
-                        }
-                        chunkLen2 = (decoder.arrayNext());
-                    } while (chunkLen2 > 0);
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
+                    recordsArrayUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                    recordsArrayUnionOption0 .clear();
                 } else {
                     recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
+                }
+                while (chunkLen2 > 0) {
+                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                        }
+                        int unionIndex2 = (decoder.readIndex());
+                        if (unionIndex2 == 0) {
+                            decoder.readNull();
+                        } else {
+                            if (unionIndex2 == 1) {
+                                recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                            }
+                        }
+                    }
+                    chunkLen2 = (decoder.arrayNext());
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption0);
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_3807952864887349709_3807952864887349709.java
@@ -68,55 +68,51 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         }
         List<Map<Utf8, IndexedRecord>> recordsArrayMap1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
-                recordsArrayMap1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
-                recordsArrayMap1 .clear();
-            } else {
-                recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object recordsArrayMapArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
-                    }
-                    Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
-                    long chunkLen1 = (decoder.readMapStart());
-                    if (chunkLen1 > 0) {
-                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
-                        if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                            recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                        }
-                        if (recordsArrayMapElemReuse0 != (null)) {
-                            recordsArrayMapElemReuse0 .clear();
-                            recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                        } else {
-                            recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
-                        }
-                        do {
-                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                                Utf8 key0 = (decoder.readString(null));
-                                int unionIndex0 = (decoder.readIndex());
-                                if (unionIndex0 == 0) {
-                                    decoder.readNull();
-                                } else {
-                                    if (unionIndex0 == 1) {
-                                        recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
-                                    }
-                                }
-                            }
-                            chunkLen1 = (decoder.mapNext());
-                        } while (chunkLen1 > 0);
-                    } else {
-                        recordsArrayMapElem0 = Collections.emptyMap();
-                    }
-                    recordsArrayMap1 .add(recordsArrayMapElem0);
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
+            recordsArrayMap1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+            recordsArrayMap1 .clear();
         } else {
             recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordsArrayMapArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
+                    recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                }
+                Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
+                long chunkLen1 = (decoder.readMapStart());
+                if (chunkLen1 > 0) {
+                    Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
+                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
+                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
+                    }
+                    if (recordsArrayMapElemReuse0 != (null)) {
+                        recordsArrayMapElemReuse0 .clear();
+                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
+                    } else {
+                        recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
+                    }
+                    do {
+                        for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex0 = (decoder.readIndex());
+                            if (unionIndex0 == 0) {
+                                decoder.readNull();
+                            } else {
+                                if (unionIndex0 == 1) {
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
+                                }
+                            }
+                        }
+                        chunkLen1 = (decoder.mapNext());
+                    } while (chunkLen1 > 0);
+                } else {
+                    recordsArrayMapElem0 = Collections.emptyMap();
+                }
+                recordsArrayMap1 .add(recordsArrayMapElem0);
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
         Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
@@ -137,32 +133,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                     Utf8 key1 = (decoder.readString(null));
                     List<IndexedRecord> recordsMapArrayValue0 = null;
                     long chunkLen3 = (decoder.readArrayStart());
-                    if (chunkLen3 > 0) {
-                        if (null instanceof List) {
-                            recordsMapArrayValue0 = ((List) null);
-                            recordsMapArrayValue0 .clear();
-                        } else {
-                            recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
-                        }
-                        do {
-                            for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
-                                Object recordsMapArrayValueArrayElementReuseVar0 = null;
-                                if (null instanceof GenericArray) {
-                                    recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
-                                }
-                                int unionIndex2 = (decoder.readIndex());
-                                if (unionIndex2 == 0) {
-                                    decoder.readNull();
-                                } else {
-                                    if (unionIndex2 == 1) {
-                                        recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
-                                    }
-                                }
-                            }
-                            chunkLen3 = (decoder.arrayNext());
-                        } while (chunkLen3 > 0);
+                    if (null instanceof List) {
+                        recordsMapArrayValue0 = ((List) null);
+                        recordsMapArrayValue0 .clear();
                     } else {
                         recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
+                    }
+                    while (chunkLen3 > 0) {
+                        for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                            Object recordsMapArrayValueArrayElementReuseVar0 = null;
+                            if (null instanceof GenericArray) {
+                                recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
+                            }
+                            int unionIndex2 = (decoder.readIndex());
+                            if (unionIndex2 == 0) {
+                                decoder.readNull();
+                            } else {
+                                if (unionIndex2 == 1) {
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                }
+                            }
+                        }
+                        chunkLen3 = (decoder.arrayNext());
                     }
                     recordsMapArray1 .put(key1, recordsMapArrayValue0);
                 }
@@ -179,55 +171,51 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
             if (unionIndex3 == 1) {
                 List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption0 = null;
                 long chunkLen4 = (decoder.readArrayStart());
-                if (chunkLen4 > 0) {
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
-                        recordsArrayMapUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
-                        recordsArrayMapUnionOption0 .clear();
-                    } else {
-                        recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
-                    }
-                    do {
-                        for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
-                            Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
-                            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
-                                recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
-                            }
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
-                            long chunkLen5 = (decoder.readMapStart());
-                            if (chunkLen5 > 0) {
-                                Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                                if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                    recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                                }
-                                if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                    recordsArrayMapUnionOptionElemReuse0 .clear();
-                                    recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                                } else {
-                                    recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
-                                }
-                                do {
-                                    for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
-                                        Utf8 key2 = (decoder.readString(null));
-                                        int unionIndex4 = (decoder.readIndex());
-                                        if (unionIndex4 == 0) {
-                                            decoder.readNull();
-                                        } else {
-                                            if (unionIndex4 == 1) {
-                                                recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
-                                            }
-                                        }
-                                    }
-                                    chunkLen5 = (decoder.mapNext());
-                                } while (chunkLen5 > 0);
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
-                            }
-                            recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
-                        }
-                        chunkLen4 = (decoder.arrayNext());
-                    } while (chunkLen4 > 0);
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
+                    recordsArrayMapUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                    recordsArrayMapUnionOption0 .clear();
                 } else {
                     recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
+                }
+                while (chunkLen4 > 0) {
+                    for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                        }
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
+                        long chunkLen5 = (decoder.readMapStart());
+                        if (chunkLen5 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
+                            }
+                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse0 .clear();
+                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
+                            } else {
+                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
+                            }
+                            do {
+                                for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
+                                    Utf8 key2 = (decoder.readString(null));
+                                    int unionIndex4 = (decoder.readIndex());
+                                    if (unionIndex4 == 0) {
+                                        decoder.readNull();
+                                    } else {
+                                        if (unionIndex4 == 1) {
+                                            recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
+                                        }
+                                    }
+                                }
+                                chunkLen5 = (decoder.mapNext());
+                            } while (chunkLen5 > 0);
+                        } else {
+                            recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
+                        }
+                        recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
+                    }
+                    chunkLen4 = (decoder.arrayNext());
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption0);
             }
@@ -255,32 +243,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                             Utf8 key3 = (decoder.readString(null));
                             List<IndexedRecord> recordsMapArrayUnionOptionValue0 = null;
                             long chunkLen7 = (decoder.readArrayStart());
-                            if (chunkLen7 > 0) {
-                                if (null instanceof List) {
-                                    recordsMapArrayUnionOptionValue0 = ((List) null);
-                                    recordsMapArrayUnionOptionValue0 .clear();
-                                } else {
-                                    recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
-                                }
-                                do {
-                                    for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
-                                        Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
-                                        if (null instanceof GenericArray) {
-                                            recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
-                                        }
-                                        int unionIndex6 = (decoder.readIndex());
-                                        if (unionIndex6 == 0) {
-                                            decoder.readNull();
-                                        } else {
-                                            if (unionIndex6 == 1) {
-                                                recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
-                                            }
-                                        }
-                                    }
-                                    chunkLen7 = (decoder.arrayNext());
-                                } while (chunkLen7 > 0);
+                            if (null instanceof List) {
+                                recordsMapArrayUnionOptionValue0 = ((List) null);
+                                recordsMapArrayUnionOptionValue0 .clear();
                             } else {
                                 recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
+                            }
+                            while (chunkLen7 > 0) {
+                                for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
+                                    if (null instanceof GenericArray) {
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
+                                    }
+                                    int unionIndex6 = (decoder.readIndex());
+                                    if (unionIndex6 == 0) {
+                                        decoder.readNull();
+                                    } else {
+                                        if (unionIndex6 == 1) {
+                                            recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                        }
+                                    }
+                                }
+                                chunkLen7 = (decoder.arrayNext());
                             }
                             recordsMapArrayUnionOption0 .put(key3, recordsMapArrayUnionOptionValue0);
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_8654323032091677966_6773600871939851106.java
@@ -120,25 +120,21 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
         List<IndexedRecord> subRecordArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
-                subRecordArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
-                subRecordArray1 .clear();
-            } else {
-                subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object subRecordArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
-                        subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
-                    }
-                    subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
+            subRecordArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+            subRecordArray1 .clear();
         } else {
             subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object subRecordArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
+                    subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                }
+                subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1);
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
@@ -65,29 +65,25 @@ public class StringableRecord_SpecificDeserializer_6174384286732341990_617438428
         }
         List<Utf8> urlArray0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (StringableRecord.get(5) instanceof List) {
-                urlArray0 = ((List) StringableRecord.get(5));
-                urlArray0 .clear();
-            } else {
-                urlArray0 = new ArrayList<Utf8>();
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object urlArrayArrayElementReuseVar0 = null;
-                    if (StringableRecord.get(5) instanceof GenericArray) {
-                        urlArrayArrayElementReuseVar0 = ((GenericArray) StringableRecord.get(5)).peek();
-                    }
-                    if (urlArrayArrayElementReuseVar0 instanceof Utf8) {
-                        urlArray0 .add((decoder).readString(((Utf8) urlArrayArrayElementReuseVar0)));
-                    } else {
-                        urlArray0 .add((decoder).readString(null));
-                    }
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (StringableRecord.get(5) instanceof List) {
+            urlArray0 = ((List) StringableRecord.get(5));
+            urlArray0 .clear();
         } else {
-            urlArray0 = Collections.emptyList();
+            urlArray0 = new ArrayList<Utf8>();
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object urlArrayArrayElementReuseVar0 = null;
+                if (StringableRecord.get(5) instanceof GenericArray) {
+                    urlArrayArrayElementReuseVar0 = ((GenericArray) StringableRecord.get(5)).peek();
+                }
+                if (urlArrayArrayElementReuseVar0 instanceof Utf8) {
+                    urlArray0 .add((decoder).readString(((Utf8) urlArrayArrayElementReuseVar0)));
+                } else {
+                    urlArray0 .add((decoder).readString(null));
+                }
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         StringableRecord.put(5, urlArray0);
         Map<Utf8, Utf8> urlMap0 = null;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -24,21 +24,17 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
     {
         PrimitiveBooleanList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveBooleanList) {
-                array0 = ((PrimitiveBooleanList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readBoolean()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveBooleanList) {
+            array0 = ((PrimitiveBooleanList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readBoolean()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -24,21 +24,17 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
     {
         PrimitiveDoubleList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveDoubleList) {
-                array0 = ((PrimitiveDoubleList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readDouble()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveDoubleList) {
+            array0 = ((PrimitiveDoubleList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readDouble()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -24,21 +24,17 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
     {
         PrimitiveIntList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveIntList) {
-                array0 = ((PrimitiveIntList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveIntArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readInt()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveIntList) {
+            array0 = ((PrimitiveIntList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -24,21 +24,17 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
     {
         PrimitiveLongList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveLongList) {
-                array0 = ((PrimitiveLongList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveLongArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readLong()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveLongList) {
+            array0 = ((PrimitiveLongList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveLongArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readLong()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -31,32 +31,28 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
     {
         List<IndexedRecord> array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof List) {
-                array0 = ((List)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object arrayArrayElementReuseVar0 = null;
-                    if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
-                    }
-                    int unionIndex0 = (decoder.readIndex());
-                    if (unionIndex0 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex0 == 1) {
-                            array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
-                        }
-                    }
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
         } else {
             array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                int unionIndex0 = (decoder.readIndex());
+                if (unionIndex0 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex0 == 1) {
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+                    }
+                }
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -29,25 +29,21 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
     {
         List<IndexedRecord> array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof List) {
-                array0 = ((List)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object arrayArrayElementReuseVar0 = null;
-                    if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
-                    }
-                    array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
         } else {
             array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -55,51 +55,43 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
-                testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
-                testEnumArray1 .clear();
-            } else {
-                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
+            testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+            testEnumArray1 .clear();
         } else {
             testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
-                testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
-                testEnumUnionArray1 .clear();
-            } else {
-                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-                        }
-                    }
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
+            testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+            testEnumUnionArray1 .clear();
         } else {
             testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testEnumUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
+                    testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+                    }
+                }
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -68,69 +68,61 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         }
         List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
-                testFixedArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
-                testFixedArray1 .clear();
-            } else {
-                testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object testFixedArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
-                        testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
-                    }
-                    byte[] testFixed2;
-                    if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
-                        testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
-                    } else {
-                        testFixed2 = ( new byte[2]);
-                    }
-                    decoder.readFixed(testFixed2);
-                    testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed2));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
+            testFixedArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+            testFixedArray1 .clear();
         } else {
             testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object testFixedArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
+                    testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                }
+                byte[] testFixed2;
+                if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
+                    testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
+                } else {
+                    testFixed2 = ( new byte[2]);
+                }
+                decoder.readFixed(testFixed2);
+                testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed2));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
         List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
-                testFixedUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
-                testFixedUnionArray1 .clear();
-            } else {
-                testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testFixedUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
-                        testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            byte[] testFixed3;
-                            if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
-                                testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
-                            } else {
-                                testFixed3 = ( new byte[2]);
-                            }
-                            decoder.readFixed(testFixed3);
-                            testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed3));
-                        }
-                    }
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
+            testFixedUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+            testFixedUnionArray1 .clear();
         } else {
             testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testFixedUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
+                    testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        byte[] testFixed3;
+                        if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
+                            testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
+                        } else {
+                            testFixed3 = ( new byte[2]);
+                        }
+                        decoder.readFixed(testFixed3);
+                        testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed3));
+                    }
+                }
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -79,21 +79,17 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                 Utf8 key1 = (decoder.readString(null));
                                 PrimitiveIntList mapFieldValueValue0 = null;
                                 long chunkLen2 = (decoder.readArrayStart());
-                                if (chunkLen2 > 0) {
-                                    if (null instanceof PrimitiveIntList) {
-                                        mapFieldValueValue0 = ((PrimitiveIntList) null);
-                                        mapFieldValueValue0 .clear();
-                                    } else {
-                                        mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
-                                    }
-                                    do {
-                                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
-                                            mapFieldValueValue0 .addPrimitive((decoder.readInt()));
-                                        }
-                                        chunkLen2 = (decoder.arrayNext());
-                                    } while (chunkLen2 > 0);
+                                if (null instanceof PrimitiveIntList) {
+                                    mapFieldValueValue0 = ((PrimitiveIntList) null);
+                                    mapFieldValueValue0 .clear();
                                 } else {
                                     mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
+                                }
+                                while (chunkLen2 > 0) {
+                                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                                        mapFieldValueValue0 .addPrimitive((decoder.readInt()));
+                                    }
+                                    chunkLen2 = (decoder.arrayNext());
                                 }
                                 mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -97,93 +97,85 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
-                testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
-                testEnumArray1 .clear();
-            } else {
-                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    int enumIndex2 = (decoder.readEnum());
-                    org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                    if (enumIndex2 == 0) {
-                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+        if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
+            testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+            testEnumArray1 .clear();
+        } else {
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                int enumIndex2 = (decoder.readEnum());
+                org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
+                if (enumIndex2 == 0) {
+                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                } else {
+                    if (enumIndex2 == 1) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                     } else {
-                        if (enumIndex2 == 1) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                        if (enumIndex2 == 2) {
+                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                         } else {
-                            if (enumIndex2 == 2) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                            if (enumIndex2 == 3) {
+                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                             } else {
-                                if (enumIndex2 == 3) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                } else {
-                                    if (enumIndex2 == 4) {
-                                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                    }
+                                if (enumIndex2 == 4) {
+                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                                 }
                             }
                         }
                     }
-                    testEnumArray1 .add(enumValue2);
                 }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
-        } else {
-            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+                testEnumArray1 .add(enumValue2);
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
-                testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
-                testEnumUnionArray1 .clear();
-            } else {
-                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            int enumIndex3 = (decoder.readEnum());
-                            org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                            if (enumIndex3 == 0) {
-                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+        if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
+            testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+            testEnumUnionArray1 .clear();
+        } else {
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testEnumUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
+                    testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        int enumIndex3 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
+                        if (enumIndex3 == 0) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        } else {
+                            if (enumIndex3 == 1) {
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                             } else {
-                                if (enumIndex3 == 1) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                                if (enumIndex3 == 2) {
+                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                                 } else {
-                                    if (enumIndex3 == 2) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                    if (enumIndex3 == 3) {
+                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                                     } else {
-                                        if (enumIndex3 == 3) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                        } else {
-                                            if (enumIndex3 == 4) {
-                                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                            }
+                                        if (enumIndex3 == 4) {
+                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                                         }
                                     }
                                 }
                             }
-                            testEnumUnionArray1 .add(enumValue3);
                         }
+                        testEnumUnionArray1 .add(enumValue3);
                     }
                 }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
-        } else {
-            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -60,25 +60,21 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         }
         List<IndexedRecord> recordsArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
-                recordsArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
-                recordsArray1 .clear();
-            } else {
-                recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object recordsArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
-                    }
-                    recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
+            recordsArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+            recordsArray1 .clear();
         } else {
             recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordsArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
+                    recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                }
+                recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
         Map<Utf8, IndexedRecord> recordsMap1 = null;
@@ -112,32 +108,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
             if (unionIndex1 == 1) {
                 List<IndexedRecord> recordsArrayUnionOption0 = null;
                 long chunkLen2 = (decoder.readArrayStart());
-                if (chunkLen2 > 0) {
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
-                        recordsArrayUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
-                        recordsArrayUnionOption0 .clear();
-                    } else {
-                        recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
-                    }
-                    do {
-                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
-                            Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
-                            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
-                                recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
-                            }
-                            int unionIndex2 = (decoder.readIndex());
-                            if (unionIndex2 == 0) {
-                                decoder.readNull();
-                            } else {
-                                if (unionIndex2 == 1) {
-                                    recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
-                                }
-                            }
-                        }
-                        chunkLen2 = (decoder.arrayNext());
-                    } while (chunkLen2 > 0);
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
+                    recordsArrayUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                    recordsArrayUnionOption0 .clear();
                 } else {
                     recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
+                }
+                while (chunkLen2 > 0) {
+                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                        }
+                        int unionIndex2 = (decoder.readIndex());
+                        if (unionIndex2 == 0) {
+                            decoder.readNull();
+                        } else {
+                            if (unionIndex2 == 1) {
+                                recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                            }
+                        }
+                    }
+                    chunkLen2 = (decoder.arrayNext());
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption0);
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -68,55 +68,51 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         }
         List<Map<Utf8, IndexedRecord>> recordsArrayMap1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
-                recordsArrayMap1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
-                recordsArrayMap1 .clear();
-            } else {
-                recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object recordsArrayMapArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
-                    }
-                    Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
-                    long chunkLen1 = (decoder.readMapStart());
-                    if (chunkLen1 > 0) {
-                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
-                        if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                            recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                        }
-                        if (recordsArrayMapElemReuse0 != (null)) {
-                            recordsArrayMapElemReuse0 .clear();
-                            recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                        } else {
-                            recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
-                        }
-                        do {
-                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                                Utf8 key0 = (decoder.readString(null));
-                                int unionIndex0 = (decoder.readIndex());
-                                if (unionIndex0 == 0) {
-                                    decoder.readNull();
-                                } else {
-                                    if (unionIndex0 == 1) {
-                                        recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
-                                    }
-                                }
-                            }
-                            chunkLen1 = (decoder.mapNext());
-                        } while (chunkLen1 > 0);
-                    } else {
-                        recordsArrayMapElem0 = Collections.emptyMap();
-                    }
-                    recordsArrayMap1 .add(recordsArrayMapElem0);
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
+            recordsArrayMap1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+            recordsArrayMap1 .clear();
         } else {
             recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordsArrayMapArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
+                    recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                }
+                Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
+                long chunkLen1 = (decoder.readMapStart());
+                if (chunkLen1 > 0) {
+                    Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
+                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
+                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
+                    }
+                    if (recordsArrayMapElemReuse0 != (null)) {
+                        recordsArrayMapElemReuse0 .clear();
+                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
+                    } else {
+                        recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
+                    }
+                    do {
+                        for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex0 = (decoder.readIndex());
+                            if (unionIndex0 == 0) {
+                                decoder.readNull();
+                            } else {
+                                if (unionIndex0 == 1) {
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
+                                }
+                            }
+                        }
+                        chunkLen1 = (decoder.mapNext());
+                    } while (chunkLen1 > 0);
+                } else {
+                    recordsArrayMapElem0 = Collections.emptyMap();
+                }
+                recordsArrayMap1 .add(recordsArrayMapElem0);
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
         Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
@@ -137,32 +133,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                     Utf8 key1 = (decoder.readString(null));
                     List<IndexedRecord> recordsMapArrayValue0 = null;
                     long chunkLen3 = (decoder.readArrayStart());
-                    if (chunkLen3 > 0) {
-                        if (null instanceof List) {
-                            recordsMapArrayValue0 = ((List) null);
-                            recordsMapArrayValue0 .clear();
-                        } else {
-                            recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
-                        }
-                        do {
-                            for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
-                                Object recordsMapArrayValueArrayElementReuseVar0 = null;
-                                if (null instanceof GenericArray) {
-                                    recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
-                                }
-                                int unionIndex2 = (decoder.readIndex());
-                                if (unionIndex2 == 0) {
-                                    decoder.readNull();
-                                } else {
-                                    if (unionIndex2 == 1) {
-                                        recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
-                                    }
-                                }
-                            }
-                            chunkLen3 = (decoder.arrayNext());
-                        } while (chunkLen3 > 0);
+                    if (null instanceof List) {
+                        recordsMapArrayValue0 = ((List) null);
+                        recordsMapArrayValue0 .clear();
                     } else {
                         recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
+                    }
+                    while (chunkLen3 > 0) {
+                        for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                            Object recordsMapArrayValueArrayElementReuseVar0 = null;
+                            if (null instanceof GenericArray) {
+                                recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
+                            }
+                            int unionIndex2 = (decoder.readIndex());
+                            if (unionIndex2 == 0) {
+                                decoder.readNull();
+                            } else {
+                                if (unionIndex2 == 1) {
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                }
+                            }
+                        }
+                        chunkLen3 = (decoder.arrayNext());
                     }
                     recordsMapArray1 .put(key1, recordsMapArrayValue0);
                 }
@@ -179,55 +171,51 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
             if (unionIndex3 == 1) {
                 List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption0 = null;
                 long chunkLen4 = (decoder.readArrayStart());
-                if (chunkLen4 > 0) {
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
-                        recordsArrayMapUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
-                        recordsArrayMapUnionOption0 .clear();
-                    } else {
-                        recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
-                    }
-                    do {
-                        for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
-                            Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
-                            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
-                                recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
-                            }
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
-                            long chunkLen5 = (decoder.readMapStart());
-                            if (chunkLen5 > 0) {
-                                Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                                if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                    recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                                }
-                                if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                    recordsArrayMapUnionOptionElemReuse0 .clear();
-                                    recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                                } else {
-                                    recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
-                                }
-                                do {
-                                    for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
-                                        Utf8 key2 = (decoder.readString(null));
-                                        int unionIndex4 = (decoder.readIndex());
-                                        if (unionIndex4 == 0) {
-                                            decoder.readNull();
-                                        } else {
-                                            if (unionIndex4 == 1) {
-                                                recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
-                                            }
-                                        }
-                                    }
-                                    chunkLen5 = (decoder.mapNext());
-                                } while (chunkLen5 > 0);
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
-                            }
-                            recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
-                        }
-                        chunkLen4 = (decoder.arrayNext());
-                    } while (chunkLen4 > 0);
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
+                    recordsArrayMapUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                    recordsArrayMapUnionOption0 .clear();
                 } else {
                     recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
+                }
+                while (chunkLen4 > 0) {
+                    for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                        }
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
+                        long chunkLen5 = (decoder.readMapStart());
+                        if (chunkLen5 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
+                            }
+                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse0 .clear();
+                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
+                            } else {
+                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
+                            }
+                            do {
+                                for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
+                                    Utf8 key2 = (decoder.readString(null));
+                                    int unionIndex4 = (decoder.readIndex());
+                                    if (unionIndex4 == 0) {
+                                        decoder.readNull();
+                                    } else {
+                                        if (unionIndex4 == 1) {
+                                            recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
+                                        }
+                                    }
+                                }
+                                chunkLen5 = (decoder.mapNext());
+                            } while (chunkLen5 > 0);
+                        } else {
+                            recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
+                        }
+                        recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
+                    }
+                    chunkLen4 = (decoder.arrayNext());
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption0);
             }
@@ -255,32 +243,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                             Utf8 key3 = (decoder.readString(null));
                             List<IndexedRecord> recordsMapArrayUnionOptionValue0 = null;
                             long chunkLen7 = (decoder.readArrayStart());
-                            if (chunkLen7 > 0) {
-                                if (null instanceof List) {
-                                    recordsMapArrayUnionOptionValue0 = ((List) null);
-                                    recordsMapArrayUnionOptionValue0 .clear();
-                                } else {
-                                    recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
-                                }
-                                do {
-                                    for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
-                                        Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
-                                        if (null instanceof GenericArray) {
-                                            recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
-                                        }
-                                        int unionIndex6 = (decoder.readIndex());
-                                        if (unionIndex6 == 0) {
-                                            decoder.readNull();
-                                        } else {
-                                            if (unionIndex6 == 1) {
-                                                recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
-                                            }
-                                        }
-                                    }
-                                    chunkLen7 = (decoder.arrayNext());
-                                } while (chunkLen7 > 0);
+                            if (null instanceof List) {
+                                recordsMapArrayUnionOptionValue0 = ((List) null);
+                                recordsMapArrayUnionOptionValue0 .clear();
                             } else {
                                 recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
+                            }
+                            while (chunkLen7 > 0) {
+                                for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
+                                    if (null instanceof GenericArray) {
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
+                                    }
+                                    int unionIndex6 = (decoder.readIndex());
+                                    if (unionIndex6 == 0) {
+                                        decoder.readNull();
+                                    } else {
+                                        if (unionIndex6 == 1) {
+                                            recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                        }
+                                    }
+                                }
+                                chunkLen7 = (decoder.arrayNext());
                             }
                             recordsMapArrayUnionOption0 .put(key3, recordsMapArrayUnionOptionValue0);
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -120,25 +120,21 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
         List<IndexedRecord> subRecordArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
-                subRecordArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
-                subRecordArray1 .clear();
-            } else {
-                subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object subRecordArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
-                        subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
-                    }
-                    subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
+            subRecordArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+            subRecordArray1 .clear();
         } else {
             subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object subRecordArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
+                    subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                }
+                subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1);
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
@@ -60,25 +60,21 @@ public class StringableRecord_SpecificDeserializer_6174384286732341990_617438428
         StringableRecord.put(4, new File((decoder.readString())));
         List<URL> urlArray0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (StringableRecord.get(5) instanceof List) {
-                urlArray0 = ((List) StringableRecord.get(5));
-                urlArray0 .clear();
-            } else {
-                urlArray0 = new ArrayList<URL>();
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object urlArrayArrayElementReuseVar0 = null;
-                    if (StringableRecord.get(5) instanceof GenericArray) {
-                        urlArrayArrayElementReuseVar0 = ((GenericArray) StringableRecord.get(5)).peek();
-                    }
-                    urlArray0 .add(new URL((decoder.readString())));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (StringableRecord.get(5) instanceof List) {
+            urlArray0 = ((List) StringableRecord.get(5));
+            urlArray0 .clear();
         } else {
-            urlArray0 = Collections.emptyList();
+            urlArray0 = new ArrayList<URL>();
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object urlArrayArrayElementReuseVar0 = null;
+                if (StringableRecord.get(5) instanceof GenericArray) {
+                    urlArrayArrayElementReuseVar0 = ((GenericArray) StringableRecord.get(5)).peek();
+                }
+                urlArray0 .add(new URL((decoder.readString())));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         StringableRecord.put(5, urlArray0);
         Map<URL, BigInteger> urlMap0 = null;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297456147388.java
@@ -24,21 +24,17 @@ public class Array_of_BOOLEAN_GenericDeserializer_5988037297456147388_5988037297
     {
         PrimitiveBooleanList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveBooleanList) {
-                array0 = ((PrimitiveBooleanList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readBoolean()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveBooleanList) {
+            array0 = ((PrimitiveBooleanList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveBooleanArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readBoolean()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_DOUBLE_GenericDeserializer_6064316435611861740_6064316435611861740.java
@@ -24,21 +24,17 @@ public class Array_of_DOUBLE_GenericDeserializer_6064316435611861740_60643164356
     {
         PrimitiveDoubleList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveDoubleList) {
-                array0 = ((PrimitiveDoubleList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readDouble()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveDoubleList) {
+            array0 = ((PrimitiveDoubleList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveDoubleArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readDouble()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_INT_GenericDeserializer_3343716480540445685_3343716480540445685.java
@@ -24,21 +24,17 @@ public class Array_of_INT_GenericDeserializer_3343716480540445685_33437164805404
     {
         PrimitiveIntList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveIntList) {
-                array0 = ((PrimitiveIntList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveIntArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readInt()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveIntList) {
+            array0 = ((PrimitiveIntList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772118358.java
@@ -24,21 +24,17 @@ public class Array_of_LONG_GenericDeserializer_2055015354772118358_2055015354772
     {
         PrimitiveLongList array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof PrimitiveLongList) {
-                array0 = ((PrimitiveLongList)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new PrimitiveLongArrayList(((int) chunkLen0));
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    array0 .addPrimitive((decoder.readLong()));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof PrimitiveLongList) {
+            array0 = ((PrimitiveLongList)(reuse));
+            array0 .clear();
         } else {
             array0 = new PrimitiveLongArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                array0 .addPrimitive((decoder.readLong()));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -31,32 +31,28 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
     {
         List<IndexedRecord> array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof List) {
-                array0 = ((List)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object arrayArrayElementReuseVar0 = null;
-                    if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
-                    }
-                    int unionIndex0 = (decoder.readIndex());
-                    if (unionIndex0 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex0 == 1) {
-                            array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
-                        }
-                    }
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
         } else {
             array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                int unionIndex0 = (decoder.readIndex());
+                if (unionIndex0 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex0 == 1) {
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+                    }
+                }
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -29,25 +29,21 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
     {
         List<IndexedRecord> array0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if ((reuse) instanceof List) {
-                array0 = ((List)(reuse));
-                array0 .clear();
-            } else {
-                array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object arrayArrayElementReuseVar0 = null;
-                    if ((reuse) instanceof GenericArray) {
-                        arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
-                    }
-                    array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
         } else {
             array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -55,51 +55,43 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
-                testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
-                testEnumArray1 .clear();
-            } else {
-                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2) instanceof List) {
+            testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(2));
+            testEnumArray1 .clear();
         } else {
             testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                testEnumArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
-                testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
-                testEnumUnionArray1 .clear();
-            } else {
-                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-                        }
-                    }
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof List) {
+            testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3));
+            testEnumUnionArray1 .clear();
         } else {
             testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testEnumUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3) instanceof GenericArray) {
+                    testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadEnum.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
+                    }
+                }
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -68,69 +68,61 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         }
         List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
-                testFixedArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
-                testFixedArray1 .clear();
-            } else {
-                testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object testFixedArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
-                        testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
-                    }
-                    byte[] testFixed2;
-                    if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
-                        testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
-                    } else {
-                        testFixed2 = ( new byte[2]);
-                    }
-                    decoder.readFixed(testFixed2);
-                    testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed2));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof List) {
+            testFixedArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2));
+            testFixedArray1 .clear();
         } else {
             testFixedArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen0), testFixedArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object testFixedArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2) instanceof GenericArray) {
+                    testFixedArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(2)).peek();
+                }
+                byte[] testFixed2;
+                if ((testFixedArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes().length == (2))) {
+                    testFixed2 = ((GenericFixed) testFixedArrayArrayElementReuseVar0).bytes();
+                } else {
+                    testFixed2 = ( new byte[2]);
+                }
+                decoder.readFixed(testFixed2);
+                testFixedArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed2));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
         List<org.apache.avro.generic.GenericData.Fixed> testFixedUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
-                testFixedUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
-                testFixedUnionArray1 .clear();
-            } else {
-                testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testFixedUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
-                        testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            byte[] testFixed3;
-                            if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
-                                testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
-                            } else {
-                                testFixed3 = ( new byte[2]);
-                            }
-                            decoder.readFixed(testFixed3);
-                            testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed3));
-                        }
-                    }
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof List) {
+            testFixedUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3));
+            testFixedUnionArray1 .clear();
         } else {
             testFixedUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.Fixed>(((int) chunkLen1), testFixedUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testFixedUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3) instanceof GenericArray) {
+                    testFixedUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadFixed.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        byte[] testFixed3;
+                        if ((testFixedUnionArrayArrayElementReuseVar0 instanceof GenericFixed)&&(((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes().length == (2))) {
+                            testFixed3 = ((GenericFixed) testFixedUnionArrayArrayElementReuseVar0).bytes();
+                        } else {
+                            testFixed3 = ( new byte[2]);
+                        }
+                        decoder.readFixed(testFixed3);
+                        testFixedUnionArray1 .add(new org.apache.avro.generic.GenericData.Fixed(null, testFixed3));
+                    }
+                }
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(3, testFixedUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_3649952671819772385_3649952671819772385.java
@@ -79,21 +79,17 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                                 Utf8 key1 = (decoder.readString(null));
                                 PrimitiveIntList mapFieldValueValue0 = null;
                                 long chunkLen2 = (decoder.readArrayStart());
-                                if (chunkLen2 > 0) {
-                                    if (null instanceof PrimitiveIntList) {
-                                        mapFieldValueValue0 = ((PrimitiveIntList) null);
-                                        mapFieldValueValue0 .clear();
-                                    } else {
-                                        mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
-                                    }
-                                    do {
-                                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
-                                            mapFieldValueValue0 .addPrimitive((decoder.readInt()));
-                                        }
-                                        chunkLen2 = (decoder.arrayNext());
-                                    } while (chunkLen2 > 0);
+                                if (null instanceof PrimitiveIntList) {
+                                    mapFieldValueValue0 = ((PrimitiveIntList) null);
+                                    mapFieldValueValue0 .clear();
                                 } else {
                                     mapFieldValueValue0 = new PrimitiveIntArrayList(((int) chunkLen2));
+                                }
+                                while (chunkLen2 > 0) {
+                                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                                        mapFieldValueValue0 .addPrimitive((decoder.readInt()));
+                                    }
+                                    chunkLen2 = (decoder.arrayNext());
                                 }
                                 mapFieldValue0 .put(key1, mapFieldValueValue0);
                             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -97,93 +97,85 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
-                testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
-                testEnumArray1 .clear();
-            } else {
-                testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    int enumIndex2 = (decoder.readEnum());
-                    org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                    if (enumIndex2 == 0) {
-                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+        if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2) instanceof List) {
+            testEnumArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(2));
+            testEnumArray1 .clear();
+        } else {
+            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                int enumIndex2 = (decoder.readEnum());
+                org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
+                if (enumIndex2 == 0) {
+                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                } else {
+                    if (enumIndex2 == 1) {
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                     } else {
-                        if (enumIndex2 == 1) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                        if (enumIndex2 == 2) {
+                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                         } else {
-                            if (enumIndex2 == 2) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                            if (enumIndex2 == 3) {
+                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                             } else {
-                                if (enumIndex2 == 3) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                } else {
-                                    if (enumIndex2 == 4) {
-                                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                    }
+                                if (enumIndex2 == 4) {
+                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                                 }
                             }
                         }
                     }
-                    testEnumArray1 .add(enumValue2);
                 }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
-        } else {
-            testEnumArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen0), testEnumArray0);
+                testEnumArray1 .add(enumValue2);
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumUnionArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
-                testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
-                testEnumUnionArray1 .clear();
-            } else {
-                testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object testEnumUnionArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
-                        testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
-                    }
-                    int unionIndex1 = (decoder.readIndex());
-                    if (unionIndex1 == 0) {
-                        decoder.readNull();
-                    } else {
-                        if (unionIndex1 == 1) {
-                            int enumIndex3 = (decoder.readEnum());
-                            org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                            if (enumIndex3 == 0) {
-                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+        if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof List) {
+            testEnumUnionArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3));
+            testEnumUnionArray1 .clear();
+        } else {
+            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object testEnumUnionArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3) instanceof GenericArray) {
+                    testEnumUnionArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.get(3)).peek();
+                }
+                int unionIndex1 = (decoder.readIndex());
+                if (unionIndex1 == 0) {
+                    decoder.readNull();
+                } else {
+                    if (unionIndex1 == 1) {
+                        int enumIndex3 = (decoder.readEnum());
+                        org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
+                        if (enumIndex3 == 0) {
+                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        } else {
+                            if (enumIndex3 == 1) {
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
                             } else {
-                                if (enumIndex3 == 1) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                                if (enumIndex3 == 2) {
+                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
                                 } else {
-                                    if (enumIndex3 == 2) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                    if (enumIndex3 == 3) {
+                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
                                     } else {
-                                        if (enumIndex3 == 3) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                        } else {
-                                            if (enumIndex3 == 4) {
-                                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                            }
+                                        if (enumIndex3 == 4) {
+                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
                                         }
                                     }
                                 }
                             }
-                            testEnumUnionArray1 .add(enumValue3);
                         }
+                        testEnumUnionArray1 .add(enumValue3);
                     }
                 }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
-        } else {
-            testEnumUnionArray1 = new org.apache.avro.generic.GenericData.Array<org.apache.avro.generic.GenericData.EnumSymbol>(((int) chunkLen1), testEnumUnionArray0);
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(3, testEnumUnionArray1);
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -60,25 +60,21 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         }
         List<IndexedRecord> recordsArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
-                recordsArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
-                recordsArray1 .clear();
-            } else {
-                recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object recordsArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
-                    }
-                    recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof List) {
+            recordsArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0));
+            recordsArray1 .clear();
         } else {
             recordsArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordsArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordsArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0) instanceof GenericArray) {
+                    recordsArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(0)).peek();
+                }
+                recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
         Map<Utf8, IndexedRecord> recordsMap1 = null;
@@ -112,32 +108,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
             if (unionIndex1 == 1) {
                 List<IndexedRecord> recordsArrayUnionOption0 = null;
                 long chunkLen2 = (decoder.readArrayStart());
-                if (chunkLen2 > 0) {
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
-                        recordsArrayUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
-                        recordsArrayUnionOption0 .clear();
-                    } else {
-                        recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
-                    }
-                    do {
-                        for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
-                            Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
-                            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
-                                recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
-                            }
-                            int unionIndex2 = (decoder.readIndex());
-                            if (unionIndex2 == 0) {
-                                decoder.readNull();
-                            } else {
-                                if (unionIndex2 == 1) {
-                                    recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
-                                }
-                            }
-                        }
-                        chunkLen2 = (decoder.arrayNext());
-                    } while (chunkLen2 > 0);
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof List) {
+                    recordsArrayUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2));
+                    recordsArrayUnionOption0 .clear();
                 } else {
                     recordsArrayUnionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen2), recordsArrayUnionOptionSchema0);
+                }
+                while (chunkLen2 > 0) {
+                    for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
+                        Object recordsArrayUnionOptionArrayElementReuseVar0 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(2)).peek();
+                        }
+                        int unionIndex2 = (decoder.readIndex());
+                        if (unionIndex2 == 0) {
+                            decoder.readNull();
+                        } else {
+                            if (unionIndex2 == 1) {
+                                recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                            }
+                        }
+                    }
+                    chunkLen2 = (decoder.arrayNext());
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(2, recordsArrayUnionOption0);
             }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -68,55 +68,51 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         }
         List<Map<Utf8, IndexedRecord>> recordsArrayMap1 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
-                recordsArrayMap1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
-                recordsArrayMap1 .clear();
-            } else {
-                recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object recordsArrayMapArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
-                        recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
-                    }
-                    Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
-                    long chunkLen1 = (decoder.readMapStart());
-                    if (chunkLen1 > 0) {
-                        Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
-                        if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                            recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                        }
-                        if (recordsArrayMapElemReuse0 != (null)) {
-                            recordsArrayMapElemReuse0 .clear();
-                            recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                        } else {
-                            recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
-                        }
-                        do {
-                            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                                Utf8 key0 = (decoder.readString(null));
-                                int unionIndex0 = (decoder.readIndex());
-                                if (unionIndex0 == 0) {
-                                    decoder.readNull();
-                                } else {
-                                    if (unionIndex0 == 1) {
-                                        recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
-                                    }
-                                }
-                            }
-                            chunkLen1 = (decoder.mapNext());
-                        } while (chunkLen1 > 0);
-                    } else {
-                        recordsArrayMapElem0 = Collections.emptyMap();
-                    }
-                    recordsArrayMap1 .add(recordsArrayMapElem0);
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof List) {
+            recordsArrayMap1 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0));
+            recordsArrayMap1 .clear();
         } else {
             recordsArrayMap1 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen0), recordsArrayMap0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordsArrayMapArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0) instanceof GenericArray) {
+                    recordsArrayMapArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(0)).peek();
+                }
+                Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
+                long chunkLen1 = (decoder.readMapStart());
+                if (chunkLen1 > 0) {
+                    Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
+                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
+                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
+                    }
+                    if (recordsArrayMapElemReuse0 != (null)) {
+                        recordsArrayMapElemReuse0 .clear();
+                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
+                    } else {
+                        recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>();
+                    }
+                    do {
+                        for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex0 = (decoder.readIndex());
+                            if (unionIndex0 == 0) {
+                                decoder.readNull();
+                            } else {
+                                if (unionIndex0 == 1) {
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
+                                }
+                            }
+                        }
+                        chunkLen1 = (decoder.mapNext());
+                    } while (chunkLen1 > 0);
+                } else {
+                    recordsArrayMapElem0 = Collections.emptyMap();
+                }
+                recordsArrayMap1 .add(recordsArrayMapElem0);
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
         Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
@@ -137,32 +133,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                     Utf8 key1 = (decoder.readString(null));
                     List<IndexedRecord> recordsMapArrayValue0 = null;
                     long chunkLen3 = (decoder.readArrayStart());
-                    if (chunkLen3 > 0) {
-                        if (null instanceof List) {
-                            recordsMapArrayValue0 = ((List) null);
-                            recordsMapArrayValue0 .clear();
-                        } else {
-                            recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
-                        }
-                        do {
-                            for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
-                                Object recordsMapArrayValueArrayElementReuseVar0 = null;
-                                if (null instanceof GenericArray) {
-                                    recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
-                                }
-                                int unionIndex2 = (decoder.readIndex());
-                                if (unionIndex2 == 0) {
-                                    decoder.readNull();
-                                } else {
-                                    if (unionIndex2 == 1) {
-                                        recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
-                                    }
-                                }
-                            }
-                            chunkLen3 = (decoder.arrayNext());
-                        } while (chunkLen3 > 0);
+                    if (null instanceof List) {
+                        recordsMapArrayValue0 = ((List) null);
+                        recordsMapArrayValue0 .clear();
                     } else {
                         recordsMapArrayValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen3), recordsMapArrayMapValueSchema0);
+                    }
+                    while (chunkLen3 > 0) {
+                        for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
+                            Object recordsMapArrayValueArrayElementReuseVar0 = null;
+                            if (null instanceof GenericArray) {
+                                recordsMapArrayValueArrayElementReuseVar0 = ((GenericArray) null).peek();
+                            }
+                            int unionIndex2 = (decoder.readIndex());
+                            if (unionIndex2 == 0) {
+                                decoder.readNull();
+                            } else {
+                                if (unionIndex2 == 1) {
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                }
+                            }
+                        }
+                        chunkLen3 = (decoder.arrayNext());
                     }
                     recordsMapArray1 .put(key1, recordsMapArrayValue0);
                 }
@@ -179,55 +171,51 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
             if (unionIndex3 == 1) {
                 List<Map<Utf8, IndexedRecord>> recordsArrayMapUnionOption0 = null;
                 long chunkLen4 = (decoder.readArrayStart());
-                if (chunkLen4 > 0) {
-                    if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
-                        recordsArrayMapUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
-                        recordsArrayMapUnionOption0 .clear();
-                    } else {
-                        recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
-                    }
-                    do {
-                        for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
-                            Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
-                            if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
-                                recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
-                            }
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
-                            long chunkLen5 = (decoder.readMapStart());
-                            if (chunkLen5 > 0) {
-                                Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                                if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                    recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                                }
-                                if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                    recordsArrayMapUnionOptionElemReuse0 .clear();
-                                    recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                                } else {
-                                    recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
-                                }
-                                do {
-                                    for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
-                                        Utf8 key2 = (decoder.readString(null));
-                                        int unionIndex4 = (decoder.readIndex());
-                                        if (unionIndex4 == 0) {
-                                            decoder.readNull();
-                                        } else {
-                                            if (unionIndex4 == 1) {
-                                                recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
-                                            }
-                                        }
-                                    }
-                                    chunkLen5 = (decoder.mapNext());
-                                } while (chunkLen5 > 0);
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
-                            }
-                            recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
-                        }
-                        chunkLen4 = (decoder.arrayNext());
-                    } while (chunkLen4 > 0);
+                if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof List) {
+                    recordsArrayMapUnionOption0 = ((List) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2));
+                    recordsArrayMapUnionOption0 .clear();
                 } else {
                     recordsArrayMapUnionOption0 = new org.apache.avro.generic.GenericData.Array<Map<Utf8, IndexedRecord>>(((int) chunkLen4), recordsArrayMap0);
+                }
+                while (chunkLen4 > 0) {
+                    for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
+                        Object recordsArrayMapUnionOptionArrayElementReuseVar0 = null;
+                        if (FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2) instanceof GenericArray) {
+                            recordsArrayMapUnionOptionArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(2)).peek();
+                        }
+                        Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
+                        long chunkLen5 = (decoder.readMapStart());
+                        if (chunkLen5 > 0) {
+                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
+                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
+                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
+                            }
+                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
+                                recordsArrayMapUnionOptionElemReuse0 .clear();
+                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
+                            } else {
+                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>();
+                            }
+                            do {
+                                for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
+                                    Utf8 key2 = (decoder.readString(null));
+                                    int unionIndex4 = (decoder.readIndex());
+                                    if (unionIndex4 == 0) {
+                                        decoder.readNull();
+                                    } else {
+                                        if (unionIndex4 == 1) {
+                                            recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
+                                        }
+                                    }
+                                }
+                                chunkLen5 = (decoder.mapNext());
+                            } while (chunkLen5 > 0);
+                        } else {
+                            recordsArrayMapUnionOptionElem0 = Collections.emptyMap();
+                        }
+                        recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
+                    }
+                    chunkLen4 = (decoder.arrayNext());
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(2, recordsArrayMapUnionOption0);
             }
@@ -255,32 +243,28 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                             Utf8 key3 = (decoder.readString(null));
                             List<IndexedRecord> recordsMapArrayUnionOptionValue0 = null;
                             long chunkLen7 = (decoder.readArrayStart());
-                            if (chunkLen7 > 0) {
-                                if (null instanceof List) {
-                                    recordsMapArrayUnionOptionValue0 = ((List) null);
-                                    recordsMapArrayUnionOptionValue0 .clear();
-                                } else {
-                                    recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
-                                }
-                                do {
-                                    for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
-                                        Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
-                                        if (null instanceof GenericArray) {
-                                            recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
-                                        }
-                                        int unionIndex6 = (decoder.readIndex());
-                                        if (unionIndex6 == 0) {
-                                            decoder.readNull();
-                                        } else {
-                                            if (unionIndex6 == 1) {
-                                                recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
-                                            }
-                                        }
-                                    }
-                                    chunkLen7 = (decoder.arrayNext());
-                                } while (chunkLen7 > 0);
+                            if (null instanceof List) {
+                                recordsMapArrayUnionOptionValue0 = ((List) null);
+                                recordsMapArrayUnionOptionValue0 .clear();
                             } else {
                                 recordsMapArrayUnionOptionValue0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen7), recordsMapArrayMapValueSchema0);
+                            }
+                            while (chunkLen7 > 0) {
+                                for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
+                                    Object recordsMapArrayUnionOptionValueArrayElementReuseVar0 = null;
+                                    if (null instanceof GenericArray) {
+                                        recordsMapArrayUnionOptionValueArrayElementReuseVar0 = ((GenericArray) null).peek();
+                                    }
+                                    int unionIndex6 = (decoder.readIndex());
+                                    if (unionIndex6 == 0) {
+                                        decoder.readNull();
+                                    } else {
+                                        if (unionIndex6 == 1) {
+                                            recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                        }
+                                    }
+                                }
+                                chunkLen7 = (decoder.arrayNext());
                             }
                             recordsMapArrayUnionOption0 .put(key3, recordsMapArrayUnionOptionValue0);
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -120,25 +120,21 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
         List<IndexedRecord> subRecordArray1 = null;
         long chunkLen1 = (decoder.readArrayStart());
-        if (chunkLen1 > 0) {
-            if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
-                subRecordArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
-                subRecordArray1 .clear();
-            } else {
-                subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
-            }
-            do {
-                for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
-                    Object subRecordArrayArrayElementReuseVar0 = null;
-                    if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
-                        subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
-                    }
-                    subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
-                }
-                chunkLen1 = (decoder.arrayNext());
-            } while (chunkLen1 > 0);
+        if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof List) {
+            subRecordArray1 = ((List) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4));
+            subRecordArray1 .clear();
         } else {
             subRecordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen1), subRecordArray0);
+        }
+        while (chunkLen1 > 0) {
+            for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
+                Object subRecordArrayArrayElementReuseVar0 = null;
+                if (FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4) instanceof GenericArray) {
+                    subRecordArrayArrayElementReuseVar0 = ((GenericArray) FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(4)).peek();
+                }
+                subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen1 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(4, subRecordArray1);
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
@@ -60,25 +60,21 @@ public class StringableRecord_SpecificDeserializer_6174384286732341990_617438428
         StringableRecord.put(4, new File((decoder.readString())));
         List<URL> urlArray0 = null;
         long chunkLen0 = (decoder.readArrayStart());
-        if (chunkLen0 > 0) {
-            if (StringableRecord.get(5) instanceof List) {
-                urlArray0 = ((List) StringableRecord.get(5));
-                urlArray0 .clear();
-            } else {
-                urlArray0 = new ArrayList<URL>();
-            }
-            do {
-                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
-                    Object urlArrayArrayElementReuseVar0 = null;
-                    if (StringableRecord.get(5) instanceof GenericArray) {
-                        urlArrayArrayElementReuseVar0 = ((GenericArray) StringableRecord.get(5)).peek();
-                    }
-                    urlArray0 .add(new URL((decoder.readString())));
-                }
-                chunkLen0 = (decoder.arrayNext());
-            } while (chunkLen0 > 0);
+        if (StringableRecord.get(5) instanceof List) {
+            urlArray0 = ((List) StringableRecord.get(5));
+            urlArray0 .clear();
         } else {
-            urlArray0 = Collections.emptyList();
+            urlArray0 = new ArrayList<URL>();
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object urlArrayArrayElementReuseVar0 = null;
+                if (StringableRecord.get(5) instanceof GenericArray) {
+                    urlArrayArrayElementReuseVar0 = ((GenericArray) StringableRecord.get(5)).peek();
+                }
+                urlArray0 .add(new URL((decoder.readString())));
+            }
+            chunkLen0 = (decoder.arrayNext());
         }
         StringableRecord.put(5, urlArray0);
         Map<URL, BigInteger> urlMap0 = null;

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveArrayList.java
@@ -7,9 +7,18 @@ import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
 
 
-public abstract class PrimitiveArrayList<T, L> extends AbstractList<T>
+public abstract class PrimitiveArrayList<T, L, A> extends AbstractList<T>
     implements GenericContainer, Comparable<GenericArray<T>> {
   private int size = 0;
+  protected A elementsArray;
+
+  public PrimitiveArrayList(int capacity) {
+    this.elementsArray = newArray(capacity);
+  }
+
+  public PrimitiveArrayList() {
+    this(10);
+  }
 
   // Abstract functions required by child classes
 
@@ -19,22 +28,10 @@ public abstract class PrimitiveArrayList<T, L> extends AbstractList<T>
   protected abstract int capacity();
 
   /**
-   * A function used to replace the primitve array instance, in cases where it needs to be resized.
-   *
-   * @param newElements primitive array instance to replace the current one
-   */
-  protected abstract void setElementsArray(Object newElements);
-
-  /**
-   * @return the primitive array instance of the child class
-   */
-  protected abstract Object getElementsArray();
-
-  /**
    * @param capacity of the new primitive array
    * @return an instance of the right type of primitive array used by the child class
    */
-  protected abstract Object newArray(int capacity);
+  protected abstract A newArray(int capacity);
 
   /**
    * @param that an instance of primitive list to use for comparison
@@ -88,7 +85,7 @@ public abstract class PrimitiveArrayList<T, L> extends AbstractList<T>
     checkIfLargerThanSize(i);
     T result = (T) get(i);
     --size;
-    System.arraycopy(getElementsArray(), i+1, getElementsArray(), i, (size-i));
+    System.arraycopy(elementsArray, i+1, elementsArray, i, (size-i));
     return result;
   }
 
@@ -161,9 +158,9 @@ public abstract class PrimitiveArrayList<T, L> extends AbstractList<T>
   /** Checks if the primitve array is at capacity, and if so, resizes it to 1.5x + 1. */
   protected void capacityCheck() {
     if (size == capacity()) {
-      Object newElements = newArray((size * 3)/2 + 1);
-      System.arraycopy(getElementsArray(), 0, newElements, 0, size);
-      setElementsArray(newElements);
+      A newElements = newArray((size * 3)/2 + 1);
+      System.arraycopy(elementsArray, 0, newElements, 0, size);
+      this.elementsArray = newElements;
     }
   }
 
@@ -177,16 +174,16 @@ public abstract class PrimitiveArrayList<T, L> extends AbstractList<T>
       throw new IndexOutOfBoundsException("Index " + location + " out of bounds.");
     }
     if (size == capacity()) {
-      Object newElements = newArray((size * 3)/2 + 1);
+      A newElements = newArray((size * 3)/2 + 1);
       if (location > 0) {
         // Copy the elements before the insertion location, if any, with same index
-        System.arraycopy(getElementsArray(), 0, newElements, 0, location - 1);
+        System.arraycopy(elementsArray, 0, newElements, 0, location - 1);
       }
       // Copy the elements after the insertion location, with index offset by 1
-      System.arraycopy(getElementsArray(), location, newElements, location + 1, size - location);
-      setElementsArray(newElements);
+      System.arraycopy(elementsArray, location, newElements, location + 1, size - location);
+      this.elementsArray = newElements;
     } else {
-      System.arraycopy(getElementsArray(), location, getElementsArray(), location + 1, size - location);
+      System.arraycopy(elementsArray, location, elementsArray, location + 1, size - location);
     }
     size++;
   }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveBooleanArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveBooleanArrayList.java
@@ -4,12 +4,15 @@ import com.linkedin.avro.api.PrimitiveBooleanList;
 import org.apache.avro.Schema;
 
 
-public class PrimitiveBooleanArrayList extends PrimitiveArrayList<Boolean, PrimitiveBooleanList> implements PrimitiveBooleanList {
+public class PrimitiveBooleanArrayList extends PrimitiveArrayList<Boolean, PrimitiveBooleanList, boolean[]> implements PrimitiveBooleanList {
   public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.BOOLEAN));
-  boolean[] elementsArray;
 
   public PrimitiveBooleanArrayList(int capacity) {
-    this.elementsArray = new boolean[capacity];
+    super(capacity);
+  }
+
+  public PrimitiveBooleanArrayList() {
+    super();
   }
 
   @Override
@@ -65,17 +68,7 @@ public class PrimitiveBooleanArrayList extends PrimitiveArrayList<Boolean, Primi
   }
 
   @Override
-  protected void setElementsArray(Object newElements) {
-    this.elementsArray = (boolean[]) newElements;
-  }
-
-  @Override
-  protected Object getElementsArray() {
-    return this.elementsArray;
-  }
-
-  @Override
-  protected Object newArray(int capacity) {
+  protected boolean[] newArray(int capacity) {
     return new boolean[capacity];
   }
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveDoubleArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveDoubleArrayList.java
@@ -5,12 +5,15 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import org.apache.avro.Schema;
 
 
-public class PrimitiveDoubleArrayList extends PrimitiveArrayList<Double, PrimitiveDoubleList> implements PrimitiveDoubleList {
+public class PrimitiveDoubleArrayList extends PrimitiveArrayList<Double, PrimitiveDoubleList, double[]> implements PrimitiveDoubleList {
   public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.DOUBLE));
-  double[] elementsArray;
 
   public PrimitiveDoubleArrayList(int capacity) {
-    this.elementsArray = new double[capacity];
+    super(capacity);
+  }
+
+  public PrimitiveDoubleArrayList() {
+    super();
   }
 
   @Override
@@ -66,17 +69,7 @@ public class PrimitiveDoubleArrayList extends PrimitiveArrayList<Double, Primiti
   }
 
   @Override
-  protected void setElementsArray(Object newElements) {
-    this.elementsArray = (double[]) newElements;
-  }
-
-  @Override
-  protected Object getElementsArray() {
-    return this.elementsArray;
-  }
-
-  @Override
-  protected Object newArray(int capacity) {
+  protected double[] newArray(int capacity) {
     return new double[capacity];
   }
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveFloatArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveFloatArrayList.java
@@ -5,12 +5,15 @@ import com.linkedin.avro.api.PrimitiveFloatList;
 import org.apache.avro.Schema;
 
 
-public class PrimitiveFloatArrayList extends PrimitiveArrayList<Float, PrimitiveFloatList> implements PrimitiveFloatList {
+public class PrimitiveFloatArrayList extends PrimitiveArrayList<Float, PrimitiveFloatList, float[]> implements PrimitiveFloatList {
   public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.FLOAT));
-  float[] elementsArray;
 
   public PrimitiveFloatArrayList(int capacity) {
-    this.elementsArray = new float[capacity];
+    super(capacity);
+  }
+
+  public PrimitiveFloatArrayList() {
+    super();
   }
 
   @Override
@@ -66,17 +69,7 @@ public class PrimitiveFloatArrayList extends PrimitiveArrayList<Float, Primitive
   }
 
   @Override
-  protected void setElementsArray(Object newElements) {
-    this.elementsArray = (float[]) newElements;
-  }
-
-  @Override
-  protected Object getElementsArray() {
-    return this.elementsArray;
-  }
-
-  @Override
-  protected Object newArray(int capacity) {
+  protected float[] newArray(int capacity) {
     return new float[capacity];
   }
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveIntArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveIntArrayList.java
@@ -5,12 +5,15 @@ import com.linkedin.avro.api.PrimitiveIntList;
 import org.apache.avro.Schema;
 
 
-public class PrimitiveIntArrayList extends PrimitiveArrayList<Integer, PrimitiveIntList> implements PrimitiveIntList {
+public class PrimitiveIntArrayList extends PrimitiveArrayList<Integer, PrimitiveIntList, int[]> implements PrimitiveIntList {
   public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.INT));
-  int[] elementsArray;
 
   public PrimitiveIntArrayList(int capacity) {
-    this.elementsArray = new int[capacity];
+    super(capacity);
+  }
+
+  public PrimitiveIntArrayList() {
+    super();
   }
 
   @Override
@@ -66,17 +69,7 @@ public class PrimitiveIntArrayList extends PrimitiveArrayList<Integer, Primitive
   }
 
   @Override
-  protected void setElementsArray(Object newElements) {
-    this.elementsArray = (int[]) newElements;
-  }
-
-  @Override
-  protected Object getElementsArray() {
-    return this.elementsArray;
-  }
-
-  @Override
-  protected Object newArray(int capacity) {
+  protected int[] newArray(int capacity) {
     return new int[capacity];
   }
 

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveLongArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveLongArrayList.java
@@ -5,12 +5,15 @@ import com.linkedin.avro.api.PrimitiveLongList;
 import org.apache.avro.Schema;
 
 
-public class PrimitiveLongArrayList extends PrimitiveArrayList<Long, PrimitiveLongList> implements PrimitiveLongList {
+public class PrimitiveLongArrayList extends PrimitiveArrayList<Long, PrimitiveLongList, long[]> implements PrimitiveLongList {
   public static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.LONG));
-  long[] elementsArray;
 
   public PrimitiveLongArrayList(int capacity) {
-    this.elementsArray = new long[capacity];
+    super(capacity);
+  }
+
+  public PrimitiveLongArrayList() {
+    super();
   }
 
   @Override
@@ -66,17 +69,7 @@ public class PrimitiveLongArrayList extends PrimitiveArrayList<Long, PrimitiveLo
   }
 
   @Override
-  protected void setElementsArray(Object newElements) {
-    this.elementsArray = (long[]) newElements;
-  }
-
-  @Override
-  protected Object getElementsArray() {
-    return this.elementsArray;
-  }
-
-  @Override
-  protected Object newArray(int capacity) {
+  protected long[] newArray(int capacity) {
     return new long[capacity];
   }
 

--- a/avro-fastserde/src/test/avro/defaultsTest.avsc
+++ b/avro-fastserde/src/test/avro/defaultsTest.avsc
@@ -350,6 +350,54 @@
         }
       },
       "default": {"test": [null]}
+    },
+    {
+      "name": "booleanArray",
+      "type": {
+        "type": "array",
+        "items": "boolean"
+      },
+      "default": []
+    },
+    {
+      "name": "doubleArray",
+      "type": {
+        "type": "array",
+        "items": "double"
+      },
+      "default": []
+    },
+    {
+      "name": "floatArray",
+      "type": {
+        "type": "array",
+        "items": "float"
+      },
+      "default": []
+    },
+    {
+      "name": "intArray",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": []
+    },
+    {
+      "name": "longArray",
+      "type": {
+        "type": "array",
+        "items": "long"
+      },
+      "default": []
+    },
+    {
+      "name": "stringArray",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": []
     }
   ]
 }

--- a/avro-fastserde/src/test/avro/fastserdetest.avsc
+++ b/avro-fastserde/src/test/avro/fastserdetest.avsc
@@ -309,6 +309,54 @@
         "int"
       ],
       "default": null
+    },
+    {
+      "name": "booleanArray",
+      "type": {
+        "type": "array",
+        "items": "boolean"
+      },
+      "default": []
+    },
+    {
+      "name": "doubleArray",
+      "type": {
+        "type": "array",
+        "items": "double"
+      },
+      "default": []
+    },
+    {
+      "name": "floatArray",
+      "type": {
+        "type": "array",
+        "items": "float"
+      },
+      "default": []
+    },
+    {
+      "name": "intArray",
+      "type": {
+        "type": "array",
+        "items": "int"
+      },
+      "default": []
+    },
+    {
+      "name": "longArray",
+      "type": {
+        "type": "array",
+        "items": "long"
+      },
+      "default": []
+    },
+    {
+      "name": "stringArray",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": []
     }
   ]
 }

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
@@ -439,6 +439,13 @@ public class FastDeserializerDefaultsTest {
     oldRecord.put("subRecordUnion", subRecord);
     oldRecord.put("subRecord", subRecord);
     oldRecord.put("recordsArray", Collections.singletonList(subRecord));
+    oldRecord.put("booleanArray", Collections.emptyList());
+    oldRecord.put("doubleArray", Collections.emptyList());
+    oldRecord.put("floatArray", Collections.emptyList());
+    oldRecord.put("intArray", Collections.emptyList());
+    oldRecord.put("longArray", Collections.emptyList());
+    oldRecord.put("stringArray", Collections.emptyList());
+
     Map<String, GenericData.Record> recordsMap = new HashMap<>();
     recordsMap.put("1", subRecord);
     oldRecord.put("recordsMap", recordsMap);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGeneratorTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGeneratorTest.java
@@ -47,14 +47,20 @@ public class FastSpecificDeserializerGeneratorTest {
     TestFixed testFixed1 = new TestFixed();
     testFixed1.bytes(new byte[]{0x01});
     record.testFixed = testFixed1;
-    record.testFixedArray = Collections.EMPTY_LIST;
+    record.testFixedArray = Collections.emptyList();
     TestFixed testFixed2 = new TestFixed();
     testFixed2.bytes(new byte[]{0x01});
     record.testFixedUnionArray = Arrays.asList(testFixed2);
 
     record.testEnum = TestEnum.A;
-    record.testEnumArray = Collections.EMPTY_LIST;
+    record.testEnumArray = Collections.emptyList();
     record.testEnumUnionArray = Arrays.asList(TestEnum.A);
+    record.booleanArray = Collections.emptyList();
+    record.doubleArray = Collections.emptyList();
+    record.floatArray = Collections.emptyList();
+    record.intArray = Collections.emptyList();
+    record.longArray = Collections.emptyList();
+    record.stringArray = Collections.emptyList();
     record.subRecord = new SubRecord();
 
     record.recordsArray = Collections.emptyList();


### PR DESCRIPTION
Addressed bugs related to missing constructors in the PrimitiveArrayList
and its child classes. Also refactored those classes slightly to reduce
boilerplate.

Altered the meta code:

- List construction does not rely on Collections.emptyList() since that
  is incompatible with the primitive list classes.
- Added a missing getShouldRead() check in cases where schema evolution
  gets rid of a list field. This would previously cause a NPE during
  code gen.