### PR TITLE
Spotbugs rules for GenericData.Fixed and Schema.Field instantiations

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -646,8 +646,8 @@ public class AvroCompatibilityHelper {
    * @param name the name of the field
    * @param schema the schema of the field
    * @param doc the doc of the field
-   * @param defaultValue the default value of the field. For avro 1.4-1.8, user should pass in a JsonNode. For avro 1.9
-   * and newer, user should pass in the default value object directly.
+   * @param defaultValue the default value of the field. For avro 1.4-1.8, user should pass in a jackson1 JsonNode.
+   *                     For avro 1.9 and newer, user should pass in the default value object directly.
    * @param order the order of the field.
    * @return fully constructed Field instance
    */

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -440,7 +440,7 @@ public class AvroCompatibilityHelper {
    * @param fixedSchema fixed schema
    * @return a new {@link org.apache.avro.generic.GenericData.Fixed} with a value of all zeroes of the correct size
    */
-  public static GenericData.Fixed newFixedField(Schema fixedSchema) {
+  public static GenericData.Fixed newFixed(Schema fixedSchema) {
     assertAvroAvailable();
     return ADAPTER.newFixedField(fixedSchema);
   }
@@ -451,9 +451,32 @@ public class AvroCompatibilityHelper {
    * @param contents initial contents of the instance.
    * @return a new {@link org.apache.avro.generic.GenericData.Fixed}
    */
-  public static GenericData.Fixed newFixedField(Schema fixedSchema, byte[] contents) {
+  public static GenericData.Fixed newFixed(Schema fixedSchema, byte[] contents) {
     assertAvroAvailable();
     return ADAPTER.newFixedField(fixedSchema, contents);
+  }
+
+  /**
+   * creates a new {@link org.apache.avro.generic.GenericData.Fixed} of the given schema with a value of zeroes
+   * @param fixedSchema fixed schema
+   * @return a new {@link org.apache.avro.generic.GenericData.Fixed} with a value of all zeroes of the correct size
+   * @deprecated use {@link #newFixed(Schema)}
+   */
+  @Deprecated
+  public static GenericData.Fixed newFixedField(Schema fixedSchema) {
+    return newFixed(fixedSchema);
+  }
+
+  /**
+   * creates a new {@link org.apache.avro.generic.GenericData.Fixed} of the given schema with the given value
+   * @param fixedSchema fixed schema
+   * @param contents initial contents of the instance.
+   * @return a new {@link org.apache.avro.generic.GenericData.Fixed}
+   * @deprecated use {@link #newFixed(Schema, byte[])}
+   */
+  @Deprecated
+  public static GenericData.Fixed newFixedField(Schema fixedSchema, byte[] contents) {
+    return newFixed(fixedSchema, contents);
   }
 
   public static boolean fieldHasDefault(Schema.Field field) {

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperGenericUtilMethodsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperGenericUtilMethodsTest.java
@@ -39,15 +39,15 @@ public class AvroCompatibilityHelperGenericUtilMethodsTest {
     SchemaParseResult result = AvroCompatibilityHelper.parse(avsc, SchemaParseConfiguration.STRICT, null);
     Schema schema = result.getMainSchema();
 
-    GenericData.Fixed fixed = AvroCompatibilityHelper.newFixedField(schema, new byte[]{1, 2, 3});
+    GenericData.Fixed fixed = AvroCompatibilityHelper.newFixed(schema, new byte[]{1, 2, 3});
     Assert.assertNotNull(fixed);
     Assert.assertEquals(fixed.bytes(), new byte[] {1, 2, 3});
 
-    fixed = AvroCompatibilityHelper.newFixedField(schema, null);
+    fixed = AvroCompatibilityHelper.newFixed(schema, null);
     Assert.assertNotNull(fixed);
     Assert.assertNull(fixed.bytes());
 
-    fixed = AvroCompatibilityHelper.newFixedField(schema);
+    fixed = AvroCompatibilityHelper.newFixed(schema);
     Assert.assertNotNull(fixed);
     Assert.assertEquals(fixed.bytes(), new byte[] {0, 0, 0});
   }

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/PropAccessTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/PropAccessTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import com.linkedin.avroutil1.TestUtil;
+import org.apache.avro.Schema;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PropAccessTest {
+
+    @Test
+    public void testSchemaStringPropAccess() throws Exception {
+        String avsc = TestUtil.load("RecordWithFieldProps.avsc");
+        Schema schema = Schema.parse(avsc);
+        Schema.Field originalField = schema.getField("stringField");
+
+        //show that can access string props under all avro
+
+        Assert.assertEquals(originalField.getProp("stringProp"), "stringValue");
+
+        originalField.addProp("moreStringProp", "moreStringValue");
+        Assert.assertEquals(originalField.getProp("moreStringProp"), "moreStringValue");
+    }
+}

--- a/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/FixedInstantiationDetector.java
+++ b/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/FixedInstantiationDetector.java
@@ -12,13 +12,13 @@ import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
 import org.apache.bcel.Const;
 
 /**
- * detects direct instantiations of GenericData.EnumSymbol, the constructor of which
- * has changed in avro 1.5+
+ * detects direct instantiations of GenericData.Fixed, the constructor of which
+ * has changed in 1.5+
  */
-public class EnumSymbolInstantiationDetector extends OpcodeStackDetector {
+public class FixedInstantiationDetector extends OpcodeStackDetector {
     private final BugReporter bugReporter;
 
-    public EnumSymbolInstantiationDetector(BugReporter bugReporter) {
+    public FixedInstantiationDetector(BugReporter bugReporter) {
         this.bugReporter = bugReporter;
     }
 
@@ -27,11 +27,11 @@ public class EnumSymbolInstantiationDetector extends OpcodeStackDetector {
         if (seen != Const.INVOKESPECIAL) {
             return;
         }
-        if (getClassConstantOperand().equals("org/apache/avro/generic/GenericData$EnumSymbol") &&
+        if (getClassConstantOperand().equals("org/apache/avro/generic/GenericData$Fixed") &&
                 getMethodDescriptorOperand().getName().equals("<init>")
         ) {
-            // constructor call for EnumSymbol
-            BugInstance bug = new BugInstance(this, "ENUMSYMBOL_INSTANTIATION", NORMAL_PRIORITY)
+            // constructor call for Fixed
+            BugInstance bug = new BugInstance(this, "FIXED_INSTANTIATION", NORMAL_PRIORITY)
                     .addClassAndMethod(this)
                     .addSourceLine(this, getPC());
             bugReporter.reportBug(bug);

--- a/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/PropAccessDetector.java
+++ b/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/PropAccessDetector.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.spotbugs;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import edu.umd.cs.findbugs.classfile.MethodDescriptor;
+import org.apache.bcel.Const;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * detects access to the following methods on org.apache.avro.Schema,
+ * org.apache.avro.Schema#Field and org.apache.avro.JsonProperties:
+ * <ul>
+ *     <li>getJsonProp() - returns jackson1 JsonNode in avro 1.7.3, became private in 1.9 (and moved to jackson2)</li>
+ *     <li>getObjectProp() - in avro 1.8+</li>
+ *     <li>addProp(JsonNode) - uses jackson1 in avro 1.7.3, became private in 1.9 (and moved to jackson2)</li>
+ *     <li>addProp(Object) - in avro 1.8+</li>
+ *     <li>props() - avro 1.6 to 1.8</li>
+ *     <li>getJsonProps() - uses jackson1 in avro 1.7.3 to 1.8</li>
+ *     <li>getObjectProps() - in avro 1.8+</li>
+ *     <li>addAllProps() - in avro 1.9+</li>
+ * </ul>
+ * the getProp(Str) and addProp(Str) methods exist in all avro versions (hence are compatible),
+ * but only operate on string props
+ */
+public class PropAccessDetector extends OpcodeStackDetector {
+    private final BugReporter bugReporter;
+    private final static Set<String> CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "org/apache/avro/Schema",
+            "org/apache/avro/Schema$Field",
+            "org/apache/avro/JsonProperties"
+    )));
+    private final static Set<String> METHOD_NAMES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            "getProps",
+            "getJsonProps",
+            "getObjectProps",
+            "getJsonProp",
+            "getObjectProp",
+            "addAllProps"
+    )));
+
+    public PropAccessDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen != Const.INVOKEVIRTUAL) {
+            return;
+        }
+        String classConstantOperand = getClassConstantOperand();
+        if (!CLASSES.contains(classConstantOperand)) {
+            return;
+        }
+        MethodDescriptor method = getMethodDescriptorOperand();
+        String methodName = method.getName();
+        boolean fileBug = false;
+        if (METHOD_NAMES.contains(methodName)) {
+            fileBug = true;
+        } else if (methodName.equals("addProp")) {
+            //make sure its NOT the string prop one
+            String signature = method.getSignature();
+            if (signature.contains("JsonNode") || signature.contains("Object")) {
+                fileBug = true;
+            }
+        }
+
+        if (fileBug) {
+            // incompatible prop access
+            BugInstance bug = new BugInstance(this, "PROP_ACCESS", NORMAL_PRIORITY)
+                    .addClassAndMethod(this)
+                    .addSourceLine(this, getPC());
+            bugReporter.reportBug(bug);
+        }
+    }
+}

--- a/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/SchemaFieldInstantiationDetector.java
+++ b/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/SchemaFieldInstantiationDetector.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.spotbugs;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import org.apache.bcel.Const;
+
+/**
+ * detects direct instantiations of Schema.Field, the constructor of which
+ * has changed in avro 1.8 and again incompatibly in avro 1.9+
+ */
+public class SchemaFieldInstantiationDetector extends OpcodeStackDetector {
+    private final BugReporter bugReporter;
+
+    public SchemaFieldInstantiationDetector(BugReporter bugReporter) {
+        this.bugReporter = bugReporter;
+    }
+
+    @Override
+    public void sawOpcode(int seen) {
+        if (seen != Const.INVOKESPECIAL) {
+            return;
+        }
+        if (getClassConstantOperand().equals("org/apache/avro/Schema$Field") &&
+                getMethodDescriptorOperand().getName().equals("<init>")
+        ) {
+            // constructor call for Field
+            BugInstance bug = new BugInstance(this, "SCHEMAFIELD_INSTANTIATION", NORMAL_PRIORITY)
+                    .addClassAndMethod(this)
+                    .addSourceLine(this, getPC());
+            bugReporter.reportBug(bug);
+        }
+    }
+}

--- a/spotbugs-plugin/src/main/resources/findbugs.xml
+++ b/spotbugs-plugin/src/main/resources/findbugs.xml
@@ -16,6 +16,7 @@
     <Detector class="com.linkedin.avroutil1.spotbugs.JsonDecoderViaDecoderFactoryDetector" reports="JSON_DECODER_FACTORY_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.JsonEncoderInstantiationDetector" reports="JSON_ENCODER_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.OldSchemaConstructableUsageDetector" reports="OLD_SCHEMACONSTRUCTABLE_USAGE" speed="fast" />
+    <Detector class="com.linkedin.avroutil1.spotbugs.SchemaFieldInstantiationDetector" reports="SCHEMAFIELD_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.SpecificDataNewInstanceUsageDetector" reports="SPECIFICDATA_NEWINSTANCE_USAGE" speed="fast" />
 
     <BugPattern type="BINARY_DECODER_INSTANTIATION" category="AVRO" abbrev="BDI"/>
@@ -28,6 +29,7 @@
     <BugPattern type="JSON_DECODER_FACTORY_INSTANTIATION" category="AVRO" abbrev="JDFI"/>
     <BugPattern type="JSON_ENCODER_INSTANTIATION" category="AVRO" abbrev="JEI"/>
     <BugPattern type="OLD_SCHEMACONSTRUCTABLE_USAGE" category="AVRO" abbrev="OSCI"/>
+    <BugPattern type="SCHEMAFIELD_INSTANTIATION" category="AVRO" abbrev="SFI"/>
     <BugPattern type="SPECIFICDATA_NEWINSTANCE_USAGE" category="AVRO" abbrev="SDNI"/>
 
 </FindbugsPlugin>

--- a/spotbugs-plugin/src/main/resources/findbugs.xml
+++ b/spotbugs-plugin/src/main/resources/findbugs.xml
@@ -16,6 +16,7 @@
     <Detector class="com.linkedin.avroutil1.spotbugs.JsonDecoderViaDecoderFactoryDetector" reports="JSON_DECODER_FACTORY_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.JsonEncoderInstantiationDetector" reports="JSON_ENCODER_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.OldSchemaConstructableUsageDetector" reports="OLD_SCHEMACONSTRUCTABLE_USAGE" speed="fast" />
+    <Detector class="com.linkedin.avroutil1.spotbugs.PropAccessDetector" reports="PROP_ACCESS" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.SchemaFieldInstantiationDetector" reports="SCHEMAFIELD_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.SpecificDataNewInstanceUsageDetector" reports="SPECIFICDATA_NEWINSTANCE_USAGE" speed="fast" />
 
@@ -29,6 +30,7 @@
     <BugPattern type="JSON_DECODER_FACTORY_INSTANTIATION" category="AVRO" abbrev="JDFI"/>
     <BugPattern type="JSON_ENCODER_INSTANTIATION" category="AVRO" abbrev="JEI"/>
     <BugPattern type="OLD_SCHEMACONSTRUCTABLE_USAGE" category="AVRO" abbrev="OSCI"/>
+    <BugPattern type="PROP_ACCESS" category="AVRO" abbrev="PA"/>
     <BugPattern type="SCHEMAFIELD_INSTANTIATION" category="AVRO" abbrev="SFI"/>
     <BugPattern type="SPECIFICDATA_NEWINSTANCE_USAGE" category="AVRO" abbrev="SDNI"/>
 

--- a/spotbugs-plugin/src/main/resources/findbugs.xml
+++ b/spotbugs-plugin/src/main/resources/findbugs.xml
@@ -10,6 +10,7 @@
     <Detector class="com.linkedin.avroutil1.spotbugs.BinaryEncoderInstantiationDetector" reports="BINARY_ENCODER_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.EnumSymbolInstantiationDetector" reports="ENUMSYMBOL_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.FieldDefaultValueAccessDetector" reports="FIELD_DEFAULT_VALUE_ACCESS" speed="fast" />
+    <Detector class="com.linkedin.avroutil1.spotbugs.FixedInstantiationDetector" reports="FIXED_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.InstanceofGenericRecordDetector" reports="INSTANCEOF_GENERICRECORD" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.JsonDecoderInstantiationDetector" reports="JSON_DECODER_INSTANTIATION" speed="fast" />
     <Detector class="com.linkedin.avroutil1.spotbugs.JsonDecoderViaDecoderFactoryDetector" reports="JSON_DECODER_FACTORY_INSTANTIATION" speed="fast" />
@@ -21,6 +22,7 @@
     <BugPattern type="BINARY_ENCODER_INSTANTIATION" category="AVRO" abbrev="BEI"/>
     <BugPattern type="ENUMSYMBOL_INSTANTIATION" category="AVRO" abbrev="ESI"/>
     <BugPattern type="FIELD_DEFAULT_VALUE_ACCESS" category="AVRO" abbrev="FDVA"/>
+    <BugPattern type="FIXED_INSTANTIATION" category="AVRO" abbrev="FI"/>
     <BugPattern type="INSTANCEOF_GENERICRECORD" category="AVRO" abbrev="IOGR"/>
     <BugPattern type="JSON_DECODER_INSTANTIATION" category="AVRO" abbrev="JDI"/>
     <BugPattern type="JSON_DECODER_FACTORY_INSTANTIATION" category="AVRO" abbrev="JDFI"/>

--- a/spotbugs-plugin/src/main/resources/messages.xml
+++ b/spotbugs-plugin/src/main/resources/messages.xml
@@ -29,6 +29,11 @@
             detects access to Schema.Field default value method(s)
         </Details>
     </Detector>
+    <Detector class="com.linkedin.avroutil1.spotbugs.FixedInstantiationDetector">
+        <Details>
+            detects direct instantiations of org.apache.avro.generic.GenericData$Fixed
+        </Details>
+    </Detector>
     <Detector class="com.linkedin.avroutil1.spotbugs.InstanceofGenericRecordDetector">
         <Details>
             detects "instanceof GenericRecord" tests
@@ -119,6 +124,21 @@
       org.apache.avro.Schema#Field.defaultValue() returns a jackson 1 JsonNode in avro < 1.9.
       its been deprecated in 1.8 and replaced with defaultVal(), which returns a java wrapper
       or other object. in 1.9+ its been made package-protected and now returns jackson 2 JsonNodes
+   </p>
+]]>
+        </Details>
+    </BugPattern>
+    <BugPattern type="FIXED_INSTANTIATION">
+        <ShortDescription>direct Fixed instantiation</ShortDescription>
+        <LongDescription>
+            direct instantiations of org.apache.avro.generic.GenericData$Fixed, which was incompatibly changed in avro 1.5
+        </LongDescription>
+        <Details>
+            <![CDATA[
+   <p>
+      org.apache.avro.generic.GenericData$Fixed is constructed using only the byte[] contents before avro 1.5
+      but requires a Schema argument in 1.5+, as such there's no way to do this across all avro versions.
+      use AvroCompatibilityHelper.newFixed()
    </p>
 ]]>
         </Details>
@@ -220,6 +240,7 @@
     <BugCode abbrev="BDI">BinaryDecoder instantiation</BugCode>
     <BugCode abbrev="BEI">BinaryEncoder instantiation</BugCode>
     <BugCode abbrev="ESI">EnumSymbol instantiation</BugCode>
+    <BugCode abbrev="FI">Fixed instantiation</BugCode>
     <BugCode abbrev="IOGR">instanceof GenericRecord</BugCode>
     <BugCode abbrev="JDI">JsonDecoder instantiation</BugCode>
     <BugCode abbrev="JDFI">JsonDecoder factory instantiation</BugCode>

--- a/spotbugs-plugin/src/main/resources/messages.xml
+++ b/spotbugs-plugin/src/main/resources/messages.xml
@@ -59,6 +59,11 @@
             detects usage of org.apache.avro.specific.SpecificDatumReader$SchemaConstructable
         </Details>
     </Detector>
+    <Detector class="com.linkedin.avroutil1.spotbugs.PropAccessDetector">
+        <Details>
+            detects usage of incompatible schema/field props APIs
+        </Details>
+    </Detector>
     <Detector class="com.linkedin.avroutil1.spotbugs.SchemaFieldInstantiationDetector">
         <Details>
             detects direct instantiations of org.apache.avro.Schema$Field
@@ -225,6 +230,31 @@
 ]]>
         </Details>
     </BugPattern>
