### PR TITLE
Code-gen output which was unintentionally left out of previous PRs.

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_8167579962882089724_8167579962882089724.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_8167579962882089724_8167579962882089724.java
@@ -66,7 +66,7 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testUnionString': "+ unionIndex0));
         }
         List<Utf8> testStringArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastStringableTest_javaStringPropertyTest_GenericDeserializer_9103393295617573707_9103393295617573707.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastStringableTest_javaStringPropertyTest_GenericDeserializer_9103393295617573707_9103393295617573707.java
@@ -66,7 +66,7 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_91033
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testUnionString': "+ unionIndex0));
         }
         List<Utf8> testStringArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
@@ -135,7 +135,7 @@ public class StringableRecord_SpecificDeserializer_6174384286732341990_617438428
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'stringUnion': "+ unionIndex0));
         }
         return StringableRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -52,7 +52,7 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
                         array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                         break;
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                        throw new RuntimeException(("Illegal union index for 'arrayElem': "+ unionIndex0));
                 }
             }
             chunkLen0 = (decoder.arrayNext());
@@ -85,7 +85,7 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex1));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -73,7 +73,7 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex0));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
@@ -53,7 +53,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testString': "+ unionIndex0));
         }
         int unionIndex1 = (decoder.readIndex());
         switch (unionIndex1) {
@@ -71,7 +71,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'testStringUnionAlias': "+ unionIndex1));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
                 FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testEnumUnion': "+ unionIndex0));
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
@@ -96,7 +96,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
                         testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                         break;
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                        throw new RuntimeException(("Illegal union index for 'testEnumUnionArrayElem': "+ unionIndex1));
                 }
             }
             chunkLen1 = (decoder.arrayNext());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -71,7 +71,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testFixedUnion': "+ unionIndex0));
         }
         List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
@@ -135,7 +135,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
                         break;
                     }
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                        throw new RuntimeException(("Illegal union index for 'testFixedUnionArrayElem': "+ unionIndex1));
                 }
             }
             chunkLen1 = (decoder.arrayNext());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
@@ -61,7 +61,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
                 FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
     }
@@ -91,7 +91,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -98,7 +98,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testEnumUnion': "+ unionIndex0));
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
@@ -184,7 +184,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                         break;
                     }
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                        throw new RuntimeException(("Illegal union index for 'testEnumUnionArrayElem': "+ unionIndex1));
                 }
             }
             chunkLen1 = (decoder.arrayNext());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
@@ -58,7 +58,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
         }
         Object oldString0 = FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2);
         if (oldString0 instanceof Utf8) {
@@ -82,7 +82,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'testStringUnion': "+ unionIndex1));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
         int unionIndex2 = (decoder.readIndex());
@@ -94,7 +94,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                throw new RuntimeException(("Illegal union index for 'testLongUnion': "+ unionIndex2));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
         int unionIndex3 = (decoder.readIndex());
@@ -106,7 +106,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'testDoubleUnion': "+ unionIndex3));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
         int unionIndex4 = (decoder.readIndex());
@@ -118,7 +118,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                throw new RuntimeException(("Illegal union index for 'testFloatUnion': "+ unionIndex4));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
         int unionIndex5 = (decoder.readIndex());
@@ -130,7 +130,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex5));
+                throw new RuntimeException(("Illegal union index for 'testBooleanUnion': "+ unionIndex5));
         }
         Object oldBytes0 = FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12);
         if (oldBytes0 instanceof ByteBuffer) {
@@ -154,7 +154,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex6));
+                throw new RuntimeException(("Illegal union index for 'testBytesUnion': "+ unionIndex6));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -134,7 +134,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                                 recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
                                 break;
                             default:
-                                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                                throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex2));
                         }
                     }
                     chunkLen2 = (decoder.arrayNext());
@@ -143,7 +143,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'recordsArrayUnion': "+ unionIndex1));
         }
         int unionIndex3 = (decoder.readIndex());
         switch (unionIndex3) {
@@ -178,7 +178,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                                     recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder)));
                                     break;
                                 default:
-                                    throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                                    throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex4));
                             }
                         }
                         chunkLen3 = (decoder.mapNext());
@@ -190,7 +190,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'recordsMapUnion': "+ unionIndex3));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
     }
