### PR TITLE
catch throwable in helper static initialization

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -76,8 +76,8 @@ public class AvroCompatibilityHelper {
           default:
             throw new IllegalStateException("unhandled avro version " + DETECTED_VERSION);
         }
-      } catch (Exception e) {
-        throw new IllegalStateException("could not initialize avro factory for " + DETECTED_VERSION, e);
+      } catch (Throwable t) {
+        throw new IllegalStateException("could not initialize avro factory for " + DETECTED_VERSION, t);
       }
     }
   }


### PR DESCRIPTION
if any static initialization blocks called from here throw an exception, that exception would be wrapped into a java.lang.ExceptionInInitializerError, which is not an exception, and will be missed.

this leads to user issues that are harder to figure out since the full caused-by chain is broken