### PR TITLE
Always construct deserialized lists with an initial capacity

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -66,7 +66,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<URL>();
+            urlArray0 = new ArrayList<URL>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -204,7 +204,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -235,7 +235,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -334,7 +334,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -371,7 +371,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -436,7 +436,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -488,7 +488,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -570,7 +570,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -639,7 +639,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -683,7 +683,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -764,7 +764,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -75,7 +75,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<Utf8>();
+            urlArray0 = new ArrayList<Utf8>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -197,7 +197,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -228,7 +228,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -327,7 +327,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -364,7 +364,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -429,7 +429,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -563,7 +563,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -632,7 +632,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -676,7 +676,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -75,7 +75,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<Utf8>();
+            urlArray0 = new ArrayList<Utf8>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -204,7 +204,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -235,7 +235,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -334,7 +334,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -371,7 +371,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -436,7 +436,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -488,7 +488,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -570,7 +570,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -639,7 +639,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -683,7 +683,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -764,7 +764,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -86,7 +86,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<Utf8>();
+            urlArray0 = new ArrayList<Utf8>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -204,7 +204,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -235,7 +235,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -334,7 +334,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -371,7 +371,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -436,7 +436,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -488,7 +488,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -570,7 +570,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -639,7 +639,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -683,7 +683,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -764,7 +764,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -66,7 +66,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<URL>();
+            urlArray0 = new ArrayList<URL>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -204,7 +204,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -235,7 +235,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -334,7 +334,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -371,7 +371,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -436,7 +436,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -488,7 +488,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -570,7 +570,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -639,7 +639,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -683,7 +683,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -764,7 +764,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -66,7 +66,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<URL>();
+            urlArray0 = new ArrayList<URL>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -204,7 +204,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -235,7 +235,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -334,7 +334,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -371,7 +371,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -436,7 +436,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -488,7 +488,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -570,7 +570,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -639,7 +639,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -683,7 +683,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -764,7 +764,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -46,7 +46,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -221,7 +221,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -252,7 +252,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -307,7 +307,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -323,7 +323,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -365,7 +365,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -417,7 +417,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -499,7 +499,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -568,7 +568,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -612,7 +612,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -693,7 +693,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -759,7 +759,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -775,7 +775,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -794,7 +794,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -810,7 +810,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -826,7 +826,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -46,7 +46,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             array0 = ((List)(reuse));
             array0 .clear();
         } else {
-            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>();
+            array0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -231,7 +231,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -262,7 +262,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -317,7 +317,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -333,7 +333,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -375,7 +375,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -427,7 +427,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -509,7 +509,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -578,7 +578,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -622,7 +622,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -703,7 +703,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -769,7 +769,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -785,7 +785,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -804,7 +804,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -820,7 +820,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -836,7 +836,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -226,7 +226,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -257,7 +257,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -312,7 +312,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -328,7 +328,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -370,7 +370,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -422,7 +422,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -504,7 +504,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -573,7 +573,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -617,7 +617,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -698,7 +698,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -764,7 +764,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -780,7 +780,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -799,7 +799,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -815,7 +815,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -831,7 +831,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -236,7 +236,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -267,7 +267,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -322,7 +322,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -338,7 +338,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -380,7 +380,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen5));
         }
         while (chunkLen5 > 0) {
             for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
@@ -432,7 +432,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen7));
                 }
                 while (chunkLen7 > 0) {
                     for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
@@ -514,7 +514,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen9));
         }
         while (chunkLen9 > 0) {
             for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
@@ -583,7 +583,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen12));
                     }
                     while (chunkLen12 > 0) {
                         for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -627,7 +627,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen13));
                 }
                 while (chunkLen13 > 0) {
                     for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
@@ -708,7 +708,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen16));
                             }
                             while (chunkLen16 > 0) {
                                 for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -774,7 +774,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -790,7 +790,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -809,7 +809,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -825,7 +825,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {
@@ -841,7 +841,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen21));
         }
         while (chunkLen21 > 0) {
             for (int counter21 = 0; (counter21 <chunkLen21); counter21 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/StringableRecord_SpecificDeserializer_6010214235595501953_6010214235595501953.java
@@ -66,7 +66,7 @@ public class StringableRecord_SpecificDeserializer_6010214235595501953_601021423
             urlArray0 = ((List) oldArray0);
             urlArray0 .clear();
         } else {
-            urlArray0 = new ArrayList<URL>();
+            urlArray0 = new ArrayList<URL>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -203,7 +203,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -234,7 +234,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -289,7 +289,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -305,7 +305,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -347,7 +347,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -399,7 +399,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -481,7 +481,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -550,7 +550,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -594,7 +594,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -675,7 +675,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
@@ -741,7 +741,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             booleanArray0 = ((PrimitiveBooleanList) oldArray8);
             booleanArray0 .clear();
         } else {
-            booleanArray0 = new PrimitiveBooleanArrayList();
+            booleanArray0 = new PrimitiveBooleanArrayList(((int) chunkLen16));
         }
         while (chunkLen16 > 0) {
             for (int counter16 = 0; (counter16 <chunkLen16); counter16 ++) {
@@ -757,7 +757,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             doubleArray0 = ((PrimitiveDoubleList) oldArray9);
             doubleArray0 .clear();
         } else {
-            doubleArray0 = new PrimitiveDoubleArrayList();
+            doubleArray0 = new PrimitiveDoubleArrayList(((int) chunkLen17));
         }
         while (chunkLen17 > 0) {
             for (int counter17 = 0; (counter17 <chunkLen17); counter17 ++) {
@@ -776,7 +776,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             intArray0 = ((PrimitiveIntList) oldArray10);
             intArray0 .clear();
         } else {
-            intArray0 = new PrimitiveIntArrayList();
+            intArray0 = new PrimitiveIntArrayList(((int) chunkLen18));
         }
         while (chunkLen18 > 0) {
             for (int counter18 = 0; (counter18 <chunkLen18); counter18 ++) {
@@ -792,7 +792,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             longArray0 = ((PrimitiveLongList) oldArray11);
             longArray0 .clear();
         } else {
-            longArray0 = new PrimitiveLongArrayList();
+            longArray0 = new PrimitiveLongArrayList(((int) chunkLen19));
         }
         while (chunkLen19 > 0) {
             for (int counter19 = 0; (counter19 <chunkLen19); counter19 ++) {
@@ -808,7 +808,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
             stringArray0 = ((List) oldArray12);
             stringArray0 .clear();
         } else {
-            stringArray0 = new ArrayList<Utf8>();
+            stringArray0 = new ArrayList<Utf8>(((int) chunkLen20));
         }
         while (chunkLen20 > 0) {
             for (int counter20 = 0; (counter20 <chunkLen20); counter20 ++) {

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -204,7 +204,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedArray0 = ((List) oldArray0);
             testFixedArray0 .clear();
         } else {
-            testFixedArray0 = new ArrayList<TestFixed>();
+            testFixedArray0 = new ArrayList<TestFixed>(((int) chunkLen0));
         }
         while (chunkLen0 > 0) {
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
@@ -235,7 +235,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testFixedUnionArray0 = ((List) oldArray1);
             testFixedUnionArray0 .clear();
         } else {
-            testFixedUnionArray0 = new ArrayList<TestFixed>();
+            testFixedUnionArray0 = new ArrayList<TestFixed>(((int) chunkLen1));
         }
         while (chunkLen1 > 0) {
             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
@@ -334,7 +334,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumArray0 = ((List) oldArray2);
             testEnumArray0 .clear();
         } else {
-            testEnumArray0 = new ArrayList<TestEnum>();
+            testEnumArray0 = new ArrayList<TestEnum>(((int) chunkLen2));
         }
         while (chunkLen2 > 0) {
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
@@ -371,7 +371,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             testEnumUnionArray0 = ((List) oldArray3);
             testEnumUnionArray0 .clear();
         } else {
-            testEnumUnionArray0 = new ArrayList<TestEnum>();
+            testEnumUnionArray0 = new ArrayList<TestEnum>(((int) chunkLen3));
         }
         while (chunkLen3 > 0) {
             for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
@@ -436,7 +436,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArray0 = ((List) oldArray4);
             recordsArray0 .clear();
         } else {
-            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+            recordsArray0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen4));
         }
         while (chunkLen4 > 0) {
             for (int counter4 = 0; (counter4 <chunkLen4); counter4 ++) {
@@ -488,7 +488,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayUnionOption0 = ((List) oldArray5);
                     recordsArrayUnionOption0 .clear();
                 } else {
-                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                    recordsArrayUnionOption0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen6));
                 }
                 while (chunkLen6 > 0) {
                     for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
@@ -570,7 +570,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             recordsArrayMap0 = ((List) oldArray6);
             recordsArrayMap0 .clear();
         } else {
-            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+            recordsArrayMap0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen8));
         }
         while (chunkLen8 > 0) {
             for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
@@ -639,7 +639,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                         recordsMapArrayValue0 = ((List) null);
                         recordsMapArrayValue0 .clear();
                     } else {
-                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                        recordsMapArrayValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen11));
                     }
                     while (chunkLen11 > 0) {
                         for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
@@ -683,7 +683,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     recordsArrayMapUnionOption0 = ((List) oldArray7);
                     recordsArrayMapUnionOption0 .clear();
                 } else {
-                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>();
+                    recordsArrayMapUnionOption0 = new ArrayList<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int) chunkLen12));
                 }
                 while (chunkLen12 > 0) {
                     for (int counter12 = 0; (counter12 <chunkLen12); counter12 ++) {
@@ -764,7 +764,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                                 recordsMapArrayUnionOptionValue0 = ((List) null);
                                 recordsMapArrayUnionOptionValue0 .clear();
                             } else {
-                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>();
+                                recordsMapArrayUnionOptionValue0 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int) chunkLen15));
                             }
                             while (chunkLen15 > 0) {
                                 for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -649,16 +649,13 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
       JClass arrayClass = schemaAssistant.classFromSchema(readerArraySchema, false, false, true);
       JClass abstractErasedArrayClass = schemaAssistant.classFromSchema(readerArraySchema, true, false, true).erasure();
 
-      JInvocation newArrayExp = JExpr._new(arrayClass);
-      if (useGenericTypes) {
-        newArrayExp = newArrayExp.arg(JExpr.cast(codeModel.INT, chunkLen));
-        if (!SchemaAssistant.isPrimitive(arraySchema.getElementType())) {
-          /**
-           * N.B.: The ColdPrimitiveXList implementations do not take the schema as a constructor param,
-           * but the {@link org.apache.avro.generic.GenericData.Array} does.
-           */
-          newArrayExp = newArrayExp.arg(getSchemaExpr(arraySchema));
-        }
+      JInvocation newArrayExp = JExpr._new(arrayClass).arg(JExpr.cast(codeModel.INT, chunkLen));
+      if (useGenericTypes && !SchemaAssistant.isPrimitive(arraySchema.getElementType())) {
+        /**
+         * N.B.: The ColdPrimitiveXList implementations do not take the schema as a constructor param,
+         * but the {@link org.apache.avro.generic.GenericData.Array} does.
+         */
+        newArrayExp = newArrayExp.arg(getSchemaExpr(arraySchema));
       }
       JInvocation finalNewArrayExp = newArrayExp;
 


### PR DESCRIPTION
Previously this was only done when using generic types.
The initial capacity specified is the size of the first block of an array