@@ -220,7 +220,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -106,7 +106,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                     recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
                                     break;
                                 default:
-                                    throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                                    throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex0));
                             }
                         }
                         chunkLen1 = (decoder.mapNext());
@@ -159,7 +159,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                     recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
                                     break;
                                 default:
-                                    throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                                    throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex2));
                             }
                         }
                         chunkLen3 = (decoder.arrayNext());
@@ -219,7 +219,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                             recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
                                             break;
                                         default:
-                                            throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                                            throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex4));
                                     }
                                 }
                                 chunkLen5 = (decoder.mapNext());
@@ -235,7 +235,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnion': "+ unionIndex3));
         }
         int unionIndex5 = (decoder.readIndex());
         switch (unionIndex5) {
@@ -284,7 +284,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                             recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
                                             break;
                                         default:
-                                            throw new RuntimeException(("Illegal union index: "+ unionIndex6));
+                                            throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex6));
                                     }
                                 }
                                 chunkLen7 = (decoder.arrayNext());
@@ -300,7 +300,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex5));
+                throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnion': "+ unionIndex5));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
     }
@@ -330,7 +330,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'record': "+ unionIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
         int unionIndex2 = (decoder.readIndex());
@@ -69,7 +69,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex2));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
     }
@@ -99,7 +99,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -70,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved': "+ unionIndex0));
         }
         int unionIndex1 = (decoder.readIndex());
         switch (unionIndex1) {
@@ -81,7 +81,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 decoder.skipString();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'testRemoved': "+ unionIndex1));
         }
         int unionIndex2 = (decoder.readIndex());
         switch (unionIndex2) {
@@ -99,7 +99,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved2': "+ unionIndex2));
         }
         int unionIndex3 = (decoder.readIndex());
         switch (unionIndex3) {
@@ -110,7 +110,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex3));
         }
         Map<Utf8, IndexedRecord> subRecordMap1 = null;
         long chunkLen0 = (decoder.readMapStart());
@@ -185,7 +185,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved': "+ unionIndex4));
         }
         int unionIndex5 = (decoder.readIndex());
         switch (unionIndex5) {
@@ -196,7 +196,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 decoder.skipString();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex5));
+                throw new RuntimeException(("Illegal union index for 'testRemoved': "+ unionIndex5));
         }
         int unionIndex6 = (decoder.readIndex());
         switch (unionIndex6) {
@@ -214,7 +214,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex6));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved2': "+ unionIndex6));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
                 deserializesubSubRecord0(null, (decoder));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test3': "+ unionIndex0));
         }
         Object oldString1 = subRecord.get(1);
         if (oldString1 instanceof Utf8) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
                 deserializesubRecord20(null, (decoder));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'subRecord3': "+ unionIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_709674896072771093.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_709674896072771093.java
@@ -51,7 +51,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_817853091626136747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_817853091626136747.java
@@ -51,7 +51,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_709674896072771093.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_709674896072771093.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
             case  2 :
                 throw new AvroTypeException("Found \"long\", expecting [\"null\", \"string\"]");
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_817853091626136747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_817853091626136747.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
                 FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType.put(0, (decoder.readLong()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_6680186467380378611.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_6680186467380378611.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_8490237361339938033.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_8490237361339938033.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_6680186467380378611.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_6680186467380378611.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_8490237361339938033.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_8490237361339938033.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_1070310743258758747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_1070310743258758747.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_3098470850842605603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_3098470850842605603.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_1070310743258758747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_1070310743258758747.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_3098470850842605603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_3098470850842605603.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_249835021014762452.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_249835021014762452.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_9121348965757202658.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_9121348965757202658.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_249835021014762452.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_249835021014762452.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_9121348965757202658.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_9121348965757202658.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_5604497262207802220_5604497262207802220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_5604497262207802220_5604497262207802220.java
@@ -53,7 +53,7 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
                 FastStringableTest_javaStringPropertyInReaderSchemaTest.put(1, (decoder).readString());
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testUnionString': "+ unionIndex0));
         }
         List<String> testStringArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastStringableTest_javaStringPropertyTest_GenericDeserializer_3411107869155152759_3411107869155152759.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastStringableTest_javaStringPropertyTest_GenericDeserializer_3411107869155152759_3411107869155152759.java
@@ -53,7 +53,7 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_34111
                 FastStringableTest_javaStringPropertyTest.put(1, (decoder).readString());
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testUnionString': "+ unionIndex0));
         }
         List<String> testStringArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -55,7 +55,7 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
                             map0 .put(key0, deserializerecord0(null, (decoder)));
                             break;
                         default:
