### PR TITLE
remove references to new avr exception classes from builders for broader compatibility

### DIFF
--- a/helper/tests/codegen-110/build.gradle
+++ b/helper/tests/codegen-110/build.gradle
@@ -25,6 +25,7 @@ sourceSets {
       srcDir 'src/main/java'
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -65,6 +66,25 @@ task runCompatAvroCodegen {
   }
 }
 
+task runCompatAvroCodegenWithBuilders {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders/java/main",
+                "-min", "AVRO_1_6"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -88,8 +108,9 @@ jar {
 
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, copyCompatAvroCodeToResources
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, copyCompatAvroCodeToResources
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-110/src/main/compat-avro-w-builders/under110wbuilders/SimpleRecord.avsc
+++ b/helper/tests/codegen-110/src/main/compat-avro-w-builders/under110wbuilders/SimpleRecord.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "namespace": "under110wbuilders",
+  "name": "SimpleRecord",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    }
+  ]
+}

--- a/helper/tests/codegen-18/build.gradle
+++ b/helper/tests/codegen-18/build.gradle
@@ -25,6 +25,7 @@ sourceSets {
       srcDir 'src/main/java'
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -64,6 +65,25 @@ task runCompatAvroCodegen {
   }
 }
 
+task runCompatAvroCodegenWithBuilders {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders/java/main",
+                "-min", "AVRO_1_6"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -87,8 +107,9 @@ jar {
 
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-18/src/main/compat-avro-w-builders/under18wbuilders/SimpleRecord.avsc
+++ b/helper/tests/codegen-18/src/main/compat-avro-w-builders/under18wbuilders/SimpleRecord.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "namespace": "under18wbuilders",
+  "name": "SimpleRecord",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    }
+  ]
+}

--- a/helper/tests/codegen-19/build.gradle
+++ b/helper/tests/codegen-19/build.gradle
@@ -25,6 +25,7 @@ sourceSets {
       srcDir 'src/main/java'
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -64,6 +65,25 @@ task runCompatAvroCodegen {
   }
 }
 
+task runCompatAvroCodegenWithBuilders {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders/java/main",
+                "-min", "AVRO_1_6"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -87,8 +107,9 @@ jar {
 
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, copyCompatAvroCodeToResources
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, copyCompatAvroCodeToResources
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-19/src/main/compat-avro-w-builders/under19wbuilders/SimpleRecord.avsc
+++ b/helper/tests/codegen-19/src/main/compat-avro-w-builders/under19wbuilders/SimpleRecord.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "namespace": "under19wbuilders",
+  "name": "SimpleRecord",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    }
+  ]
+}

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110BuildersTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110BuildersTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro110;
+
+import org.apache.avro.AvroMissingFieldException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class Avro110BuildersTest {
+
+    @Test (expectedExceptions = AvroMissingFieldException.class)
+    public void demoDefaultValueExceptionOnBuild() {
+        by110.SimpleRecord.Builder builder = by110.SimpleRecord.newBuilder();
+        //the single field in this schema has no default value, and we didnt populate it
+        builder.build();
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder19() {
+        try {
+            under19wbuilders.SimpleRecord.Builder builder = under19wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroMissingFieldException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder110() {
+        try {
+            under110wbuilders.SimpleRecord.Builder builder = under110wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroMissingFieldException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+}

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17BuildersTest.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17BuildersTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro17;
+
+import by19.SimpleRecord;
+import org.apache.avro.AvroRuntimeException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class Avro17BuildersTest {
+
+    @Test(expectedExceptions = NoClassDefFoundError.class)
+    public void demoAvro19BuildersDontWork() {
+        SimpleRecord.Builder builder = SimpleRecord.newBuilder();
+        //the single field in this schema has no default value, and we didnt populate it
+        builder.build();
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder19() {
+        try {
+            under19wbuilders.SimpleRecord.Builder builder = under19wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroRuntimeException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder110() {
+        try {
+            under110wbuilders.SimpleRecord.Builder builder = under110wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroRuntimeException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+}

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18BuildersTest.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18BuildersTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro18;
+
+import org.apache.avro.AvroRuntimeException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class Avro18BuildersTest {
+
+    @Test
+    public void demoAvro19BuildersDontWork() {
+        try {
+            by19.SimpleRecord.Builder builder = by19.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            //but the exception it tries to throw doesnt exist under 1.8
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (NoClassDefFoundError expected) {
+            Assert.assertTrue(expected.getMessage().contains("AvroMissingFieldException"));
+        }
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder19() {
+        try {
+            under19wbuilders.SimpleRecord.Builder builder = under19wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroRuntimeException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder110() {
+        try {
+            under110wbuilders.SimpleRecord.Builder builder = under110wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroRuntimeException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+}

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19BuildersTest.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19BuildersTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro19;
+
+import org.apache.avro.AvroMissingFieldException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class Avro19BuildersTest {
+
+    @Test
+    public void testCompatibleBuildersUnder19() {
+        try {
+            under19wbuilders.SimpleRecord.Builder builder = under19wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroMissingFieldException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+
+    @Test
+    public void testCompatibleBuildersUnder110() {
+        try {
+            under110wbuilders.SimpleRecord.Builder builder = under110wbuilders.SimpleRecord.newBuilder();
+            //the single field in this schema has no default value, and we didnt populate it
+            builder.build();
+            Assert.fail("expected to throw");
+        } catch (AvroMissingFieldException expected) {
+            Assert.assertTrue(expected.getMessage().contains("has no default"));
+        }
+    }
+}


### PR DESCRIPTION
addresses #151

this code replaces this bit:
```java
catch (org.apache.avro.AvroMissingFieldException e) {
   throw e;
} catch (java.lang.Exception e) {
   throw new org.apache.avro.AvroRuntimeException(e);
}
```
which references AvroMissingFieldException - that only exists in avro 1.9+ - with this:
```java
catch (java.lang.Exception e) {
   throw e instanceof org.apache.avro.AvroRuntimeException ? (org.apache.avro.AvroRuntimeException) e : new org.apache.avro.AvroRuntimeException(e);
}
```