+    <BugPattern type="PROP_ACCESS">
+        <ShortDescription>incompatible schema/field props access</ShortDescription>
+        <LongDescription>
+            usage of schema/field props APIs that are not compatible across avro versions
+        </LongDescription>
+        <Details>
+            <![CDATA[
+   <p>
+      detects access to the following methods on Schema, Schema$Field and JsonProperties:
+      <ul>
+         <li>getJsonProp() - returns jackson1 JsonNode in avro 1.7.3, became private in 1.9 (and moved to jackson2)</li>
+         <li>getObjectProp() - in avro 1.8+</li>
+         <li>addProp(JsonNode) - uses jackson1 in avro 1.7.3, became private in 1.9 (and moved to jackson2)</li>
+         <li>addProp(Object) - in avro 1.8+</li>
+         <li>props() - avro 1.6 to 1.8</li>
+         <li>getJsonProps() - uses jackson1 in avro 1.7.3 to 1.8</li>
+         <li>getObjectProps() - in avro 1.8, became private in 1.9</li>
+         <li>addAllProps() - in avro 1.9+</li>
+      </ul>
+      NOTE: the getProp(Str) and addProp(Str) methods exist in all avro versions (hence are compatible),
+      but only operate on string props
+   </p>
+]]>
+        </Details>
+    </BugPattern>
     <BugPattern type="SCHEMAFIELD_INSTANTIATION">
         <ShortDescription>direct Schema.Field instantiation</ShortDescription>
         <LongDescription>