-                            throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                            throw new RuntimeException(("Illegal union index for 'mapValue': "+ unionIndex0));
                     }
                 }
                 chunkLen0 = (decoder.mapNext());
@@ -91,7 +91,7 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex1));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -79,7 +79,7 @@ public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex0));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
@@ -114,7 +114,7 @@ public class StringableRecord_SpecificDeserializer_6174384286732341990_617438428
                 StringableRecord.put(9, (decoder).readString());
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'stringUnion': "+ unionIndex0));
         }
         return StringableRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -50,7 +50,7 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
                 recordName.put(1, deserializerecordName0(recordName.get(1), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
         }
         return recordName;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_GenericDeserializer_585074122056792963_585074122056792963.java
@@ -52,7 +52,7 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
                         array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
                         break;
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                        throw new RuntimeException(("Illegal union index for 'arrayElem': "+ unionIndex0));
                 }
             }
             chunkLen0 = (decoder.arrayNext());
@@ -85,7 +85,7 @@ public class Array_of_UNION_GenericDeserializer_585074122056792963_5850741220567
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex1));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_1629046702287533603_1629046702287533603.java
@@ -73,7 +73,7 @@ public class Array_of_record_GenericDeserializer_1629046702287533603_16290467022
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex0));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_7444250593254323838_5967444021771418968.java
@@ -53,7 +53,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testString': "+ unionIndex0));
         }
         int unionIndex1 = (decoder.readIndex());
         switch (unionIndex1) {
@@ -71,7 +71,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'testStringUnionAlias': "+ unionIndex1));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_5976145119973076881_5976145119973076881.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
                 FastGenericDeserializerGeneratorTest_shouldReadEnum.put(1, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testEnumUnion': "+ unionIndex0));
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
@@ -96,7 +96,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
                         testEnumUnionArray1 .add(new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
                         break;
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                        throw new RuntimeException(("Illegal union index for 'testEnumUnionArrayElem': "+ unionIndex1));
                 }
             }
             chunkLen1 = (decoder.arrayNext());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_3518023893123209014_3518023893123209014.java
@@ -71,7 +71,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testFixedUnion': "+ unionIndex0));
         }
         List<org.apache.avro.generic.GenericData.Fixed> testFixedArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
@@ -135,7 +135,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
                         break;
                     }
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                        throw new RuntimeException(("Illegal union index for 'testFixedUnionArrayElem': "+ unionIndex1));
                 }
             }
             chunkLen1 = (decoder.arrayNext());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_6068669851166793050_6068669851166793050.java
@@ -61,7 +61,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
                 FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
     }
@@ -91,7 +91,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -98,7 +98,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testEnumUnion': "+ unionIndex0));
         }
         List<org.apache.avro.generic.GenericData.EnumSymbol> testEnumArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
@@ -184,7 +184,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                         break;
                     }
                     default:
-                        throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                        throw new RuntimeException(("Illegal union index for 'testEnumUnionArrayElem': "+ unionIndex1));
                 }
             }
             chunkLen1 = (decoder.arrayNext());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_6705572650240186052_6705572650240186052.java
