### PR TITLE
add serialized payload generation, demonstrate avro json format union incompatibility

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,4 +42,5 @@ jobs:
       - name: Run SonarCloud analysis
         env:
           sonar.login: ${{ secrets.SONARCLOUD_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew sonarqube --no-daemon

--- a/helper/tests/codegen-14/build.gradle
+++ b/helper/tests/codegen-14/build.gradle
@@ -14,6 +14,9 @@ configurations {
   codegen {
     extendsFrom implementation
   }
+  resourcegen {
+    extendsFrom runtimeClasspath
+  }
 }
 
 sourceSets {
@@ -24,7 +27,7 @@ sourceSets {
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
     }
     resources {
-      srcDirs = ["src/main/raw-avro", "src/main/compat-avro"]
+      srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
     }
   }
 }
@@ -62,16 +65,36 @@ task copyCompatAvroCodeToResources(type: Copy) {
   into "$buildDir/resources/main"
 }
 
-copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen
+task runResourceGeneration(type: JavaExec) {
+  classpath configurations.resourcegen + sourceSets.main.output
+  main = "com.linkedin.avroutil1.compatibility.avro14.Generate14TestResources"
+  args "$buildDir/generated/resources"
+  debug false
+}
+
+jar {
+  //normal contents
+  from sourceSets.main.output
+  //resource generation output. has to be explicitly included in the jar because
+  //"processResources" ran before this was generated
+  from "$buildDir/generated/resources"
+}
+
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
+copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen
+jar.dependsOn runResourceGeneration
 
 dependencies {
   codegen "net.sf.jopt-simple:jopt-simple:3.2"   //avro 1.4 needs this for codegen but is missing a dependency
   codegen "org.apache.hadoop:hadoop-core:0.20.2" //avro 1.4 needs this for codegen but is missing a dependency
   codegen project(":helper:tests:helper-tests-common")
   codegen project(":helper:helper")
+  //redirect logging to log4j2 for code generation
+  codegen "org.apache.logging.log4j:log4j-core:2.11.2"
+  codegen "org.apache.logging.log4j:log4j-slf4j-impl:2.11.2"
+  codegen files('../codegenClasspath')
 
   //required because generated code depends on the helper
   implementation project(":helper:helper")
@@ -82,4 +105,11 @@ dependencies {
     exclude group: "org.jboss.netty"
     exclude group: "com.thoughtworks.paranamer", module: "paranamer-ant"
   }
+
+  //this block required for resource generation code
+  implementation project(":helper:tests:helper-tests-common")
+  //redirect logging to log4j2 for resource generation
+  resourcegen "org.apache.logging.log4j:log4j-core:2.11.2"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.11.2"
+  resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Generate14TestResources.java
+++ b/helper/tests/codegen-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Generate14TestResources.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro14;
+
+import com.linkedin.avroutil1.TestUtil;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.JsonEncoder;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+/**
+ * this class generates test payloads based on the avro schemas defined in this module
+ * under avro 1.4 in various wire formats. these payloads are then available for use
+ * by the modules containing the actual unit tests
+ */
+public class Generate14TestResources {
+
+    public static void main(String[] args) {
+        if (args == null || args.length != 1) {
+            System.err.println("exactly single argument required - output path. instead got " + Arrays.toString(args));
+            System.exit(1);
+        }
+        Path outputRoot = Paths.get(args[0].trim()).toAbsolutePath();
+        Path by14Root = outputRoot.resolve("by14");
+
+        by14.RecordWithUnion outer = new by14.RecordWithUnion();
+        outer.f = new by14.InnerUnionRecord();
+        outer.f.f = 14;
+        try {
+            SpecificDatumWriter<by14.RecordWithUnion> writer = new SpecificDatumWriter<>(outer.getSchema());
+
+            Path binaryRecordWithUnion = TestUtil.getNewFile(by14Root, "RecordWithUnion.binary");
+            BinaryEncoder binaryEnc = new BinaryEncoder(Files.newOutputStream(binaryRecordWithUnion));
+
+            Path jsonRecordWithUnion = TestUtil.getNewFile(by14Root, "RecordWithUnion.json");
+            JsonEncoder jsonEnc = new JsonEncoder(outer.getSchema(), Files.newOutputStream(jsonRecordWithUnion));
+
+            writer.write(outer, binaryEnc);
+            binaryEnc.flush();
+
+            writer.write(outer, jsonEnc);
+            jsonEnc.flush();
+        } catch (Exception e) {
+            System.err.println("failed to generate payloads");
+            e.printStackTrace(System.err);
+            System.exit(1);
+        }
+    }
+}

--- a/helper/tests/codegen-14/src/main/raw-avro/by14/RecordWithUnion.avsc
+++ b/helper/tests/codegen-14/src/main/raw-avro/by14/RecordWithUnion.avsc
@@ -1,0 +1,21 @@
+{
+  "type": "record",
+  "namespace": "by14",
+  "name": "RecordWithUnion",
+  "fields": [
+    {
+      "name": "f",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "InnerUnionRecord",
+          "fields" : [
+            {"name": "f", "type": "int"}
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/helper/tests/codegen-15/build.gradle
+++ b/helper/tests/codegen-15/build.gradle
@@ -14,6 +14,9 @@ configurations {
   codegen {
     extendsFrom implementation
   }
+  resourcegen {
+    extendsFrom runtimeClasspath
+  }
 }
 
 sourceSets {
@@ -24,14 +27,13 @@ sourceSets {
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
     }
     resources {
-      srcDirs = ["src/main/raw-avro", "src/main/compat-avro"]
+      srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
     }
   }
 }
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
-
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -63,10 +65,26 @@ task copyCompatAvroCodeToResources(type: Copy) {
   into "$buildDir/resources/main"
 }
 
-copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen
+task runResourceGeneration(type: JavaExec) {
+  classpath configurations.resourcegen + sourceSets.main.output
+  main = "com.linkedin.avroutil1.compatibility.avro15.Generate15TestResources"
+  args "$buildDir/generated/resources"
+  debug false
+}
+
+jar {
+  //normal contents
+  from sourceSets.main.output
+  //resource generation output. has to be explicitly included in the jar because
+  //"processResources" ran before this was generated
+  from "$buildDir/generated/resources"
+}
+
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
+copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen
+jar.dependsOn runResourceGeneration
 
 dependencies {
   codegen "org.apache.avro:avro-tools:1.5.4"
@@ -77,4 +95,11 @@ dependencies {
   //required because generated code depends on the helper
   implementation project(":helper:helper")
   implementation "org.apache.avro:avro:1.5.4"
+
+  //this block required for resource generation code
+  implementation project(":helper:tests:helper-tests-common")
+  //redirect logging to log4j2 for resource generation
+  resourcegen "org.apache.logging.log4j:log4j-core:2.11.2"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.11.2"
+  resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Generate15TestResources.java
+++ b/helper/tests/codegen-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Generate15TestResources.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro15;
+
+import com.linkedin.avroutil1.TestUtil;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.io.JsonEncoder;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+/**
+ * this class generates test payloads based on the avro schemas defined in this module
+ * under avro 1.5 in various wire formats. these payloads are then available for use
+ * by the modules containing the actual unit tests
+ */
+public class Generate15TestResources {
+
+    public static void main(String[] args) {
+        if (args == null || args.length != 1) {
+            System.err.println("exactly single argument required - output path. instead got " + Arrays.toString(args));
+            System.exit(1);
+        }
+        Path outputRoot = Paths.get(args[0].trim()).toAbsolutePath();
+        Path by15Root = outputRoot.resolve("by15");
+
+        by15.RecordWithUnion outer = new by15.RecordWithUnion();
+        outer.f = new by15.InnerUnionRecord();
+        outer.f.f = 15;
+        try {
+            SpecificDatumWriter<by15.RecordWithUnion> writer = new SpecificDatumWriter<>(outer.getSchema());
+
+            Path binaryRecordWithUnion = TestUtil.getNewFile(by15Root, "RecordWithUnion.binary");
+            BinaryEncoder binaryEnc = EncoderFactory.get().binaryEncoder(Files.newOutputStream(binaryRecordWithUnion), null);
+
+            Path jsonRecordWithUnion = TestUtil.getNewFile(by15Root, "RecordWithUnion.json");
+            JsonEncoder jsonEnc = EncoderFactory.get().jsonEncoder(outer.getSchema(), Files.newOutputStream(jsonRecordWithUnion));
+
+            writer.write(outer, binaryEnc);
+            binaryEnc.flush();
+
+            writer.write(outer, jsonEnc);
+            jsonEnc.flush();
+        } catch (Exception e) {
+            System.err.println("failed to generate payloads");
+            e.printStackTrace(System.err);
+            System.exit(1);
+        }
+    }
+}

--- a/helper/tests/codegen-15/src/main/raw-avro/by15/RecordWithUnion.avsc
+++ b/helper/tests/codegen-15/src/main/raw-avro/by15/RecordWithUnion.avsc
@@ -1,0 +1,21 @@
+{
+  "type": "record",
+  "namespace": "by15",
+  "name": "RecordWithUnion",
+  "fields": [
+    {
+      "name": "f",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "InnerUnionRecord",
+          "fields" : [
+            {"name": "f", "type": "int"}
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/helper/tests/codegenClasspath/log4j2.xml
+++ b/helper/tests/codegenClasspath/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] [%t] %c - %msg%n" />
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="warn" additivity="false">
+            <AppenderRef ref="console" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14WireFormatCompatibilityTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro14;
+
+import com.linkedin.avroutil1.TestUtil;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.JsonDecoder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro14WireFormatCompatibilityTest {
+
+  @Test
+  public void demonstrateAbleToReadAvro14Json() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("by14/RecordWithUnion.avsc"));
+    String serialized = TestUtil.load("by14/RecordWithUnion.json");
+    JsonDecoder decoder = new JsonDecoder(schema, serialized);
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+    IndexedRecord deserialized = reader.read(null, decoder);
+    IndexedRecord inner = (IndexedRecord) deserialized.get(deserialized.getSchema().getField("f").pos());
+    Assert.assertEquals(14, inner.get(inner.getSchema().getField("f").pos()));
+  }
+
+  @Test
+  public void demonstrateUnableToReadAvro15Json() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("by15/RecordWithUnion.avsc"));
+    String serialized = TestUtil.load("by15/RecordWithUnion.json");
+    JsonDecoder decoder = new JsonDecoder(schema, serialized);
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+    try {
+      reader.read(null, decoder);
+      Assert.fail("expected to fail deserialization");
+    } catch (AvroTypeException expected) {
+      Assert.assertEquals(expected.getMessage(), "Unknown union branch by15.InnerUnionRecord");
+    }
+  }
+}

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15WireFormatCompatibilityTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro15;
+
+import com.linkedin.avroutil1.TestUtil;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.JsonDecoder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro15WireFormatCompatibilityTest {
+
+  @Test
+  public void demonstrateUnableToReadAvro14Json() throws Exception {
+    Schema schema = new Schema.Parser().parse(TestUtil.load("by14/RecordWithUnion.avsc"));
+    String serialized = TestUtil.load("by14/RecordWithUnion.json");
+    JsonDecoder decoder = DecoderFactory.get().jsonDecoder(schema, serialized);
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+    try {
+      reader.read(null, decoder);
+      Assert.fail("expected to fail deserialization");
+    } catch (AvroTypeException expected) {
+      Assert.assertEquals(expected.getMessage(), "Unknown union branch InnerUnionRecord");
+    }
+  }
+
+  @Test
+  public void demonstrateAbleToReadAvro15Json() throws Exception {
+    Schema schema = new Schema.Parser().parse(TestUtil.load("by15/RecordWithUnion.avsc"));
+    String serialized = TestUtil.load("by15/RecordWithUnion.json");
+    JsonDecoder decoder = DecoderFactory.get().jsonDecoder(schema, serialized);
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+    IndexedRecord deserialized = reader.read(null, decoder);
+    IndexedRecord inner = (IndexedRecord) deserialized.get(deserialized.getSchema().getField("f").pos());
+    Assert.assertEquals(15, inner.get(inner.getSchema().getField("f").pos()));
+  }
+}

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroWireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroWireFormatCompatibilityTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import com.linkedin.avroutil1.TestUtil;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroWireFormatCompatibilityTest {
+
+  @Test
+  public void demonstrateAbleToReadAvro14Binary() throws Exception {
+    Schema schema = AvroCompatibilityHelper.parse(TestUtil.load("by14/RecordWithUnion.avsc"));
+    byte[] serialized = TestUtil.loadBinary("by14/RecordWithUnion.binary");
+    BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(serialized);
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+    IndexedRecord deserialized = reader.read(null, decoder);
+    IndexedRecord inner = (IndexedRecord) deserialized.get(deserialized.getSchema().getField("f").pos());
+    Assert.assertEquals(14, inner.get(inner.getSchema().getField("f").pos()));
+  }
+
+  @Test
+  public void demonstrateAbleToReadAvro15Binary() throws Exception {
+    Schema schema = AvroCompatibilityHelper.parse(TestUtil.load("by15/RecordWithUnion.avsc"));
+    byte[] serialized = TestUtil.loadBinary("by15/RecordWithUnion.binary");
+    BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(serialized);
+    GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+    IndexedRecord deserialized = reader.read(null, decoder);
+    IndexedRecord inner = (IndexedRecord) deserialized.get(deserialized.getSchema().getField("f").pos());
+    Assert.assertEquals(15, inner.get(inner.getSchema().getField("f").pos()));
+  }
+}

--- a/helper/tests/helper-tests-common/src/main/java/com/linkedin/avroutil1/TestUtil.java
+++ b/helper/tests/helper-tests-common/src/main/java/com/linkedin/avroutil1/TestUtil.java
@@ -8,6 +8,8 @@ package com.linkedin.avroutil1;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.Properties;
 import org.apache.commons.io.IOUtils;
@@ -31,6 +33,18 @@ public class TestUtil {
     }
   }
 
+  public static byte[] loadBinary(String path) throws IOException {
+    InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
+    if (is == null) {
+      throw new IllegalArgumentException("resource " + path + " not found on context classloader");
+    }
+    try {
+      return IOUtils.toByteArray(is);
+    } finally {
+      is.close();
+    }
+  }
+
   public static boolean compilerExpectedOnClasspath() {
     //when we create the gradle test tasks we set a system property ("runtime.avro.version")
     //with the name of the gradle configuration used for avro. those that have "NoCompiler"
@@ -48,5 +62,23 @@ public class TestUtil {
       throw new AssertionError("value under system property \"runtime.avro.version\" is empty");
     }
     return !trimmed.contains("nocompiler");
+  }
+
+  public static Path getNewFile(Path folder, String fileName) throws IOException {
+    if (!Files.exists(folder)) {
+      Files.createDirectories(folder);
+    }
+    if (!Files.isDirectory(folder) || !Files.isWritable(folder)) {
+      throw new IllegalStateException("root folder " + folder + " not a directory or isnt writable");
+    }
+    Path file = folder.resolve(fileName);
+    if (Files.exists(file)) {
+      if (!Files.isRegularFile(file)) {
+        throw new IllegalStateException("was expecting " + file + " to be a regular file");
+      }
+      Files.delete(file);
+    }
+    Files.createFile(file);
+    return file;
   }
 }


### PR DESCRIPTION
codegen-X modules in helper tests now can generate not just specific record classes from schemas, but also payloads (serialized records) of those generated records in json and binary wire formats.

added tests that show that avro 1.4 and 1.5 disagree on json format while all avro can read binaries produced by 1.4 and 1.5 - for a single simple schema with an inner record union