@@ -266,6 +296,7 @@
     <BugCode abbrev="JDFI">JsonDecoder factory instantiation</BugCode>
     <BugCode abbrev="JEI">JsonEncoder instantiation</BugCode>
     <BugCode abbrev="OSCI">Old SchemaConstructable usage</BugCode>
+    <BugCode abbrev="PA">incompatible prop access</BugCode>
     <BugCode abbrev="SDNI">SecificData.newInstance() usage</BugCode>
     <BugCode abbrev="SFI">Schema.Field instantiation</BugCode>
 </MessageCollection>

--- a/spotbugs-plugin/src/main/resources/messages.xml
+++ b/spotbugs-plugin/src/main/resources/messages.xml
@@ -59,6 +59,11 @@
             detects usage of org.apache.avro.specific.SpecificDatumReader$SchemaConstructable
         </Details>
     </Detector>
+    <Detector class="com.linkedin.avroutil1.spotbugs.SchemaFieldInstantiationDetector">
+        <Details>
+            detects direct instantiations of org.apache.avro.Schema$Field
+        </Details>
+    </Detector>
     <Detector class="com.linkedin.avroutil1.spotbugs.SpecificDataNewInstanceUsageDetector">
         <Details>
             detects usage of org.apache.avro.specific.SpecificData.newInstance()
