### PR TITLE
fix end-of-custom-coders code block detection

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
@@ -63,7 +63,7 @@ public class CodeTransformations {
   private static final Pattern CREATE_DECODER_INVOCATION_SHORT = Pattern.compile(Pattern.quote("SpecificData.getDecoder(in)"));
   private static final String  CREATE_DECODER_VIA_HELPER = Matcher.quoteReplacement(HelperConsts.HELPER_FQCN + ".newBinaryDecoder(in)");
   private static final Pattern HAS_CUSTOM_CODERS_SIGNATURE_SIGNATURE = Pattern.compile(Pattern.quote("@Override protected boolean hasCustomCoders"));
-  private static final Pattern END_CUSTOM_DECODE_PATTERN = Pattern.compile("}\\s+}\\s+}\\s+}");
+  private static final Pattern END_CUSTOM_DECODE_PATTERN = Pattern.compile("}\\s+}\\s+}\\s+}\\s*[\\r\\n]+");
 
   private static final String FIXED_CLASS_BODY_TEMPLATE = TemplateUtil.loadTemplate("avroutil1/templates/SpecificFixedBody.template");
   private static final String FIXED_CLASS_NO_NAMESPACE_BODY_TEMPLATE = TemplateUtil.loadTemplate("avroutil1/templates/SpecificFixedBodyNoNamespace.template");
@@ -642,7 +642,7 @@ public class CodeTransformations {
     }
 
     @SuppressWarnings("UnnecessaryLocalVariable")
-    String codeWithout = code.substring(0, startMatcher.start()) + code.substring(endMatcher.end());
+    String codeWithout = code.substring(0, startMatcher.start()) + "\n" + code.substring(endMatcher.end());
     return codeWithout;
   }
 


### PR DESCRIPTION
capture all the way to the whitespace between methods otherwise this matches the middle of a deeply nested condition for a large-enough schema