@@ -58,7 +58,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(1, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
         }
         Object oldString0 = FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(2);
         if (oldString0 instanceof Utf8) {
@@ -82,7 +82,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'testStringUnion': "+ unionIndex1));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
         int unionIndex2 = (decoder.readIndex());
@@ -94,7 +94,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(5, (decoder.readLong()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                throw new RuntimeException(("Illegal union index for 'testLongUnion': "+ unionIndex2));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
         int unionIndex3 = (decoder.readIndex());
@@ -106,7 +106,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(7, (decoder.readDouble()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'testDoubleUnion': "+ unionIndex3));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
         int unionIndex4 = (decoder.readIndex());
@@ -118,7 +118,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(9, (decoder.readFloat()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                throw new RuntimeException(("Illegal union index for 'testFloatUnion': "+ unionIndex4));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
         int unionIndex5 = (decoder.readIndex());
@@ -130,7 +130,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(11, (decoder.readBoolean()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex5));
+                throw new RuntimeException(("Illegal union index for 'testBooleanUnion': "+ unionIndex5));
         }
         Object oldBytes0 = FastGenericDeserializerGeneratorTest_shouldReadPrimitives.get(12);
         if (oldBytes0 instanceof ByteBuffer) {
@@ -154,7 +154,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex6));
+                throw new RuntimeException(("Illegal union index for 'testBytesUnion': "+ unionIndex6));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_3641773645471631090_3641773645471631090.java
@@ -134,7 +134,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                                 recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
                                 break;
                             default:
-                                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                                throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex2));
                         }
                     }
                     chunkLen2 = (decoder.arrayNext());
@@ -143,7 +143,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'recordsArrayUnion': "+ unionIndex1));
         }
         int unionIndex3 = (decoder.readIndex());
         switch (unionIndex3) {
@@ -178,7 +178,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                                     recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder)));
                                     break;
                                 default:
-                                    throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                                    throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex4));
                             }
                         }
                         chunkLen3 = (decoder.mapNext());
@@ -190,7 +190,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'recordsMapUnion': "+ unionIndex3));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
     }
@@ -220,7 +220,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_1368792156564876103_1368792156564876103.java
@@ -106,7 +106,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                     recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
                                     break;
                                 default:
-                                    throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                                    throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex0));
                             }
                         }
                         chunkLen1 = (decoder.mapNext());
@@ -159,7 +159,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                     recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
                                     break;
                                 default:
-                                    throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                                    throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex2));
                             }
                         }
                         chunkLen3 = (decoder.arrayNext());
@@ -219,7 +219,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                             recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
                                             break;
                                         default:
-                                            throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                                            throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex4));
                                     }
                                 }
                                 chunkLen5 = (decoder.mapNext());
@@ -235,7 +235,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnion': "+ unionIndex3));
         }
         int unionIndex5 = (decoder.readIndex());
         switch (unionIndex5) {
@@ -284,7 +284,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                             recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
                                             break;
                                         default:
-                                            throw new RuntimeException(("Illegal union index: "+ unionIndex6));
+                                            throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex6));
                                     }
                                 }
                                 chunkLen7 = (decoder.arrayNext());
@@ -300,7 +300,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex5));
+                throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnion': "+ unionIndex5));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
     }
@@ -330,7 +330,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_7544686714080602018_7544686714080602018.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'record': "+ unionIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
         int unionIndex2 = (decoder.readIndex());
@@ -69,7 +69,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex2));
         }
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
     }
@@ -99,7 +99,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_3843748224527120400_2388689330760710730.java
@@ -70,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved': "+ unionIndex0));
         }
         int unionIndex1 = (decoder.readIndex());
         switch (unionIndex1) {
@@ -81,7 +81,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 decoder.skipString();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'testRemoved': "+ unionIndex1));
         }
         int unionIndex2 = (decoder.readIndex());
         switch (unionIndex2) {
@@ -99,7 +99,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex2));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved2': "+ unionIndex2));
         }
         int unionIndex3 = (decoder.readIndex());
         switch (unionIndex3) {
@@ -110,7 +110,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex3));
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex3));
         }
         Map<Utf8, IndexedRecord> subRecordMap1 = null;
         long chunkLen0 = (decoder.readMapStart());
@@ -185,7 +185,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex4));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved': "+ unionIndex4));
         }
         int unionIndex5 = (decoder.readIndex());
         switch (unionIndex5) {
@@ -196,7 +196,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 decoder.skipString();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex5));
+                throw new RuntimeException(("Illegal union index for 'testRemoved': "+ unionIndex5));
         }
         int unionIndex6 = (decoder.readIndex());
         switch (unionIndex6) {
@@ -214,7 +214,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex6));
+                throw new RuntimeException(("Illegal union index for 'testNotRemoved2': "+ unionIndex6));
         }
         return subRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_859610261780137064_1500282458003629018.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
                 deserializesubSubRecord0(null, (decoder));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test3': "+ unionIndex0));
         }
         Object oldString1 = subRecord.get(1);
         if (oldString1 instanceof Utf8) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_5796370398524630883_5489153763878840830.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
                 deserializesubRecord20(null, (decoder));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'subRecord3': "+ unionIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_709674896072771093.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_709674896072771093.java