@@ -220,6 +225,21 @@
 ]]>
         </Details>
     </BugPattern>
+    <BugPattern type="SCHEMAFIELD_INSTANTIATION">
+        <ShortDescription>direct Schema.Field instantiation</ShortDescription>
+        <LongDescription>
+            direct instantiation of org.apache.avro.Schema$Field, which there is no way of compatibly doing across avro versions
+        </LongDescription>
+        <Details>
+            <![CDATA[
+   <p>
+      org.apache.avro.Schema$Field has switched from using jackson1 to using Object literals for default values
+      (as part of avro moving to jackson2 internally) starting with 1.9. this completely changed all constructor signatures.
+      use AvroCompatibilityHelper.createSchemaField() instead.
+   </p>
+]]>
+        </Details>
+    </BugPattern>
     <BugPattern type="SPECIFICDATA_NEWINSTANCE_USAGE">
         <ShortDescription>usage of org.apache.avro.specific.SpecificData.newInstance()</ShortDescription>
         <LongDescription>
@@ -247,4 +267,5 @@
     <BugCode abbrev="JEI">JsonEncoder instantiation</BugCode>
     <BugCode abbrev="OSCI">Old SchemaConstructable usage</BugCode>
     <BugCode abbrev="SDNI">SecificData.newInstance() usage</BugCode>
