### PR TITLE
Adding support for defaults from EnumSymbols

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
@@ -10,6 +10,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.generic.GenericData;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.JsonNodeFactory;
@@ -50,6 +51,9 @@ public class Jackson1Utils {
     } else if (datum instanceof Collection) {
       ObjectMapper mapper = new ObjectMapper();
       return mapper.convertValue(datum, JsonNode.class);
+    } else if (datum instanceof GenericData.EnumSymbol) {
+      GenericData.EnumSymbol enumSymbol = (GenericData.EnumSymbol) datum;
+      return JsonNodeFactory.instance.textNode(enumSymbol.toString());
     } else {
       throw new AvroRuntimeException("Unknown datum class: " + datum.getClass());
     }

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperAvro17Test.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperAvro17Test.java
@@ -73,4 +73,21 @@ public class AvroCompatibilityHelperAvro17Test {
     List<List<String>> actualListValue = mapper.convertValue(actualJsonNode, new TypeReference<List<List<String>>>(){});
     Assert.assertEquals(actualListValue.get(0).get(0), "dummyElement");
   }
+
+  @Test
+  public void testGetGenericDefaultValueCloningForEnums() throws IOException {
+    // Given a schema with a default enum field
+    Schema schema = Schema.parse(TestUtil.load("RecordWithRecursiveTypesAndDefaults.avsc"));
+    Schema.Field field = schema.getField("enumFieldWithDefault");
+
+    // When cloning the field with a field builder and setting the default value as the default value from the schema
+    Schema.Field clone = AvroCompatibilityHelper.cloneSchemaField(field)
+        .setDoc(field.doc())
+        .setSchema(field.schema())
+        .setDefault(AvroCompatibilityHelper.getGenericDefaultValue(field))
+        .build();
+
+    // Then we should expect the clone and original to be equal
+    Assert.assertEquals(field, clone);
+  }
 }

--- a/helper/tests/helper-tests-common/src/main/resources/RecordWithRecursiveTypesAndDefaults.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/RecordWithRecursiveTypesAndDefaults.avsc
@@ -38,6 +38,17 @@
       "default": [
         ["dummyElement"]
       ]
+    },
+    {
+      "name": "enumFieldWithDefault",
+      "type": {
+        "type": "enum",
+        "namespace": "com.acme",
+        "name": "PerfectlyNormalEnum",
+        "doc": "this enum is perfectly normal",
+        "symbols": ["A", "B"]
+      },
+      "default": "B"
     }
   ]
 }


### PR DESCRIPTION
When creating fields with the FieldBuilder and supplying a default
value to the field builder by using the adapter's genericDefaultValue
from an existing field, it will return a `GenericData.EnumSymbol`.

This changeset makes Jackson1Utils `GenericData.EnumSymbol` aware.