### PR TITLE
fix NPE in OldSchemaConstructableUsageDetector for methods without a local variable table

### DIFF
--- a/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/OldSchemaConstructableUsageDetector.java
+++ b/spotbugs-plugin/src/main/java/com/linkedin/avroutil1/spotbugs/OldSchemaConstructableUsageDetector.java
@@ -98,6 +98,9 @@ public class OldSchemaConstructableUsageDetector extends OpcodeStackDetector {
                 continue; //no variables to look at
             }
             LocalVariableTable localVariableTable = method.getLocalVariableTable(); //includes method args
+            if (localVariableTable == null) {
+                return;
+            }
             for (LocalVariable variable : localVariableTable.getLocalVariableTable()) {
                 if (checkSignature(variable.getSignature())) {
                     //TODO - figure out how to add sour line number?


### PR DESCRIPTION
resolves #173 