+    <BugCode abbrev="SFI">Schema.Field instantiation</BugCode>
 </MessageCollection>

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
+@SuppressWarnings("unused") //not used in code, but the compiled bytecode is used in tests
 public abstract class BadClass {
 
     public void instantiateBinaryDecoder() {
@@ -93,5 +94,11 @@ public abstract class BadClass {
     //compiles under avro < 1.5
     public void instantiateEnumSymbol() {
         new GenericData.EnumSymbol("bob");
+    }
+
+    //compiles under avro < 1.5
+    public void fixedInstantiation() throws Exception {
+        new GenericData.Fixed((Schema) null);
+        new GenericData.Fixed(new byte[] {1, 2, 3});
     }
 }

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
@@ -106,4 +106,54 @@ public abstract class BadClass {
     public void schemaFieldInstantiation() throws Exception {
         new Schema.Field("file", null, "doc", null, Schema.Field.Order.ASCENDING);
     }
+
+//    //compiles under avro 1.7
+//    public void propAccessUnder17() throws Exception {
+//        Schema s = Schema.parse("whatever");
+//        Schema.Field f = s.getField("f");
+//        org.apache.avro.JsonProperties p = (org.apache.avro.JsonProperties) Schema.parse("something else");
+//
+//        //12 violations follow
+//
+//        s.getProps();
+//        f.getProps();
+//        p.getProps();
+//
+//        s.addProp("K", (org.codehaus.jackson.JsonNode) null);
+//        f.addProp("K", (org.codehaus.jackson.JsonNode) null);
+//        p.addProp("K", (org.codehaus.jackson.JsonNode) null);
+//
+//        s.getJsonProp("K");
+//        f.getJsonProp("K");
+//        p.getJsonProp("K");
+//
+//        s.getJsonProps();
+//        f.getJsonProps();
+//        p.getJsonProps();
+//    }
+
+//    //compiles under avro 1.9
+//    public void propAccessUnder19() throws Exception {
+//        Schema s = Schema.parse("whatever");
+//        Schema.Field f = s.getField("f");
+//        org.apache.avro.JsonProperties p = (org.apache.avro.JsonProperties) Schema.parse("something else");
+//
+//        //12 violations follow
+//
+//        s.addProp("K", new Object());
+//        f.addProp("K", new Object());
+//        p.addProp("K", new Object());
+//
+//        s.getObjectProp("K");
+//        f.getObjectProp("K");
+//        p.getObjectProp("K");
+//
+//        s.getObjectProps();
+//        f.getObjectProps();
+//        p.getObjectProps();
+//
+//        s.addAllProps(null);
+//        f.addAllProps(null);
+//        p.addAllProps(null);
+//    }
 }

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
@@ -101,4 +101,9 @@ public abstract class BadClass {
         new GenericData.Fixed((Schema) null);
         new GenericData.Fixed(new byte[] {1, 2, 3});
     }
+
+    //compiles under avro < 1.9
+    public void schemaFieldInstantiation() throws Exception {
+        new Schema.Field("file", null, "doc", null, Schema.Field.Order.ASCENDING);
+    }
 }

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/FixedInstantiationDetectorTest.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/FixedInstantiationDetectorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.spotbugs;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+
+public class FixedInstantiationDetectorTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Test
+    public void testBadCase() {
+        Path path = Paths.get("build/classes/java/test", BadClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("FIXED_INSTANTIATION")
+                .inMethod("fixedInstantiation").build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(2, bugTypeMatcher));
+    }
+
+    @Test
+    public void testGoodCase() {
+        Path path = Paths.get("build/classes/java/test", GoodClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("FIXED_INSTANTIATION")
+                .build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
+    }
+}

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
@@ -18,6 +18,7 @@ import org.apache.avro.specific.SpecificRecordBase;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+@SuppressWarnings("unused") //not used in code, but the compiled bytecode is used in tests
 public class GoodClass {
 
     public void instantiateBinaryDecoder() {
@@ -47,5 +48,9 @@ public class GoodClass {
 
     public void instantiateEnumSymbol() {
         AvroCompatibilityHelper.newEnumSymbol(null, "bob");
+    }
+
+    public void instantiationFixed() throws Exception {
+        AvroCompatibilityHelper.newFixed(null, new byte[] {1, 2, 3});
     }
 }

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
@@ -8,6 +8,7 @@ package com.linkedin.avroutil1.spotbugs;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import org.apache.avro.Schema;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
@@ -52,5 +53,9 @@ public class GoodClass {
 
     public void instantiationFixed() throws Exception {
         AvroCompatibilityHelper.newFixed(null, new byte[] {1, 2, 3});
+    }
+
+    public void instantiateSchemaField() throws Exception {
+        AvroCompatibilityHelper.createSchemaField("file", null, "doc", null, Schema.Field.Order.ASCENDING);
     }
 }

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
@@ -58,4 +58,17 @@ public class GoodClass {
     public void instantiateSchemaField() throws Exception {
         AvroCompatibilityHelper.createSchemaField("file", null, "doc", null, Schema.Field.Order.ASCENDING);
     }
+
+    public void stringPropAccess() throws Exception {
+        //these are limited to string props, but work across all avro versions
+        Schema s = Schema.parse("whatever");
+        s.addProp("K", "V");
+        s.getProp("K");
+        Schema.Field f = s.getField("f");
+        f.addProp("K", "V");
+        f.getProp("K");
+
+        AvroCompatibilityHelper.getSchemaPropAsJsonString(s, "K");
+        AvroCompatibilityHelper.getFieldPropAsJsonString(f, "K");
+    }
 }

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/PropAccessDetectorTest.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/PropAccessDetectorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.spotbugs;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.hamcrest.MatcherAssert;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+
+public class PropAccessDetectorTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Ignore //can only be run if test are compiled against avro 1.7
+    @Test
+    public void testBadCaseUnder17() {
+        Path path = Paths.get("build/classes/java/test", BadClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("PROP_ACCESS")
+                .inMethod("propAccessUnder17").build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(12, bugTypeMatcher));
+    }
+
+    @Ignore //can only be run if test are compiled against avro 1.9+
+    @Test
+    public void testBadCaseUnder19() {
+        Path path = Paths.get("build/classes/java/test", BadClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("PROP_ACCESS")
+                .inMethod("propAccessUnder19").build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(12, bugTypeMatcher));
+    }
+
+    @Test
+    public void testGoodCase() {
+        Path path = Paths.get("build/classes/java/test", GoodClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("PROP_ACCESS")
+                .build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
+    }
+}

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/SchemaFieldInstantiationDetectorTest.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/SchemaFieldInstantiationDetectorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.spotbugs;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import org.hamcrest.MatcherAssert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+
+public class SchemaFieldInstantiationDetectorTest {
+    @Rule
+    public SpotBugsRule spotbugs = new SpotBugsRule();
+
+    @Test
+    public void testBadCase() {
+        Path path = Paths.get("build/classes/java/test", BadClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("SCHEMAFIELD_INSTANTIATION")
+                .inMethod("schemaFieldInstantiation").build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+    }
+
+    @Test
+    public void testGoodCase() {
+        Path path = Paths.get("build/classes/java/test", GoodClass.class.getName().replace('.', '/') + ".class");
+        BugCollection bugCollection = spotbugs.performAnalysis(path);
+
+        BugInstanceMatcher bugTypeMatcher = new BugInstanceMatcherBuilder()
+                .bugType("SCHEMAFIELD_INSTANTIATION")
+                .build();
+        MatcherAssert.assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
+    }
+}


### PR DESCRIPTION
also renamed newFixedField() to newFixed() to make more sense