### PR TITLE
Make isSpecificRecord public in AvroCompatibilityHelper

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -330,7 +330,7 @@ public class AvroCompatibilityHelper {
    * @param indexedRecord the record in question
    * @return true if argument is a specific record
    */
-  static boolean isSpecificRecord(IndexedRecord indexedRecord) {
+  public static boolean isSpecificRecord(IndexedRecord indexedRecord) {
     return indexedRecord instanceof SpecificRecord;
   }
 


### PR DESCRIPTION
Make isSpecificRecord public in AvroCompatibilityHelper for use.