### PR TITLE
Faulty deserializers generated when record is splitted in subsequent schema

### DIFF
--- a/avro-fastserde/regenerate_avro.sh
+++ b/avro-fastserde/regenerate_avro.sh
@@ -51,6 +51,8 @@ fi
 
 # schema path to compile
 AVRO_SCHEMAS_PATH=(
+  "src/test/avro/splitRecordTest1.avsc"
+  "src/test/avro/splitRecordTest2.avsc"
   "src/test/avro/fastserdetest.avsc"
   "src/test/avro/defaultsTest.avsc"
   "src/test/avro/stringableTest.avsc"
@@ -64,6 +66,8 @@ CODE_GEN_PATH="src/test/java"
 # full path to store the compiled classes, and the dimension of this array
 # should be same as ${#AVRO_SCHEMAS_PATH[@]}
 FULL_CODE_GEN_PATH=(
+  "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
+  "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
   "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
   "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"
   "${CODE_GEN_PATH}/com/linkedin/avro/fastserde/generated/avro/*.java"

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        subRecord.put(0, null);
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                aliasedSubRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = aliasedSubRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return aliasedSubRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
@@ -1,0 +1,159 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest10((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
+        if ((reuse)!= null) {
+            SplitRecordTest1 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1)(reuse));
+        } else {
+            SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
+        }
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest1 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest1 .put(2, record30);
+        return SplitRecordTest1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = FullRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        FullRecord.put(1, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        FullRecord.put(0, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = FullRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return FullRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
@@ -1,0 +1,181 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.FullRecord;
+import com.linkedin.avro.fastserde.generated.avro.StringRecord;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest20((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
+        if ((reuse)!= null) {
+            SplitRecordTest2 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2)(reuse));
+        } else {
+            SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
+        }
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        List<FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest2 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest2 .put(2, record30);
+        return SplitRecordTest2;
+    }
+
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        StringRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((StringRecord)(reuse));
+        } else {
+            IntRecord = new StringRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = IntRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        return IntRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((com.linkedin.avro.fastserde.generated.avro.IntRecord)(reuse));
+        } else {
+            IntRecord = new com.linkedin.avro.fastserde.generated.avro.IntRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.skipString();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return IntRecord;
+    }
+
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        FullRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((FullRecord)(reuse));
+        } else {
+            IntRecord = new FullRecord();
+        }
+        int unionIndex4 = (decoder.readIndex());
+        switch (unionIndex4) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = IntRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
+        }
+        int unionIndex5 = (decoder.readIndex());
+        switch (unionIndex5) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex5));
+        }
+        return IntRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        aliasedSubRecord.put(0, null);
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                aliasedSubRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = aliasedSubRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return aliasedSubRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        subRecord.put(0, null);
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
@@ -1,0 +1,159 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest10((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
+        if ((reuse)!= null) {
+            SplitRecordTest1 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1)(reuse));
+        } else {
+            SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
+        }
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest1 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest1 .put(2, record30);
+        return SplitRecordTest1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = FullRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        FullRecord.put(1, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        FullRecord.put(0, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = FullRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return FullRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
@@ -1,0 +1,181 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.FullRecord;
+import com.linkedin.avro.fastserde.generated.avro.StringRecord;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest20((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
+        if ((reuse)!= null) {
+            SplitRecordTest2 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2)(reuse));
+        } else {
+            SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
+        }
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        List<FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest2 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest2 .put(2, record30);
+        return SplitRecordTest2;
+    }
+
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        StringRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((StringRecord)(reuse));
+        } else {
+            IntRecord = new StringRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = IntRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        return IntRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((com.linkedin.avro.fastserde.generated.avro.IntRecord)(reuse));
+        } else {
+            IntRecord = new com.linkedin.avro.fastserde.generated.avro.IntRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.skipString();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return IntRecord;
+    }
+
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        FullRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((FullRecord)(reuse));
+        } else {
+            IntRecord = new FullRecord();
+        }
+        int unionIndex4 = (decoder.readIndex());
+        switch (unionIndex4) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = IntRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
+        }
+        int unionIndex5 = (decoder.readIndex());
+        switch (unionIndex5) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex5));
+        }
+        return IntRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3676269449561141324_8274098733431623188(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                aliasedSubRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = aliasedSubRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return aliasedSubRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_8274098733431623188_3676269449561141324(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        subRecord.put(0, null);
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
@@ -1,0 +1,159 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest10((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
+        if ((reuse)!= null) {
+            SplitRecordTest1 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1)(reuse));
+        } else {
+            SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
+        }
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest1 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest1 .put(2, record30);
+        return SplitRecordTest1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = FullRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        FullRecord.put(1, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        FullRecord.put(0, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = FullRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return FullRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
@@ -1,0 +1,181 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.FullRecord;
+import com.linkedin.avro.fastserde.generated.avro.StringRecord;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest20((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
+        if ((reuse)!= null) {
+            SplitRecordTest2 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2)(reuse));
+        } else {
+            SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
+        }
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        List<FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest2 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest2 .put(2, record30);
+        return SplitRecordTest2;
+    }
+
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        StringRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((StringRecord)(reuse));
+        } else {
+            IntRecord = new StringRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = IntRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        return IntRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((com.linkedin.avro.fastserde.generated.avro.IntRecord)(reuse));
+        } else {
+            IntRecord = new com.linkedin.avro.fastserde.generated.avro.IntRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.skipString();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return IntRecord;
+    }
+
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        FullRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((FullRecord)(reuse));
+        } else {
+            IntRecord = new FullRecord();
+        }
+        int unionIndex4 = (decoder.readIndex());
+        switch (unionIndex4) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = IntRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
+        }
+        int unionIndex5 = (decoder.readIndex());
+        switch (unionIndex5) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex5));
+        }
+        return IntRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        subRecord.put(0, null);
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                aliasedSubRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = aliasedSubRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return aliasedSubRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
@@ -1,0 +1,159 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest10((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
+        if ((reuse)!= null) {
+            SplitRecordTest1 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1)(reuse));
+        } else {
+            SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
+        }
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest1 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest1 .put(2, record30);
+        return SplitRecordTest1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = FullRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        FullRecord.put(1, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        FullRecord.put(0, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = FullRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return FullRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
@@ -1,0 +1,181 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.FullRecord;
+import com.linkedin.avro.fastserde.generated.avro.StringRecord;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest20((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
+        if ((reuse)!= null) {
+            SplitRecordTest2 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2)(reuse));
+        } else {
+            SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
+        }
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        List<FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest2 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest2 .put(2, record30);
+        return SplitRecordTest2;
+    }
+
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        StringRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((StringRecord)(reuse));
+        } else {
+            IntRecord = new StringRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = IntRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        return IntRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((com.linkedin.avro.fastserde.generated.avro.IntRecord)(reuse));
+        } else {
+            IntRecord = new com.linkedin.avro.fastserde.generated.avro.IntRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.skipString();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return IntRecord;
+    }
+
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        FullRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((FullRecord)(reuse));
+        } else {
+            IntRecord = new FullRecord();
+        }
+        int unionIndex4 = (decoder.readIndex());
+        switch (unionIndex4) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = IntRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
+        }
+        int unionIndex5 = (decoder.readIndex());
+        switch (unionIndex5) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex5));
+        }
+        return IntRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        subRecord.put(0, null);
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                aliasedSubRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = aliasedSubRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return aliasedSubRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
@@ -1,0 +1,159 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest10((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
+        if ((reuse)!= null) {
+            SplitRecordTest1 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1)(reuse));
+        } else {
+            SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
+        }
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest1 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest1 .put(2, record30);
+        return SplitRecordTest1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = FullRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        FullRecord.put(1, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        FullRecord.put(0, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = FullRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return FullRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
@@ -1,0 +1,181 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.FullRecord;
+import com.linkedin.avro.fastserde.generated.avro.StringRecord;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest20((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
+        if ((reuse)!= null) {
+            SplitRecordTest2 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2)(reuse));
+        } else {
+            SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
+        }
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        List<FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest2 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest2 .put(2, record30);
+        return SplitRecordTest2;
+    }
+
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        StringRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((StringRecord)(reuse));
+        } else {
+            IntRecord = new StringRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = IntRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        return IntRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((com.linkedin.avro.fastserde.generated.avro.IntRecord)(reuse));
+        } else {
+            IntRecord = new com.linkedin.avro.fastserde.generated.avro.IntRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.skipString();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return IntRecord;
+    }
+
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        FullRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((FullRecord)(reuse));
+        } else {
+            IntRecord = new FullRecord();
+        }
+        int unionIndex4 = (decoder.readIndex());
+        switch (unionIndex4) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = IntRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
+        }
+        int unionIndex5 = (decoder.readIndex());
+        switch (unionIndex5) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex5));
+        }
+        return IntRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662.java
@@ -1,0 +1,147 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema intFieldField0;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_3149879252336907422_4539751468693059662(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.intFieldField0 = record10 .getField("intField").schema();
+        this.intField0 = record10 .getField("intField").schema();
+        this.subField1 = record10 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = subRecord.get(1);
+                if (oldString0 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex0));
+        }
+        subRecord.put(0, null);
+        return subRecord;
+    }
+
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                subRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = subRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    subRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    subRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex2));
+        }
+        return subRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422.java
@@ -1,0 +1,157 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema record10;
+    private final Schema subField0;
+    private final Schema record20;
+    private final Schema intField0;
+    private final Schema subField1;
+    private final Schema recordArray0;
+
+    public FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_4539751468693059662_3149879252336907422(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.record10 = readerSchema.getField("record1").schema();
+        this.subField0 = record10 .getField("subField").schema();
+        this.record20 = readerSchema.getField("record2").schema();
+        this.intField0 = record20 .getField("intField").schema();
+        this.subField1 = record20 .getField("subField").schema();
+        this.recordArray0 = readerSchema.getField("recordArray").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        List<IndexedRecord> recordArray1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
+        if (oldArray0 instanceof List) {
+            recordArray1 = ((List) oldArray0);
+            recordArray1 .clear();
+        } else {
+            recordArray1 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), recordArray0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object recordArrayArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
+        return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
+    }
+
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record10)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record10);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = aliasedSubRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    aliasedSubRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    aliasedSubRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex1));
+        }
+        return aliasedSubRecord;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord aliasedSubRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == record20)) {
+            aliasedSubRecord = ((IndexedRecord)(reuse));
+        } else {
+            aliasedSubRecord = new org.apache.avro.generic.GenericData.Record(record20);
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                aliasedSubRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = aliasedSubRecord.get(1);
+                if (oldString1 instanceof Utf8) {
+                    aliasedSubRecord.put(1, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    aliasedSubRecord.put(1, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex3));
+        }
+        return aliasedSubRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854.java
@@ -1,0 +1,159 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest1_SpecificDeserializer_1895547120338206469_999827040798143854(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest10((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
+        if ((reuse)!= null) {
+            SplitRecordTest1 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1)(reuse));
+        } else {
+            SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
+        }
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest1 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<com.linkedin.avro.fastserde.generated.avro.FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest1 .put(2, record30);
+        return SplitRecordTest1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = FullRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        FullRecord.put(1, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        FullRecord.put(0, null);
+        return FullRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
+        if ((reuse)!= null) {
+            FullRecord = ((com.linkedin.avro.fastserde.generated.avro.FullRecord)(reuse));
+        } else {
+            FullRecord = new com.linkedin.avro.fastserde.generated.avro.FullRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = FullRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    FullRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    FullRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                FullRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return FullRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469.java
@@ -1,0 +1,181 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.FullRecord;
+import com.linkedin.avro.fastserde.generated.avro.StringRecord;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2>
+{
+
+    private final Schema readerSchema;
+
+    public SplitRecordTest2_SpecificDeserializer_999827040798143854_1895547120338206469(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeSplitRecordTest20((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
+        if ((reuse)!= null) {
+            SplitRecordTest2 = ((com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2)(reuse));
+        } else {
+            SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
+        }
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        List<FullRecord> record30 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = SplitRecordTest2 .get(2);
+        if (oldArray0 instanceof List) {
+            record30 = ((List) oldArray0);
+            record30 .clear();
+        } else {
+            record30 = new ArrayList<FullRecord>(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object record3ArrayElementReuseVar0 = null;
+                if (oldArray0 instanceof GenericArray) {
+                    record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                }
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        SplitRecordTest2 .put(2, record30);
+        return SplitRecordTest2;
+    }
+
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        StringRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((StringRecord)(reuse));
+        } else {
+            IntRecord = new StringRecord();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        switch (unionIndex0) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString0 = IntRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString0)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
+        }
+        int unionIndex1 = (decoder.readIndex());
+        switch (unionIndex1) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.readInt();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex1));
+        }
+        return IntRecord;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((com.linkedin.avro.fastserde.generated.avro.IntRecord)(reuse));
+        } else {
+            IntRecord = new com.linkedin.avro.fastserde.generated.avro.IntRecord();
+        }
+        int unionIndex2 = (decoder.readIndex());
+        switch (unionIndex2) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                decoder.skipString();
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
+        }
+        int unionIndex3 = (decoder.readIndex());
+        switch (unionIndex3) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(0, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex3));
+        }
+        return IntRecord;
+    }
+
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        FullRecord IntRecord;
+        if ((reuse)!= null) {
+            IntRecord = ((FullRecord)(reuse));
+        } else {
+            IntRecord = new FullRecord();
+        }
+        int unionIndex4 = (decoder.readIndex());
+        switch (unionIndex4) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+            {
+                Object oldString1 = IntRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    IntRecord.put(0, (decoder).readString(((Utf8) oldString1)));
+                } else {
+                    IntRecord.put(0, (decoder).readString(null));
+                }
+                break;
+            }
+            default:
+                throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
+        }
+        int unionIndex5 = (decoder.readIndex());
+        switch (unionIndex5) {
+            case  0 :
+                decoder.readNull();
+                break;
+            case  1 :
+                IntRecord.put(1, (decoder.readInt()));
+                break;
+            default:
+                throw new RuntimeException(("Illegal union index for 'field2': "+ unionIndex5));
+        }
+        return IntRecord;
+    }
+
+}

