### PR TITLE
Tests for union re-ordering in fast-avro.

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_1219945526301414819.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_1219945526301414819.java
@@ -1,0 +1,57 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_1219945526301414819
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_1219945526301414819(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_4625137430106543195.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_4625137430106543195.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_4625137430106543195
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1219945526301414819_4625137430106543195(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_1219945526301414819.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_1219945526301414819.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_1219945526301414819
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_1219945526301414819(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_4625137430106543195.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_4625137430106543195.java
@@ -1,0 +1,57 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_4625137430106543195
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4625137430106543195_4625137430106543195(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_4480152023124204661.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_4480152023124204661.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_4480152023124204661
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_4480152023124204661(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_8811030206500064012.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_8811030206500064012.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_8811030206500064012
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_4480152023124204661_8811030206500064012(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_4480152023124204661.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_4480152023124204661.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_4480152023124204661
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_4480152023124204661(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_8811030206500064012.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_8811030206500064012.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_8811030206500064012
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_8811030206500064012_8811030206500064012(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
@@ -1,0 +1,57 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
@@ -1,0 +1,57 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
@@ -1,0 +1,57 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                    } else {
+                        FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                    }
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
@@ -1,0 +1,57 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                if (FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0) instanceof Utf8) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(((Utf8) FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.get(0))));
+                } else {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder).readString(null));
+                }
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
@@ -1,0 +1,52 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema test0;
+
+    public FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.test0 = readerSchema.getField("test").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
+            } else {
+                if (unionIndex0 == 2) {
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
+                }
+            }
+        }
+        return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
+    }
+
+}


### PR DESCRIPTION
There is a bug where a union which includes a string cannot be
re-ordered. The test is made to pass by swallowing an exception.
The swallowing should be eliminated once the main code is fixed.

Code-gen for the decoders, including the buggy ones, is included.