@@ -51,7 +51,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_817853091626136747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_709674896072771093_817853091626136747.java
@@ -51,7 +51,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_709674896072771093.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_709674896072771093.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
             case  2 :
                 throw new AvroTypeException("Found \"long\", expecting [\"null\", \"string\"]");
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_817853091626136747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_817853091626136747_817853091626136747.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
                 FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType.put(0, (decoder.readLong()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_4534842416730234317.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_4534842416730234317_7939612101894249525.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_4534842416730234317.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_7939612101894249525_7939612101894249525.java
@@ -54,7 +54,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_6680186467380378611.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_6680186467380378611.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_8490237361339938033.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_6680186467380378611_8490237361339938033.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_6680186467380378611.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_6680186467380378611.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_8490237361339938033.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_8490237361339938033_8490237361339938033.java
@@ -64,7 +64,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_1070310743258758747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_1070310743258758747.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_3098470850842605603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_1070310743258758747_3098470850842605603.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_1070310743258758747.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_1070310743258758747.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_3098470850842605603.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_3098470850842605603_3098470850842605603.java
@@ -75,7 +75,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_2766669985292859070.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_2766669985292859070_7065739331635323329.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readInt()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_2766669985292859070.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_7065739331635323329_7065739331635323329.java
@@ -46,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString.put(0, (decoder.readBoolean()));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_249835021014762452.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_249835021014762452.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_9121348965757202658.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_249835021014762452_9121348965757202658.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_249835021014762452.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_249835021014762452.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_9121348965757202658.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_9121348965757202658_9121348965757202658.java
@@ -50,7 +50,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 decoder.readNull();
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
         }
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_5604497262207802220_5604497262207802220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_5604497262207802220_5604497262207802220.java
@@ -53,7 +53,7 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
                 FastStringableTest_javaStringPropertyInReaderSchemaTest.put(1, (decoder).readString());
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testUnionString': "+ unionIndex0));
         }
         List<String> testStringArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastStringableTest_javaStringPropertyTest_GenericDeserializer_3411107869155152759_3411107869155152759.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastStringableTest_javaStringPropertyTest_GenericDeserializer_3411107869155152759_3411107869155152759.java
@@ -53,7 +53,7 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_34111
                 FastStringableTest_javaStringPropertyTest.put(1, (decoder).readString());
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'testUnionString': "+ unionIndex0));
         }
         List<String> testStringArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_GenericDeserializer_2087096002965517991_2087096002965517991.java
@@ -55,7 +55,7 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
                             map0 .put(key0, deserializerecord0(null, (decoder)));
                             break;
                         default:
-                            throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                            throw new RuntimeException(("Illegal union index for 'mapValue': "+ unionIndex0));
                     }
                 }
                 chunkLen0 = (decoder.mapNext());
@@ -91,7 +91,7 @@ public class Map_of_UNION_GenericDeserializer_2087096002965517991_20870960029655
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex1));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex1));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_2141121767969292399_2141121767969292399.java
@@ -79,7 +79,7 @@ public class Map_of_record_GenericDeserializer_2141121767969292399_2141121767969
                 break;
             }
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'field': "+ unionIndex0));
         }
         return record;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/StringableRecord_SpecificDeserializer_6174384286732341990_6174384286732341990.java
@@ -114,7 +114,7 @@ public class StringableRecord_SpecificDeserializer_6174384286732341990_617438428
                 StringableRecord.put(9, (decoder).readString());
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'stringUnion': "+ unionIndex0));
         }
         return StringableRecord;
     }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/recordName_GenericDeserializer_6897301803194779359_6897301803194779359.java
@@ -50,7 +50,7 @@ public class recordName_GenericDeserializer_6897301803194779359_6897301803194779
                 recordName.put(1, deserializerecordName0(recordName.get(1), (decoder)));
                 break;
             default:
-                throw new RuntimeException(("Illegal union index: "+ unionIndex0));
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
         }
         return recordName;
     }


### PR DESCRIPTION
These need to be checked in, otherwise the CI pipeline publishes
SNAPSHOT artifacts rather than normal ones.