--- a/avro-fastserde/src/test/avro/splitRecordTest1.avsc
+++ b/avro-fastserde/src/test/avro/splitRecordTest1.avsc
@@ -1,0 +1,52 @@
+{
+  "type": "record",
+  "name": "SplitRecordTest1",
+  "aliases": [
+    "com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2"
+  ],
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "doc": null,
+  "fields": [
+    {
+      "name": "record1",
+      "type": {
+        "type": "record",
+        "aliases": [
+          "com.linkedin.avro.fastserde.generated.avro.IntRecord",
+          "com.linkedin.avro.fastserde.generated.avro.StringRecord"
+        ],
+        "name": "FullRecord",
+        "doc": null,
+        "fields": [
+          {
+            "name": "field1",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          },
+          {
+            "name": "field2",
+            "type": [
+              "null",
+              "int"
+            ],
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "record2",
+      "type": "FullRecord"
+    },
+    {
+      "name": "record3",
+      "type": {
+        "type": "array",
+        "items": "FullRecord"
+      }
+    }
+  ]
+}

--- a/avro-fastserde/src/test/avro/splitRecordTest2.avsc
+++ b/avro-fastserde/src/test/avro/splitRecordTest2.avsc
@@ -1,0 +1,80 @@
+{
+  "type": "record",
+  "name": "SplitRecordTest2",
+  "aliases": ["com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1"],
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "doc": null,
+  "fields": [
+    {
+      "name": "record1",
+      "type": {
+        "type": "record",
+        "name": "StringRecord",
+        "aliases": [
+          "com.linkedin.avro.fastserde.generated.avro.FullRecord"
+        ],
+        "doc": null,
+        "fields": [
+          {
+            "name": "field1",
+            "type": [
+              "null",
+              "string"
+            ],
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "record2",
+      "type": {
+        "type": "record",
+        "name": "IntRecord",
+        "aliases": [
+          "com.linkedin.avro.fastserde.generated.avro.FullRecord"
+        ],
+        "doc": null,
+        "fields": [
+          {
+            "name": "field2",
+            "type": [
+              "null",
+              "int"
+            ],
+            "default": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "record3",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "FullRecord",
+          "doc": null,
+          "fields": [
+            {
+              "name": "field1",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "field2",
+              "type": [
+                "null",
+                "int"
+              ],
+              "default": null
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hi,

Recently we ran into this issue while doing some refactoring on our production schemas. The aim of the refactoring was to split the already existing record into two separate records preserving the backwards compatibility via the use of type aliases.

Example: record A with aliases B and C in the next version is changed into records B and C, both of them have an alias to A.

This resulted in faulty deserializers being generated, which were unable to read the data for both reading scenarios with schemas interchanged.

The fix for this bug required some changes around method reference caching in FastDeserializerGenerator and in various places the writer schema had to be altered with reader schema.

15f4495 contains the test cases with faulty deserializers code-gen
48e6b22 contains the fix with proper deserializers code-gen

cheers,
Peter
  