### PR TITLE
start work on parser module - implement a location-preserving json parser

### DIFF
--- a/helper/tests/codegen-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Generate110TestResources.java
+++ b/helper/tests/codegen-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Generate110TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro110;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;

--- a/helper/tests/codegen-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Generate14TestResources.java
+++ b/helper/tests/codegen-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Generate14TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro14;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificDatumWriter;

--- a/helper/tests/codegen-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Generate15TestResources.java
+++ b/helper/tests/codegen-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Generate15TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro15;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;

--- a/helper/tests/codegen-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Generate16TestResources.java
+++ b/helper/tests/codegen-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Generate16TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro16;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;

--- a/helper/tests/codegen-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Generate17TestResources.java
+++ b/helper/tests/codegen-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Generate17TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro17;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;

--- a/helper/tests/codegen-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Generate18TestResources.java
+++ b/helper/tests/codegen-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Generate18TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro18;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;

--- a/helper/tests/codegen-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Generate19TestResources.java
+++ b/helper/tests/codegen-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Generate19TestResources.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro19;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonEncoder;

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro110;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro110;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/AvroCompatibilityHelperAvro110Test.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/AvroCompatibilityHelperAvro110Test.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro110;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CodeTransformationsAvro110Test.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CodeTransformationsAvro110Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro110;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14FutureGeneratedCodeAtCompileTest.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14FutureGeneratedCodeAtCompileTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro14;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import net.openhft.compiler.CompilerUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14GeneratedCodeTest.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14GeneratedCodeTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro14;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import net.openhft.compiler.CompilerUtils;
 import org.apache.avro.Schema;

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro14;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro14;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/AvroCompatibilityHelperAvro14Test.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/AvroCompatibilityHelperAvro14Test.java
@@ -7,13 +7,14 @@
 package com.linkedin.avroutil1.compatibility.avro14;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/CodeTransformationsAvro14Test.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/CodeTransformationsAvro14Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro14;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro15;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.testng.Assert;

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro15;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/AvroCompatibilityHelperAvro15Test.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/AvroCompatibilityHelperAvro15Test.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro15;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/CodeTransformationsAvro15Test.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/CodeTransformationsAvro15Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro15;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/Avro16ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/Avro16ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro16;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 import org.testng.Assert;

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/Avro16WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/Avro16WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro16;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/AvroCompatibilityHelperAvro16Test.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/AvroCompatibilityHelperAvro16Test.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro16;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/CodeTransformationsAvro16Test.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/CodeTransformationsAvro16Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro16;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro17;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro17;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperAvro17Test.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperAvro17Test.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/CodeTransformationsAvro17Test.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/CodeTransformationsAvro17Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro17;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro18;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro18;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/AvroCompatibilityHelperAvro18Test.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/AvroCompatibilityHelperAvro18Test.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro18;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/CodeTransformationsAvro18Test.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/CodeTransformationsAvro18Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro18;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19ParseBehaviorTest.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19ParseBehaviorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro19;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19WireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19WireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro19;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/AvroCompatibilityHelperAvro19Test.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/AvroCompatibilityHelperAvro19Test.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro19;
 
 import com.linkedin.avroutil1.Pojo;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import java.io.IOException;

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/CodeTransformationsAvro19Test.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/CodeTransformationsAvro19Test.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility.avro19;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperDefaultsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperDefaultsTest.java
@@ -7,7 +7,7 @@
 package com.linkedin.avroutil1.compatibility;
 
 import com.google.common.base.Throwables;
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperGenericUtilMethodsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperGenericUtilMethodsTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.testng.Assert;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperJsonCodecsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperJsonCodecsTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import net.javacrumbs.jsonunit.assertj.JsonAssertions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperParsingTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperParsingTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import java.util.Arrays;
 import java.util.Map;
 import org.apache.avro.AvroTypeException;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroWireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroWireFormatCompatibilityTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/FieldBuilderTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/FieldBuilderTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/PropAccessTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/PropAccessTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SchemaBuilderTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SchemaBuilderTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/helper/tests/helper-tests-common/build.gradle
