### PR TITLE
Add Schema.Field default value compatibility support in avro 1.4-1.10

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -90,6 +90,8 @@ public interface AvroAdapter {
 
   FieldBuilder cloneSchemaField(Schema.Field field);
 
+  FieldBuilder newFieldBuilder(String name);
+
   //code generation
 
   Collection<AvroGeneratedSourceCode> compile(

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/FieldBuilder.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/FieldBuilder.java
@@ -21,6 +21,8 @@ public interface FieldBuilder {
 
   FieldBuilder setDoc(String doc);
 
+  FieldBuilder setDefault(Object defaultValue);
+
   FieldBuilder setOrder(Order order);
 
   FieldBuilder copyFromField();

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Collection;
+import java.util.Map;
+import org.apache.avro.AvroRuntimeException;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.node.JsonNodeFactory;
+
+
+public class Jackson1Utils {
+  static final String BYTES_CHARSET = "ISO-8859-1";
+
+  /**
+   * toJsonNode takes in an arbitrary object and convert it into corresponding JsonNode
+   * @param datum input datum object
+   * @return generated JsonNode object.
+   */
+  public static JsonNode toJsonNode(Object datum) {
+    if (datum == null) {
+      return JsonNodeFactory.instance.nullNode();
+    } else if (datum instanceof byte[]) {
+      try {
+        return JsonNodeFactory.instance.textNode(new String((byte[]) datum, BYTES_CHARSET));
+      } catch (UnsupportedEncodingException e) {
+        throw new AvroRuntimeException(e);
+      }
+    } else if (datum instanceof CharSequence || datum instanceof Enum<?>) {
+      return JsonNodeFactory.instance.textNode(datum.toString());
+    } else if (datum instanceof Double) {
+      return JsonNodeFactory.instance.numberNode((Double) datum);
+    } else if (datum instanceof Float) {
+      return JsonNodeFactory.instance.numberNode((Float) datum);
+    } else if (datum instanceof Long) {
+      return JsonNodeFactory.instance.numberNode((Long) datum);
+    } else if (datum instanceof Integer) {
+      return JsonNodeFactory.instance.numberNode((Integer) datum);
+    } else if (datum instanceof Boolean) {
+      return JsonNodeFactory.instance.booleanNode((Boolean) datum);
+    } else if (datum instanceof Map) {
+      ObjectMapper mapper = new ObjectMapper();
+      return mapper.convertValue(datum, JsonNode.class);
+    } else if (datum instanceof Collection) {
+      ObjectMapper mapper = new ObjectMapper();
+      return mapper.convertValue(datum, JsonNode.class);
+    } else {
+      throw new AvroRuntimeException("Unknown datum class: " + datum.getClass());
+    }
+  }
+
+}

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -602,4 +602,28 @@ public class AvroCompatibilityHelper {
       return schema.getName();
     }
   }
+
+  /**
+   * Create a new schema field with provided arguments. This adds compatibility layer for {@link Schema.Field} before
+   * avro 1.9, which takes JsonNode as default value in constructor instead of Object.
+   * @param name the name of the field
+   * @param schema the schema of the field
+   * @param doc the doc of the field
+   * @param defaultValue the default value of the field. For avro 1.4-1.8, user should pass in a JsonNode. For avro 1.9
+   * and newer, user should pass in the default value object directly.
+   * @param order the order of the field.
+   * @return fully constructed Field instance
+   */
+  public static Schema.Field createSchemaField(String name, Schema schema, String doc, Object defaultValue, Schema.Field.Order order) {
+    FieldBuilder fieldBuilder = ADAPTER.newFieldBuilder(name);
+    fieldBuilder.setSchema(schema);
+    fieldBuilder.setDoc(doc);
+    fieldBuilder.setDefault(defaultValue);
+    fieldBuilder.setOrder(order);
+    return fieldBuilder.build();
+  }
+
+  public static Schema.Field createSchemaField(String name, Schema schema, String doc, Object defaultValue) {
+    return createSchemaField(name, schema, doc, defaultValue, Schema.Field.Order.ASCENDING);
+  }
 }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -248,6 +248,11 @@ public class Avro110Adapter implements AvroAdapter {
     }
 
     @Override
+    public FieldBuilder newFieldBuilder(String name) {
+        return new FieldBuilder110(name);
+    }
+
+    @Override
     public Collection<AvroGeneratedSourceCode> compile(
         Collection<Schema> toCompile,
         AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/FieldBuilder110.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/FieldBuilder110.java
@@ -12,14 +12,20 @@ import org.apache.avro.Schema.Field.Order;
 
 
 public class FieldBuilder110 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private Object _defaultVal;
   private Order _order;
 
   public FieldBuilder110(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder110(String name) {
+    _name = name;
   }
 
   @Override
@@ -34,6 +40,7 @@ public class FieldBuilder110 implements FieldBuilder {
     return this;
   }
 
+  @Override
   public FieldBuilder setDefault(Object defaultValue) {
     _defaultVal = defaultValue;
     return this;
@@ -58,6 +65,6 @@ public class FieldBuilder110 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -232,6 +232,11 @@ public class Avro14Adapter implements AvroAdapter {
   }
 
   @Override
+  public FieldBuilder newFieldBuilder(String name) {
+    return new FieldBuilder14(name);
+  }
+
+  @Override
   public Collection<AvroGeneratedSourceCode> compile(
       Collection<Schema> toCompile,
       AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/FieldBuilder14.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/FieldBuilder14.java
@@ -7,20 +7,27 @@
 package com.linkedin.avroutil1.compatibility.avro14;
 
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 import org.codehaus.jackson.JsonNode;
 
 
 public class FieldBuilder14 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private JsonNode _defaultVal;
   private Order _order;
 
   public FieldBuilder14(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder14(String name) {
+    _name = name;
   }
 
   @Override
@@ -33,6 +40,11 @@ public class FieldBuilder14 implements FieldBuilder {
   public FieldBuilder setDoc(String doc) {
     _doc = doc;
     return this;
+  }
+
+  @Override
+  public FieldBuilder setDefault(Object defaultValue) {
+    return setDefault(Jackson1Utils.toJsonNode(defaultValue));
   }
 
   public FieldBuilder setDefault(JsonNode defaultValue) {
@@ -59,6 +71,6 @@ public class FieldBuilder14 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -250,6 +250,11 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
+  public FieldBuilder newFieldBuilder(String name) {
+    return new FieldBuilder15(name);
+  }
+
+  @Override
   public Collection<AvroGeneratedSourceCode> compile(
       Collection<Schema> toCompile,
       AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/FieldBuilder15.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/FieldBuilder15.java
@@ -7,20 +7,27 @@
 package com.linkedin.avroutil1.compatibility.avro15;
 
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 import org.codehaus.jackson.JsonNode;
 
 
 public class FieldBuilder15 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private JsonNode _defaultVal;
   private Order _order;
 
   public FieldBuilder15(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder15(String name) {
+    _name = name;
   }
 
   @Override
@@ -33,6 +40,11 @@ public class FieldBuilder15 implements FieldBuilder {
   public FieldBuilder setDoc(String doc) {
     _doc = doc;
     return this;
+  }
+
+  @Override
+  public FieldBuilder setDefault(Object defaultValue) {
+    return setDefault(Jackson1Utils.toJsonNode(defaultValue));
   }
 
   public FieldBuilder setDefault(JsonNode defaultValue) {
@@ -59,6 +71,6 @@ public class FieldBuilder15 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -256,6 +256,11 @@ public class Avro16Adapter implements AvroAdapter {
   }
 
   @Override
+  public FieldBuilder newFieldBuilder(String name) {
+    return new FieldBuilder16(name);
+  }
+
+  @Override
   public Collection<AvroGeneratedSourceCode> compile(
       Collection<Schema> toCompile,
       AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/FieldBuilder16.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/FieldBuilder16.java
@@ -7,20 +7,27 @@
 package com.linkedin.avroutil1.compatibility.avro16;
 
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 import org.codehaus.jackson.JsonNode;
 
 
 public class FieldBuilder16 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private JsonNode _defaultVal;
   private Order _order;
 
   public FieldBuilder16(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder16(String name) {
+    _name = name;
   }
 
   @Override
@@ -33,6 +40,11 @@ public class FieldBuilder16 implements FieldBuilder {
   public FieldBuilder setDoc(String doc) {
     _doc = doc;
     return this;
+  }
+
+  @Override
+  public FieldBuilder setDefault(Object defaultValue) {
+    return setDefault(Jackson1Utils.toJsonNode(defaultValue));
   }
 
   public FieldBuilder setDefault(JsonNode defaultValue) {
@@ -59,6 +71,6 @@ public class FieldBuilder16 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -315,6 +315,11 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
+  public FieldBuilder newFieldBuilder(String name) {
+    return new FieldBuilder17(name);
+  }
+
+  @Override
   public Collection<AvroGeneratedSourceCode> compile(
       Collection<Schema> toCompile,
       AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/FieldBuilder17.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/FieldBuilder17.java
@@ -7,20 +7,27 @@
 package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 import org.codehaus.jackson.JsonNode;
 
 
 public class FieldBuilder17 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private JsonNode _defaultVal;
   private Order _order;
 
   public FieldBuilder17(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder17(String name) {
+    _name = name;
   }
 
   @Override
@@ -33,6 +40,11 @@ public class FieldBuilder17 implements FieldBuilder {
   public FieldBuilder setDoc(String doc) {
     _doc = doc;
     return this;
+  }
+
+  @Override
+  public FieldBuilder setDefault(Object defaultValue) {
+    return setDefault(Jackson1Utils.toJsonNode(defaultValue));
   }
 
   public FieldBuilder setDefault(JsonNode defaultValue) {
@@ -59,6 +71,6 @@ public class FieldBuilder17 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -253,6 +253,11 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
+  public FieldBuilder newFieldBuilder(String name) {
+    return new FieldBuilder18(name);
+  }
+
+  @Override
   public Collection<AvroGeneratedSourceCode> compile(
       Collection<Schema> toCompile,
       AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/FieldBuilder18.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/FieldBuilder18.java
@@ -7,20 +7,27 @@
 package com.linkedin.avroutil1.compatibility.avro18;
 
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 import org.codehaus.jackson.JsonNode;
 
 
 public class FieldBuilder18 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private JsonNode _defaultVal;
   private Order _order;
 
   public FieldBuilder18(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder18(String name) {
+    _name = name;
   }
 
   @Override
@@ -33,6 +40,11 @@ public class FieldBuilder18 implements FieldBuilder {
   public FieldBuilder setDoc(String doc) {
     _doc = doc;
     return this;
+  }
+
+  @Override
+  public FieldBuilder setDefault(Object defaultValue) {
+    return setDefault(Jackson1Utils.toJsonNode(defaultValue));
   }
 
   public FieldBuilder setDefault(JsonNode defaultValue) {
@@ -59,6 +71,6 @@ public class FieldBuilder18 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -251,6 +251,11 @@ public class Avro19Adapter implements AvroAdapter {
   }
 
   @Override
+  public FieldBuilder newFieldBuilder(String name) {
+    return new FieldBuilder19(name);
+  }
+
+  @Override
   public Collection<AvroGeneratedSourceCode> compile(
       Collection<Schema> toCompile,
       AvroVersion minSupportedVersion,

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/FieldBuilder19.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/FieldBuilder19.java
@@ -12,14 +12,20 @@ import org.apache.avro.Schema.Field.Order;
 
 
 public class FieldBuilder19 implements FieldBuilder {
-  private final Schema.Field _field;
+  private final String _name;
+  private Schema.Field _field;
   private Schema _schema;
   private String _doc;
   private Object _defaultVal;
   private Order _order;
 
   public FieldBuilder19(Schema.Field field) {
+    this(field.name());
     _field = field;
+  }
+
+  public FieldBuilder19(String name) {
+    _name = name;
   }
 
   @Override
@@ -34,6 +40,7 @@ public class FieldBuilder19 implements FieldBuilder {
     return this;
   }
 
+  @Override
   public FieldBuilder setDefault(Object defaultValue) {
     _defaultVal = defaultValue;
     return this;
@@ -58,6 +65,6 @@ public class FieldBuilder19 implements FieldBuilder {
 
   @Override
   public Schema.Field build() {
-    return new Schema.Field(_field.name(), _schema, _doc, _defaultVal, _order);
+    return new Schema.Field(_name, _schema, _doc, _defaultVal, _order);
   }
 }

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/AvroCompatibilityHelperAvro110Test.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/AvroCompatibilityHelperAvro110Test.java
@@ -7,8 +7,12 @@
 package com.linkedin.avroutil1.compatibility.avro110;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -41,4 +45,26 @@ public class AvroCompatibilityHelperAvro110Test {
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
   }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertNull(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultVal());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", field.defaultVal()).defaultVal(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> actualMapValue =
+        (Map<String, List<String>>) AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", field.defaultVal()).defaultVal();
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> actualListValue =
+        (List<List<String>>) AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", field.defaultVal()).defaultVal();
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
+  }
+
 }

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/AvroCompatibilityHelperAvro14Test.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/AvroCompatibilityHelperAvro14Test.java
@@ -7,9 +7,17 @@
 package com.linkedin.avroutil1.compatibility.avro14;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,5 +48,29 @@ public class AvroCompatibilityHelperAvro14Test {
     Object instance = AvroCompatibilityHelper.newInstance(Pojo.class, schema);
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
+  }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertTrue(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultValue().isNull());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", 1.0).defaultValue().getDoubleValue(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> defaultMapValue = Collections.singletonMap("dummyKey", Collections.singletonList("dummyValue"));
+    JsonNode actualJsonNode = AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", defaultMapValue).defaultValue();
+    Map<String, List<String>> actualMapValue = mapper.convertValue(actualJsonNode, new TypeReference<Map<String, List<String>>>(){});
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> defaultListValue = Collections.singletonList(Collections.singletonList("dummyElement"));
+    actualJsonNode = AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", defaultListValue).defaultValue();
+    List<List<String>> actualListValue = mapper.convertValue(actualJsonNode, new TypeReference<List<List<String>>>(){});
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
 }

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/AvroCompatibilityHelperAvro15Test.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/AvroCompatibilityHelperAvro15Test.java
@@ -7,9 +7,17 @@
 package com.linkedin.avroutil1.compatibility.avro15;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,5 +48,29 @@ public class AvroCompatibilityHelperAvro15Test {
     Object instance = AvroCompatibilityHelper.newInstance(Pojo.class, schema);
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
+  }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertTrue(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultValue().isNull());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", 1.0).defaultValue().getDoubleValue(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> defaultMapValue = Collections.singletonMap("dummyKey", Collections.singletonList("dummyValue"));
+    JsonNode actualJsonNode = AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", defaultMapValue).defaultValue();
+    Map<String, List<String>> actualMapValue = mapper.convertValue(actualJsonNode, new TypeReference<Map<String, List<String>>>(){});
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> defaultListValue = Collections.singletonList(Collections.singletonList("dummyElement"));
+    actualJsonNode = AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", defaultListValue).defaultValue();
+    List<List<String>> actualListValue = mapper.convertValue(actualJsonNode, new TypeReference<List<List<String>>>(){});
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
 }

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/AvroCompatibilityHelperAvro16Test.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/AvroCompatibilityHelperAvro16Test.java
@@ -7,9 +7,17 @@
 package com.linkedin.avroutil1.compatibility.avro16;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,5 +48,29 @@ public class AvroCompatibilityHelperAvro16Test {
     Object instance = AvroCompatibilityHelper.newInstance(Pojo.class, schema);
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
+  }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertTrue(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultValue().isNull());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", 1.0).defaultValue().getDoubleValue(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> defaultMapValue = Collections.singletonMap("dummyKey", Collections.singletonList("dummyValue"));
+    JsonNode actualJsonNode = AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", defaultMapValue).defaultValue();
+    Map<String, List<String>> actualMapValue = mapper.convertValue(actualJsonNode, new TypeReference<Map<String, List<String>>>(){});
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> defaultListValue = Collections.singletonList(Collections.singletonList("dummyElement"));
+    actualJsonNode = AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", defaultListValue).defaultValue();
+    List<List<String>> actualListValue = mapper.convertValue(actualJsonNode, new TypeReference<List<List<String>>>(){});
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
 }

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperAvro17Test.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperAvro17Test.java
@@ -7,9 +7,17 @@
 package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,5 +48,29 @@ public class AvroCompatibilityHelperAvro17Test {
     Object instance = AvroCompatibilityHelper.newInstance(Pojo.class, schema);
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
+  }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertTrue(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultValue().isNull());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", 1.0).defaultValue().getDoubleValue(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> defaultMapValue = Collections.singletonMap("dummyKey", Collections.singletonList("dummyValue"));
+    JsonNode actualJsonNode = AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", defaultMapValue).defaultValue();
+    Map<String, List<String>> actualMapValue = mapper.convertValue(actualJsonNode, new TypeReference<Map<String, List<String>>>(){});
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> defaultListValue = Collections.singletonList(Collections.singletonList("dummyElement"));
+    actualJsonNode = AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", defaultListValue).defaultValue();
+    List<List<String>> actualListValue = mapper.convertValue(actualJsonNode, new TypeReference<List<List<String>>>(){});
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
 }

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/AvroCompatibilityHelperAvro18Test.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/AvroCompatibilityHelperAvro18Test.java
@@ -7,9 +7,17 @@
 package com.linkedin.avroutil1.compatibility.avro18;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,5 +48,29 @@ public class AvroCompatibilityHelperAvro18Test {
     Object instance = AvroCompatibilityHelper.newInstance(Pojo.class, schema);
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
+  }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertTrue(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultValue().isNull());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", 1.0).defaultValue().getDoubleValue(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> defaultMapValue = Collections.singletonMap("dummyKey", Collections.singletonList("dummyValue"));
+    JsonNode actualJsonNode = AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", defaultMapValue).defaultValue();
+    Map<String, List<String>> actualMapValue = mapper.convertValue(actualJsonNode, new TypeReference<Map<String, List<String>>>(){});
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> defaultListValue = Collections.singletonList(Collections.singletonList("dummyElement"));
+    actualJsonNode = AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", defaultListValue).defaultValue();
+    List<List<String>> actualListValue = mapper.convertValue(actualJsonNode, new TypeReference<List<List<String>>>(){});
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
 }

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/AvroCompatibilityHelperAvro19Test.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/AvroCompatibilityHelperAvro19Test.java
@@ -7,8 +7,12 @@
 package com.linkedin.avroutil1.compatibility.avro19;
 
 import com.linkedin.avroutil1.Pojo;
+import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -40,5 +44,26 @@ public class AvroCompatibilityHelperAvro19Test {
     Object instance = AvroCompatibilityHelper.newInstance(Pojo.class, schema);
     Assert.assertNotNull(instance);
     Assert.assertTrue(instance instanceof  Pojo);
+  }
+
+  @Test
+  public void testCreateSchemaFieldWithProvidedDefaultValue() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    // Test null default value
+    Schema.Field field = schema.getField("unionWithNullDefault");
+    Assert.assertNull(AvroCompatibilityHelper.createSchemaField("unionWithNullDefault", field.schema(), "", null).defaultVal());
+    // Test primitive default value
+    field = schema.getField("doubleFieldWithDefault");
+    Assert.assertEquals(AvroCompatibilityHelper.createSchemaField("doubleFieldWithDefault", field.schema(), "", field.defaultVal()).defaultVal(), 1.0);
+    // Test map default value
+    field = schema.getField("mapOfArrayWithDefault");
+    Map<String, List<String>> actualMapValue =
+        (Map<String, List<String>>) AvroCompatibilityHelper.createSchemaField("mapOfArrayWithDefault", field.schema(), "", field.defaultVal()).defaultVal();
+    Assert.assertEquals(actualMapValue.get("dummyKey").get(0), "dummyValue");
+    // Test array default value
+    field = schema.getField("arrayOfArrayWithDefault");
+    List<List<String>> actualListValue =
+        (List<List<String>>) AvroCompatibilityHelper.createSchemaField("arrayOfArrayWithDefault", field.schema(), "", field.defaultVal()).defaultVal();
+    Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
 }

--- a/helper/tests/helper-tests-common/src/main/resources/RecordWithRecursiveTypesAndDefaults.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/RecordWithRecursiveTypesAndDefaults.avsc
@@ -1,0 +1,43 @@
+{
+  "type": "record",
+  "namespace": "com.acme",
+  "name": "HasDefaults",
+  "fields": [
+    {
+      "name": "doubleFieldWithDefault",
+      "type": "double",
+      "default": 1.0
+    },
+    {
+      "name": "unionWithNullDefault",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      "name": "mapOfArrayWithDefault",
+      "type": {
+        "type": "map",
+        "values": {
+          "type": "array",
+          "items": "string"
+        }
+      },
+      "default": {
+        "dummyKey": ["dummyValue"]
+      }
+    },
+    {
+      "name": "arrayOfArrayWithDefault",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": "string"
+        }
+      },
+      "default": [
+        ["dummyElement"]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Before avro 1.9, the default value in **Schema.Field** constructor takes in **JsonNode** object. Since avro 1.9, it starts taking **Object** as its default value. 
This PR adds a helper function **createSchemaField** in **AvroCompatibilityHelper** to create a Schema.Field instance for all avro versions with the help of FieldBuilder interface.