+++ b/helper/tests/helper-tests-common/build.gradle
@@ -11,9 +11,7 @@ plugins {
 
 dependencies {
   api project(":helper:helper")
-  //we use this module as an easy way to "export" libraries for use by other test modules
-  api "commons-io:commons-io:2.6"
-  api "net.openhft:compiler:2.3.6"
+  api project(":test-common")
 
   implementation "args4j:args4j:2.33"
 

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+plugins {
+    id "java-library"
+    id "checkstyle"
+}
+
+dependencies {
+
+    //json-p under its new home @ https://projects.eclipse.org/projects/ee4j.jsonp
+    api "jakarta.json:jakarta.json-api:2.0.1"
+    implementation "org.glassfish:jakarta.json:2.0.1"
+
+    testImplementation project(":test-common")
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/BuilderWithLocations.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/BuilderWithLocations.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+public abstract class BuilderWithLocations<T extends JsonValueExt> {
+
+    protected Path source;
+    protected JsonLocation startLocation;
+    protected JsonLocation endLocation;
+
+    public Path getSource() {
+        return source;
+    }
+
+    public void setSource(Path source) {
+        this.source = source;
+    }
+
+    public JsonLocation getStartLocation() {
+        return startLocation;
+    }
+
+    public void setStartLocation(JsonLocation startLocation) {
+        this.startLocation = startLocation;
+    }
+
+    public JsonLocation getEndLocation() {
+        return endLocation;
+    }
+
+    public void setEndLocation(JsonLocation endLocation) {
+        this.endLocation = endLocation;
+    }
+
+    public abstract T build();
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonArrayExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonArrayExt.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonArray;
+
+public interface JsonArrayExt extends JsonArray, JsonStructureExt {
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonArrayExtBuilder.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonArrayExtBuilder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import java.util.ArrayList;
+
+public class JsonArrayExtBuilder extends BuilderWithLocations<JsonArrayExt> {
+    private ArrayList<JsonValueExt> valueList = new ArrayList<>(1);
+
+    public JsonArrayExtBuilder add(JsonValueExt value) {
+        if (value == null) {
+            throw new IllegalArgumentException("value cannot be null");
+        }
+        valueList.add(value);
+        return this;
+    }
+
+    @Override
+    public JsonArrayExt build() {
+        return new JsonArrayExtImpl(getSource(), getStartLocation(), getEndLocation(), valueList);
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonArrayExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonArrayExtImpl.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+import java.util.AbstractList;
+import java.util.List;
+import java.util.StringJoiner;
+
+public class JsonArrayExtImpl extends AbstractList<JsonValue> implements JsonArrayExt {
+    private final Path source;
+    private final JsonLocation startLocation;
+    private final JsonLocation endLocation;
+    private final List<JsonValueExt> valueList;    // Unmodifiable
+    private int hashCode;
+
+    JsonArrayExtImpl(
+            Path source,
+            JsonLocation startLocation,
+            JsonLocation endLocation,
+            List<JsonValueExt> valueList
+    ) {
+        this.source = source;
+        this.startLocation = startLocation;
+        this.endLocation = endLocation;
+        this.valueList = valueList;
+    }
+
+    @Override
+    public Path getSource() {
+        return source;
+    }
+
+    @Override
+    public JsonLocation getStartLocation() {
+        return startLocation;
+    }
+
+    @Override
+    public JsonLocation getEndLocation() {
+        return endLocation;
+    }
+
+    @Override
+    public int size() {
+        return valueList.size();
+    }
+
+    @Override
+    public JsonObjectExt getJsonObject(int index) {
+        return (JsonObjectExt) valueList.get(index);
+    }
+
+    @Override
+    public JsonArrayExt getJsonArray(int index) {
+        return (JsonArrayExt) valueList.get(index);
+    }
+
+    @Override
+    public JsonNumberExt getJsonNumber(int index) {
+        return (JsonNumberExt) valueList.get(index);
+    }
+
+    @Override
+    public JsonStringExt getJsonString(int index) {
+        return (JsonStringExt) valueList.get(index);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends JsonValue> List<T> getValuesAs(Class<T> clazz) {
+        return (List<T>)valueList;
+    }
+
+    @Override
+    public String getString(int index) {
+        return getJsonString(index).getString();
+    }
+
+    @Override
+    public String getString(int index, String defaultValue) {
+        //TODO - fix index out of bounds
+        JsonStringExt jsonString = getJsonString(index);
+        return jsonString != null ? jsonString.getString() : defaultValue;
+    }
+
+    @Override
+    public int getInt(int index) {
+        return getJsonNumber(index).intValue();
+    }
+
+    @Override
+    public int getInt(int index, int defaultValue) {
+        JsonNumberExt jsonNumber = getJsonNumber(index);
+        try {
+            return getInt(index);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int index) {
+        JsonValue jsonValue = get(index);
+        if (jsonValue == null) {
+            throw new IllegalStateException();
+        }
+        ValueType type = jsonValue.getValueType();
+        switch (type) {
+            case TRUE:
+                return true;
+            case FALSE:
+                return false;
+            default:
+                throw new ClassCastException("value at index " + index + " is " + type + " and not boolean - " + jsonValue);
+        }
+    }
+
+    @Override
+    public boolean getBoolean(int index, boolean defaultValue) {
+        try {
+            return getBoolean(index);
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    @Override
+    public boolean isNull(int index) {
+        return valueList.get(index).equals(JsonValue.NULL);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.ARRAY;
+    }
+
+    @Override
+    public JsonValueExt get(int index) {
+        return valueList.get(index);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == 0) {
+            hashCode = super.hashCode();
+        }
+        return hashCode;
+    }
+
+    @Override
+    public JsonArray asJsonArray() {
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner csv = new StringJoiner(", ");
+        for (JsonValueExt value : valueList) {
+            csv.add(value.toString());
+        }
+        return "[" + csv + "]";
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonFalseExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonFalseExtImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+public class JsonFalseExtImpl extends JsonValueExtImpl implements JsonValueExt {
+    public JsonFalseExtImpl(Path source, JsonLocation startLocation, JsonLocation endLocation) {
+        super(source, startLocation, endLocation);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.FALSE;
+    }
+
+    @Override
+    public String toString() {
+        return "false";
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonNullExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonNullExtImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+public class JsonNullExtImpl extends JsonValueExtImpl implements JsonValueExt {
+    public JsonNullExtImpl(Path source, JsonLocation startLocation, JsonLocation endLocation) {
+        super(source, startLocation, endLocation);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.NULL;
+    }
+
+    @Override
+    public String toString() {
+        return "null";
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonNumberExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonNumberExt.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonNumber;
+
+public interface JsonNumberExt extends JsonNumber, JsonValueExt {
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonNumberExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonNumberExtImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.file.Path;
+
+public class JsonNumberExtImpl extends JsonValueExtImpl implements JsonNumberExt {
+    private final BigDecimal bigDecimal;
+
+    public JsonNumberExtImpl(
+            Path source,
+            JsonLocation startLocation,
+            JsonLocation endLocation,
+            BigDecimal value
+    ) {
+        super(source, startLocation, endLocation);
+        this.bigDecimal = value;
+    }
+
+    @Override
+    public boolean isIntegral() {
+        return bigDecimal.scale() == 0;
+    }
+
+    @Override
+    public int intValue() {
+        return bigDecimal.intValue();
+    }
+
+    @Override
+    public int intValueExact() {
+        return bigDecimal.intValueExact();
+    }
+
+    @Override
+    public long longValue() {
+        return bigDecimal.longValue();
+    }
+
+    @Override
+    public long longValueExact() {
+        return bigDecimal.longValueExact();
+    }
+
+    @Override
+    public BigInteger bigIntegerValue() {
+        return bigDecimal.toBigInteger();
+    }
+
+    @Override
+    public BigInteger bigIntegerValueExact() {
+        return bigDecimal.toBigIntegerExact();
+    }
+
+    @Override
+    public double doubleValue() {
+        return bigDecimal.doubleValue();
+    }
+
+    @Override
+    public BigDecimal bigDecimalValue() {
+        return bigDecimal;
+    }
+
+    @Override
+    public Number numberValue() {
+        return bigDecimal;
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.NUMBER;
+    }
+
+    @Override
+    public String toString() {
+        return bigDecimal.toString();
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonObjectExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonObjectExt.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonObject;
+
+public interface JsonObjectExt extends JsonObject, JsonStructureExt {
+
+    @Override
+    JsonArrayExt getJsonArray(String name);
+
+    @Override
+    JsonNumberExt getJsonNumber(String name);
+
+    @Override
+    JsonObjectExt getJsonObject(String name);
+
+    @Override
+    JsonStringExt getJsonString(String name);
+
+    JsonValueExt get(String name);
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonObjectExtBuilder.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonObjectExtBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JsonObjectExtBuilder extends BuilderWithLocations<JsonObjectExt> {
+
+    protected Map<String, JsonValueExt> valueMap = new HashMap<>(1);
+
+    JsonObjectExtBuilder add(String name, JsonValueExt value) {
+        JsonValueExt conflictingValue = valueMap.get(name);
+        if (conflictingValue != null) {
+            throw new JsonException("key " + name + " is defined at " + conflictingValue.getStartLocation() + " and again at " + value.getStartLocation());
+        }
+        valueMap.put(name, value);
+        return this;
+    }
+
+    public JsonObjectExt build() {
+        return new JsonObjectExtImpl(source, startLocation, endLocation, valueMap);
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonObjectExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonObjectExtImpl.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+
+public class JsonObjectExtImpl extends AbstractMap<String, JsonValue> implements JsonObjectExt {
+
+    private final Path source;
+    private final JsonLocation startLocation;
+    private final JsonLocation endLocation;
+    private final Map<String, JsonValueExt> valueMap;
+    private Integer hashCode = null;
+
+    public JsonObjectExtImpl(
+            Path source,
+            JsonLocation startLocation,
+            JsonLocation endLocation,
+            Map<String, JsonValueExt> values
+    ) {
+        this.source = source;
+        this.startLocation = startLocation;
+        this.endLocation = endLocation;
+        this.valueMap = values;
+    }
+
+    @Override
+    public Path getSource() {
+        return source;
+    }
+
+    @Override
+    public JsonLocation getStartLocation() {
+        return startLocation;
+    }
+
+    @Override
+    public JsonLocation getEndLocation() {
+        return endLocation;
+    }
+
+    @Override
+    public JsonArrayExt getJsonArray(String name) {
+        return (JsonArrayExt) get(name);
+    }
+
+    @Override
+    public JsonNumberExt getJsonNumber(String name) {
+        return (JsonNumberExt) get(name);
+    }
+
+    @Override
+    public JsonObjectExt getJsonObject(String name) {
+        return (JsonObjectExt) get(name);
+    }
+
+    @Override
+    public JsonStringExt getJsonString(String name) {
+        return (JsonStringExt) get(name);
+    }
+
+    @Override
+    public JsonValueExt get(String name) {
+        return (JsonValueExt) super.get(name);
+    }
+
+    @Override
+    public String getString(String name) {
+        return getJsonString(name).getString();
+    }
+
+    @Override
+    public String getString(String name, String defaultValue) {
+        JsonValueExt value = get(name);
+        if (value instanceof JsonStringExt) {
+            return ((JsonStringExt) value).getString();
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public int getInt(String name) {
+        return getJsonNumber(name).intValue();
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue) {
+        JsonValueExt value = get(name);
+        if (value instanceof JsonNumberExt) {
+            return ((JsonNumberExt) value).intValue();
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public boolean getBoolean(String name) {
+        JsonValueExt value = get(name);
+        if (value == null) {
+            throw new NullPointerException();
+        }
+        switch (value.getValueType()) {
+            case TRUE:
+                return true;
+            case FALSE:
+                return false;
+            default:
+                throw new ClassCastException("property " + name + " is a " + value.getValueType() + " and not a boolean");
+        }
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue) {
+        JsonValueExt value = get(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        switch (value.getValueType()) {
+            case TRUE:
+                return true;
+            case FALSE:
+                return false;
+            default:
+                return defaultValue;
+        }
+    }
+
+    @Override
+    public boolean isNull(String name) {
+        JsonValueExt value = get(name);
+        if (value == null) {
+            throw new NullPointerException("no such property " + name);
+        }
+        return value.getValueType() == ValueType.NULL;
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.OBJECT;
+    }
+
+    @Override
+    public int size() {
+        return valueMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return valueMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return valueMap.containsKey(key);
+    }
+
+    @Override
+    public JsonValueExt get(Object key) {
+        return valueMap.get(key);
+    }
+
+    @Override
+    public JsonValueExt remove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JsonValue put(String key, JsonValue value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends JsonValue> m) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Entry<String, JsonValue>> entrySet() {
+        //we love java generics
+        Set<?> raw = valueMap.entrySet();
+        //noinspection unchecked
+        return (Set<Entry<String, JsonValue>>) raw;
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == null) {
+            hashCode = super.hashCode();
+        }
+        return hashCode;
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonReaderExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonReaderExt.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonReader;
+
+public interface JsonReaderExt extends JsonReader {
+
+    @Override
+    JsonStructureExt read();
+
+    @Override
+    JsonObjectExt readObject();
+
+    @Override
+    JsonArrayExt readArray();
+
+    @Override
+    JsonValueExt readValue();
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonReaderWithLocations.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonReaderWithLocations.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import jakarta.json.stream.JsonParser;
+
+import java.io.Reader;
+import java.nio.file.Path;
+
+public class JsonReaderWithLocations implements JsonReaderExt {
+    private final JsonParser parser;
+    private final Path source;
+
+    private boolean readDone;
+    private JsonParser.Event currentEvent;
+
+    public JsonReaderWithLocations(Reader reader, Path source) {
+        this.parser = Json.createParser(reader);
+        this.source = source;
+        this.readDone = false;
+    }
+
+    @Override
+    public JsonStructureExt read() {
+        throw new UnsupportedOperationException("you want this? you write it!");
+    }
+
+    @Override
+    public JsonObjectExt readObject() {
+        ensureSingleUse();
+        advance();
+        if (!JsonParser.Event.START_OBJECT.equals(currentEvent)) {
+            throw new IllegalStateException("was expecting START_OBJECT (\"{\") at location " + parser.getLocation() + " but instead found " + currentEvent);
+        }
+        return readObjectInternal();
+    }
+
+    @Override
+    public JsonArrayExt readArray() {
+        ensureSingleUse();
+        throw new UnsupportedOperationException("you want this? you write it!");
+    }
+
+    @Override
+    public void close() {
+        readDone = true;
+        parser.close();
+    }
+
+    @Override
+    public JsonValueExt readValue() {
+        ensureSingleUse();
+        advance();
+        return readJsonValueInternal();
+    }
+
+    protected JsonObjectExt readObjectInternal() {
+        JsonObjectExtBuilder builder = new JsonObjectExtBuilder();
+        builder.setSource(source);
+        builder.setStartLocation(parser.getLocation());
+        while(parser.hasNext()) {
+            advance();
+            if (currentEvent == JsonParser.Event.END_OBJECT) {
+                // } - close object
+                builder.setEndLocation(parser.getLocation());
+                return builder.build();
+            }
+            // expecting key = value
+            if (currentEvent != JsonParser.Event.KEY_NAME) {
+                throw new JsonException("expecting key name at " + parser.getLocation() + " but got " + currentEvent);
+            }
+            String key = parser.getString();
+            advance();
+            JsonValueExt value = readJsonValueInternal();
+            builder.add(key, value);
+        }
+        throw new JsonException("object that started at " + builder.getStartLocation() + " never closed");
+    }
+
+    protected JsonValueExt readJsonValueInternal() {
+        switch (currentEvent) {
+            case START_ARRAY:
+                return readJsonArrayInternal();
+            case START_OBJECT:
+                return readObjectInternal();
+            case KEY_NAME:
+                throw new JsonException("unexpected " + currentEvent + " at " + parser.getLocation());
+            //TODO - better start/end for all "short" values
+            case VALUE_STRING:
+                return new JsonStringExtImpl(source, parser.getLocation(), parser.getLocation(), parser.getString());
+            case VALUE_NUMBER:
+                //we dont bother optimizing for ints/longs
+                return new JsonNumberExtImpl(source, parser.getLocation(), parser.getLocation(), parser.getBigDecimal());
+            case VALUE_TRUE:
+                return new JsonTrueExtImpl(source, parser.getLocation(), parser.getLocation());
+            case VALUE_FALSE:
+                return new JsonFalseExtImpl(source, parser.getLocation(), parser.getLocation());
+            case VALUE_NULL:
+                return new JsonNullExtImpl(source, parser.getLocation(), parser.getLocation());
+            case END_ARRAY:
+                throw new JsonException("unexpected " + currentEvent + " at " + parser.getLocation());
+            case END_OBJECT:
+                throw new JsonException("unexpected " + currentEvent + " at " + parser.getLocation());
+            default:
+                throw new JsonException("unexpected " + currentEvent + " at " + parser.getLocation());
+        }
+    }
+
+    protected JsonArrayExt readJsonArrayInternal() {
+        JsonArrayExtBuilder builder = new JsonArrayExtBuilder();
+        builder.setSource(source);
+        builder.setStartLocation(parser.getLocation());
+        while(parser.hasNext()) {
+            advance();
+            if (currentEvent == JsonParser.Event.END_ARRAY) {
+                // ] - close array
+                builder.setEndLocation(parser.getLocation());
+                return builder.build();
+            }
+            // expecting value
+            JsonValueExt value = readJsonValueInternal();
+            builder.add(value);
+        }
+        throw new JsonException("array that started at " + builder.getStartLocation() + " never closed");
+    }
+
+    /**
+     * ensures this class can only be used once to read a single top-level json value
+     * as per the docs on {@link jakarta.json.JsonReader}
+     */
+    protected void ensureSingleUse() {
+        if (readDone) {
+            throw new IllegalStateException("reader is done");
+        }
+        readDone = true;
+        if (!parser.hasNext()) {
+            throw new IllegalStateException("parser has no next element?!");
+        }
+    }
+
+    protected void advance() {
+        currentEvent = parser.next();
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonStringExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonStringExt.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonString;
+
+public interface JsonStringExt extends JsonString, JsonValueExt{
+
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonStringExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonStringExtImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+public class JsonStringExtImpl extends JsonValueExtImpl implements JsonStringExt {
+    private final String value;
+
+    public JsonStringExtImpl(
+            Path source,
+            JsonLocation startLocation,
+            JsonLocation endLocation,
+            String value
+    ) {
+        super(source, startLocation, endLocation);
+        this.value = value;
+    }
+
+    @Override
+    public String getString() {
+        return value;
+    }
+
+    @Override
+    public CharSequence getChars() {
+        return value;
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.STRING;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonStructureExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonStructureExt.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonStructure;
+
+public interface JsonStructureExt extends JsonStructure, JsonValueExt {
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonTrueExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonTrueExtImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+public class JsonTrueExtImpl extends JsonValueExtImpl implements JsonValueExt {
+    public JsonTrueExtImpl(Path source, JsonLocation startLocation, JsonLocation endLocation) {
+        super(source, startLocation, endLocation);
+    }
+
+    @Override
+    public ValueType getValueType() {
+        return ValueType.TRUE;
+    }
+
+    @Override
+    public String toString() {
+        return "true";
+    }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonValueExt.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonValueExt.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.JsonValue;
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+/**
+ * extends {@link JsonValue} with its start (inclusive) and end (inclusive?)
+ * locations in a file.
+ */
+public interface JsonValueExt extends JsonValue {
+    Path getSource();
+    JsonLocation getStartLocation();
+    JsonLocation getEndLocation();
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonValueExtImpl.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/jsonpext/JsonValueExtImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser.jsonpext;
+
+import jakarta.json.stream.JsonLocation;
+
+import java.nio.file.Path;
+
+public abstract class JsonValueExtImpl implements JsonValueExt {
+    private final Path source;
+    private final JsonLocation startLocation;
+    private final JsonLocation endLocation;
+
+    protected JsonValueExtImpl(Path source, JsonLocation startLocation, JsonLocation endLocation) {
+        this.source = source;
+        this.startLocation = startLocation;
+        this.endLocation = endLocation;
+    }
+
+    @Override
+    public Path getSource() {
+        return source;
+    }
+
+    @Override
+    public JsonLocation getStartLocation() {
+        return startLocation;
+    }
+
+    @Override
+    public JsonLocation getEndLocation() {
+        return endLocation;
+    }
+}

--- a/parser/src/test/java/com/linkedin/avroutil1/parser/TestJsonParsing.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/parser/TestJsonParsing.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.parser;
+
+import com.linkedin.avroutil1.parser.jsonpext.JsonObjectExt;
+import com.linkedin.avroutil1.parser.jsonpext.JsonReaderExt;
+import com.linkedin.avroutil1.parser.jsonpext.JsonReaderWithLocations;
+import com.linkedin.avroutil1.parser.jsonpext.JsonValueExt;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.stream.JsonLocation;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.StringReader;
+
+public class TestJsonParsing {
+
+    @Test
+    public void testSimpleSchema() throws Exception {
+        String avsc = TestUtil.load("schemas/TestRecord.avsc");
+        JsonReader referenceReader = Json.createReader(new StringReader(avsc));
+        JsonObject referenceObject = referenceReader.readObject();
+        JsonReaderExt ourReader = new JsonReaderWithLocations(new StringReader(avsc), null);
+        JsonObjectExt ourObject = ourReader.readObject();
+
+        //assert we read everything correctly. our equals() implementations are not
+        //commutative with regular json-p objects (yet?)
+        //noinspection SimplifiableAssertion
+        Assert.assertTrue(referenceObject.equals(ourObject));
+
+        //see that we have text locations for json values
+        JsonValueExt fields = ourObject.get("fields");
+        JsonLocation startLocation = fields.getStartLocation();
+        JsonLocation endLocation = fields.getEndLocation();
+        Assert.assertEquals(startLocation.getLineNumber(), 5);
+        Assert.assertEquals(endLocation.getLineNumber(), 10);
+    }
+}

--- a/parser/src/test/resources/schemas/TestRecord.avsc
+++ b/parser/src/test/resources/schemas/TestRecord.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "namespace": "com.acme",
+  "name": "TestRecord",
+  "fields": [
+    {
+      "name": "stringField",
+      "type": "string"
+    }
+  ]
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,8 @@ apply plugin: 'net.vivin.gradle-semantic-build-versioning'
 //otherwise it defaults to the folder name
 rootProject.name = 'avro-util'
 
+include 'test-common'
+include 'parser'
 include 'avro-codegen'
 include 'avro-fastserde'
 

--- a/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/OldSchemaConstructableUsageDetector.java
+++ b/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/OldSchemaConstructableUsageDetector.java
@@ -98,6 +98,9 @@ public class OldSchemaConstructableUsageDetector extends OpcodeStackDetector {
                 continue; //no variables to look at
             }
             LocalVariableTable localVariableTable = method.getLocalVariableTable(); //includes method args
+            if (localVariableTable == null) {
+                return;
+            }
             for (LocalVariable variable : localVariableTable.getLocalVariableTable()) {
                 if (checkSignature(variable.getSignature())) {
                     //TODO - figure out how to add sour line number?

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/BadClass.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.spotbugs;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/OldSchemaConstructableUsageDetectorTest.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/OldSchemaConstructableUsageDetectorTest.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.spotbugs;
 
-import com.linkedin.avroutil1.TestUtil;
+import com.linkedin.avroutil1.testcommon.TestUtil;
 import edu.umd.cs.findbugs.BugCollection;
 import edu.umd.cs.findbugs.test.SpotBugsRule;
 import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+plugins {
+  id "java-library"
+  id "checkstyle"
+}
+
+dependencies {
+  //we use this module as an easy way to "export" libraries for use by other test modules
+  api "commons-io:commons-io:2.6"
+  api "net.openhft:compiler:2.3.6"
+}

--- a/test-common/src/main/java/com/linkedin/avroutil1/testcommon/TestUtil.java
+++ b/test-common/src/main/java/com/linkedin/avroutil1/testcommon/TestUtil.java
@@ -4,7 +4,7 @@
  * See License in the project root for license information.
  */
 
-package com.linkedin.avroutil1;
+package com.linkedin.avroutil1.testcommon;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
this is a building block on the way to implementing our own parser for avsc files.
having a json parser that can trace elements back to their line/column/character is key for better error messages to users.
json-p was chosen as jackson is "tainted" because avro uses different (incompatible) versions of it and we want to coexist with avro (and we dont want to shade).
 