### PR TITLE
fail at runtime for unknown enums to keep consistent with vanilla avro

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -288,6 +289,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +320,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +360,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +410,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -1,5 +1,5 @@
 
-package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -137,17 +138,10 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                 decoder.readNull();
                 break;
             case  1 :
-            {
-                Object oldString1 = TestRecord.get(13);
-                if (oldString1 instanceof Utf8) {
-                    TestRecord.put(13, (decoder).readString(((Utf8) oldString1)));
-                } else {
-                    TestRecord.put(13, (decoder).readString(null));
-                }
+                decoder.skipString();
                 break;
-            }
             default:
-                throw new RuntimeException(("Illegal union index for 'testStringUnion': "+ unionIndex6));
+                throw new RuntimeException(("Illegal union index for 'testStringAlias': "+ unionIndex6));
         }
         int unionIndex7 = (decoder.readIndex());
         switch (unionIndex7) {
@@ -288,6 +282,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +313,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +353,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +403,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
@@ -808,9 +810,9 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                 break;
             case  2 :
             {
-                Object oldString4 = TestRecord.get(32);
-                if (oldString4 instanceof Utf8) {
-                    TestRecord.put(32, (decoder).readString(((Utf8) oldString4)));
+                Object oldString3 = TestRecord.get(32);
+                if (oldString3 instanceof Utf8) {
+                    TestRecord.put(32, (decoder).readString(((Utf8) oldString3)));
                 } else {
                     TestRecord.put(32, (decoder).readString(null));
                 }
@@ -822,6 +824,7 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             default:
                 throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex26));
         }
+        TestRecord.put(13, null);
         ArrayList<Boolean> defaultArray0 = new ArrayList<Boolean>();
         TestRecord.put(33, defaultArray0);
         ArrayList<Double> defaultArray1 = new ArrayList<Double>();
@@ -853,9 +856,9 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                 break;
             case  1 :
             {
-                Object oldString2 = SubRecord.get(0);
-                if (oldString2 instanceof Utf8) {
-                    SubRecord.put(0, (decoder).readString(((Utf8) oldString2)));
+                Object oldString1 = SubRecord.get(0);
+                if (oldString1 instanceof Utf8) {
+                    SubRecord.put(0, (decoder).readString(((Utf8) oldString1)));
                 } else {
                     SubRecord.put(0, (decoder).readString(null));
                 }
@@ -882,9 +885,9 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                 break;
             case  1 :
             {
-                Object oldString3 = SubRecord.get(1);
-                if (oldString3 instanceof Utf8) {
-                    SubRecord.put(1, (decoder).readString(((Utf8) oldString3)));
+                Object oldString2 = SubRecord.get(1);
+                if (oldString2 instanceof Utf8) {
+                    SubRecord.put(1, (decoder).readString(((Utf8) oldString2)));
                 } else {
                     SubRecord.put(1, (decoder).readString(null));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -265,24 +265,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
         TestRecord.put(17, testFixedUnionArray0);
         int enumIndex0 = (decoder.readEnum());
         TestEnum enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = TestEnum.values()[ 4 ];
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = TestEnum.values()[ 4 ];
+                break;
+            case  1 :
                 enumValue0 = TestEnum.values()[ 3 ];
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = TestEnum.values()[ 1 ];
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = TestEnum.values()[ 2 ];
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = TestEnum.values()[ 0 ];
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = TestEnum.values()[ 1 ];
+                break;
+            case  3 :
+                enumValue0 = TestEnum.values()[ 2 ];
+                break;
+            case  4 :
+                enumValue0 = TestEnum.values()[ 0 ];
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
         TestRecord.put(18, enumValue0);
         int unionIndex10 = (decoder.readIndex());
@@ -294,24 +294,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             {
                 int enumIndex1 = (decoder.readEnum());
                 TestEnum enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue1 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue1 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue1 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
                 TestRecord.put(19, enumValue1);
                 break;
@@ -332,24 +332,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 TestEnum enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue2 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue2 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue2 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
                 testEnumArray0 .add(enumValue2);
             }
@@ -380,24 +380,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     {
                         int enumIndex3 = (decoder.readEnum());
                         TestEnum enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = TestEnum.values()[ 4 ];
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = TestEnum.values()[ 4 ];
+                                break;
+                            case  1 :
                                 enumValue3 = TestEnum.values()[ 3 ];
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = TestEnum.values()[ 1 ];
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = TestEnum.values()[ 2 ];
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = TestEnum.values()[ 0 ];
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = TestEnum.values()[ 1 ];
+                                break;
+                            case  3 :
+                                enumValue3 = TestEnum.values()[ 2 ];
+                                break;
+                            case  4 :
+                                enumValue3 = TestEnum.values()[ 0 ];
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray0 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -1,5 +1,5 @@
 
-package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -288,6 +289,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +320,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +360,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +410,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -272,24 +272,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
         TestRecord.put(17, testFixedUnionArray0);
         int enumIndex0 = (decoder.readEnum());
         TestEnum enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = TestEnum.values()[ 4 ];
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = TestEnum.values()[ 4 ];
+                break;
+            case  1 :
                 enumValue0 = TestEnum.values()[ 3 ];
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = TestEnum.values()[ 1 ];
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = TestEnum.values()[ 2 ];
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = TestEnum.values()[ 0 ];
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = TestEnum.values()[ 1 ];
+                break;
+            case  3 :
+                enumValue0 = TestEnum.values()[ 2 ];
+                break;
+            case  4 :
+                enumValue0 = TestEnum.values()[ 0 ];
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
         TestRecord.put(18, enumValue0);
         int unionIndex10 = (decoder.readIndex());
@@ -301,24 +301,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             {
                 int enumIndex1 = (decoder.readEnum());
                 TestEnum enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue1 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue1 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue1 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
                 TestRecord.put(19, enumValue1);
                 break;
@@ -339,24 +339,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 TestEnum enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue2 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue2 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue2 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
                 testEnumArray0 .add(enumValue2);
             }
@@ -387,24 +387,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     {
                         int enumIndex3 = (decoder.readEnum());
                         TestEnum enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = TestEnum.values()[ 4 ];
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = TestEnum.values()[ 4 ];
+                                break;
+                            case  1 :
                                 enumValue3 = TestEnum.values()[ 3 ];
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = TestEnum.values()[ 1 ];
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = TestEnum.values()[ 2 ];
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = TestEnum.values()[ 0 ];
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = TestEnum.values()[ 1 ];
+                                break;
+                            case  3 :
+                                enumValue3 = TestEnum.values()[ 2 ];
+                                break;
+                            case  4 :
+                                enumValue3 = TestEnum.values()[ 0 ];
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray0 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_405768074940221895_541502821296456517.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -1,5 +1,5 @@
 
-package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -288,6 +289,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +320,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +360,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +410,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -272,24 +272,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
         TestRecord.put(17, testFixedUnionArray0);
         int enumIndex0 = (decoder.readEnum());
         TestEnum enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = TestEnum.values()[ 4 ];
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = TestEnum.values()[ 4 ];
+                break;
+            case  1 :
                 enumValue0 = TestEnum.values()[ 3 ];
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = TestEnum.values()[ 1 ];
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = TestEnum.values()[ 2 ];
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = TestEnum.values()[ 0 ];
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = TestEnum.values()[ 1 ];
+                break;
+            case  3 :
+                enumValue0 = TestEnum.values()[ 2 ];
+                break;
+            case  4 :
+                enumValue0 = TestEnum.values()[ 0 ];
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
         TestRecord.put(18, enumValue0);
         int unionIndex10 = (decoder.readIndex());
@@ -301,24 +301,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             {
                 int enumIndex1 = (decoder.readEnum());
                 TestEnum enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue1 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue1 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue1 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
                 TestRecord.put(19, enumValue1);
                 break;
@@ -339,24 +339,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 TestEnum enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue2 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue2 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue2 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
                 testEnumArray0 .add(enumValue2);
             }
@@ -387,24 +387,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     {
                         int enumIndex3 = (decoder.readEnum());
                         TestEnum enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = TestEnum.values()[ 4 ];
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = TestEnum.values()[ 4 ];
+                                break;
+                            case  1 :
                                 enumValue3 = TestEnum.values()[ 3 ];
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = TestEnum.values()[ 1 ];
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = TestEnum.values()[ 2 ];
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = TestEnum.values()[ 0 ];
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = TestEnum.values()[ 1 ];
+                                break;
+                            case  3 :
+                                enumValue3 = TestEnum.values()[ 2 ];
+                                break;
+                            case  4 :
+                                enumValue3 = TestEnum.values()[ 0 ];
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray0 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -1,5 +1,5 @@
 
-package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -288,6 +289,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +320,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +360,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +410,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -272,24 +272,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
         TestRecord.put(17, testFixedUnionArray0);
         int enumIndex0 = (decoder.readEnum());
         TestEnum enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = TestEnum.values()[ 4 ];
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = TestEnum.values()[ 4 ];
+                break;
+            case  1 :
                 enumValue0 = TestEnum.values()[ 3 ];
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = TestEnum.values()[ 1 ];
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = TestEnum.values()[ 2 ];
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = TestEnum.values()[ 0 ];
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = TestEnum.values()[ 1 ];
+                break;
+            case  3 :
+                enumValue0 = TestEnum.values()[ 2 ];
+                break;
+            case  4 :
+                enumValue0 = TestEnum.values()[ 0 ];
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
         TestRecord.put(18, enumValue0);
         int unionIndex10 = (decoder.readIndex());
@@ -301,24 +301,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             {
                 int enumIndex1 = (decoder.readEnum());
                 TestEnum enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue1 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue1 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue1 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
                 TestRecord.put(19, enumValue1);
                 break;
@@ -339,24 +339,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 TestEnum enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue2 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue2 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue2 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
                 testEnumArray0 .add(enumValue2);
             }
@@ -387,24 +387,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     {
                         int enumIndex3 = (decoder.readEnum());
                         TestEnum enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = TestEnum.values()[ 4 ];
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = TestEnum.values()[ 4 ];
+                                break;
+                            case  1 :
                                 enumValue3 = TestEnum.values()[ 3 ];
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = TestEnum.values()[ 1 ];
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = TestEnum.values()[ 2 ];
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = TestEnum.values()[ 0 ];
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = TestEnum.values()[ 1 ];
+                                break;
+                            case  3 :
+                                enumValue3 = TestEnum.values()[ 2 ];
+                                break;
+                            case  4 :
+                                enumValue3 = TestEnum.values()[ 0 ];
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray0 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -1,5 +1,5 @@
 
-package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -288,6 +289,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +320,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +360,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +410,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -272,24 +272,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
         TestRecord.put(17, testFixedUnionArray0);
         int enumIndex0 = (decoder.readEnum());
         TestEnum enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = TestEnum.values()[ 4 ];
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = TestEnum.values()[ 4 ];
+                break;
+            case  1 :
                 enumValue0 = TestEnum.values()[ 3 ];
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = TestEnum.values()[ 1 ];
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = TestEnum.values()[ 2 ];
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = TestEnum.values()[ 0 ];
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = TestEnum.values()[ 1 ];
+                break;
+            case  3 :
+                enumValue0 = TestEnum.values()[ 2 ];
+                break;
+            case  4 :
+                enumValue0 = TestEnum.values()[ 0 ];
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
         TestRecord.put(18, enumValue0);
         int unionIndex10 = (decoder.readIndex());
@@ -301,24 +301,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             {
                 int enumIndex1 = (decoder.readEnum());
                 TestEnum enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue1 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue1 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue1 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
                 TestRecord.put(19, enumValue1);
                 break;
@@ -339,24 +339,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 TestEnum enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue2 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue2 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue2 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
                 testEnumArray0 .add(enumValue2);
             }
@@ -387,24 +387,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     {
                         int enumIndex3 = (decoder.readEnum());
                         TestEnum enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = TestEnum.values()[ 4 ];
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = TestEnum.values()[ 4 ];
+                                break;
+                            case  1 :
                                 enumValue3 = TestEnum.values()[ 3 ];
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = TestEnum.values()[ 1 ];
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = TestEnum.values()[ 2 ];
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = TestEnum.values()[ 0 ];
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = TestEnum.values()[ 1 ];
+                                break;
+                            case  3 :
+                                enumValue3 = TestEnum.values()[ 2 ];
+                                break;
+                            case  4 :
+                                enumValue3 = TestEnum.values()[ 0 ];
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray0 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_4569735063969434812_4415968328266630720.java
@@ -46,24 +46,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         }
         int enumIndex0 = (decoder.readEnum());
         org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  1 :
                 enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                break;
+            case  3 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                break;
+            case  4 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
         int unionIndex0 = (decoder.readIndex());
@@ -75,24 +75,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             {
                 int enumIndex1 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue1 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex1));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(1, enumValue1);
                 break;
@@ -113,24 +113,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 org.apache.avro.generic.GenericData.EnumSymbol enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                        break;
+                    case  1 :
                         enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                        break;
+                    case  3 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                        break;
+                    case  4 :
+                        enumValue2 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex2));
                 }
                 testEnumArray1 .add(enumValue2);
             }
@@ -161,24 +161,24 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
                     {
                         int enumIndex3 = (decoder.readEnum());
                         org.apache.avro.generic.GenericData.EnumSymbol enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                                break;
+                            case  1 :
                                 enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(4));
+                                break;
+                            case  3 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(2));
+                                break;
+                            case  4 :
+                                enumValue3 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(3));
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray1 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544.java
@@ -1,5 +1,5 @@
 
-package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -10,19 +10,20 @@ import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544
+public class TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544
     implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.TestRecord>
 {
 
     private final Schema readerSchema;
 
-    public TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544(Schema readerSchema) {
+    public TestRecord_SpecificDeserializer_1330694222118468182_4584175291925934544(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -288,6 +289,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             case  4 :
                 enumValue0 = TestEnum.values()[ 0 ];
                 break;
+            case  5 :
+                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
             default:
                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
@@ -317,6 +320,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue1 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
@@ -355,6 +360,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     case  4 :
                         enumValue2 = TestEnum.values()[ 0 ];
                         break;
+                    case  5 :
+                        throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                     default:
                         throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
@@ -403,6 +410,8 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                             case  4 :
                                 enumValue3 = TestEnum.values()[ 0 ];
                                 break;
+                            case  5 :
+                                throw new AvroTypeException("com.linkedin.avro.fastserde.generated.avro.TestEnum: No match for F");
                             default:
                                 throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_6151968197633927516_4584175291925934544.java
@@ -272,24 +272,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
         TestRecord.put(17, testFixedUnionArray0);
         int enumIndex0 = (decoder.readEnum());
         TestEnum enumValue0 = null;
-        if (enumIndex0 == 0) {
-            enumValue0 = TestEnum.values()[ 4 ];
-        } else {
-            if (enumIndex0 == 1) {
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = TestEnum.values()[ 4 ];
+                break;
+            case  1 :
                 enumValue0 = TestEnum.values()[ 3 ];
-            } else {
-                if (enumIndex0 == 2) {
-                    enumValue0 = TestEnum.values()[ 1 ];
-                } else {
-                    if (enumIndex0 == 3) {
-                        enumValue0 = TestEnum.values()[ 2 ];
-                    } else {
-                        if (enumIndex0 == 4) {
-                            enumValue0 = TestEnum.values()[ 0 ];
-                        }
-                    }
-                }
-            }
+                break;
+            case  2 :
+                enumValue0 = TestEnum.values()[ 1 ];
+                break;
+            case  3 :
+                enumValue0 = TestEnum.values()[ 2 ];
+                break;
+            case  4 :
+                enumValue0 = TestEnum.values()[ 0 ];
+                break;
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex0));
         }
         TestRecord.put(18, enumValue0);
         int unionIndex10 = (decoder.readIndex());
@@ -301,24 +301,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             {
                 int enumIndex1 = (decoder.readEnum());
                 TestEnum enumValue1 = null;
-                if (enumIndex1 == 0) {
-                    enumValue1 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex1 == 1) {
+                switch (enumIndex1) {
+                    case  0 :
+                        enumValue1 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue1 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex1 == 2) {
-                            enumValue1 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex1 == 3) {
-                                enumValue1 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex1 == 4) {
-                                    enumValue1 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue1 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue1 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue1 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex1));
                 }
                 TestRecord.put(19, enumValue1);
                 break;
@@ -339,24 +339,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
             for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                 int enumIndex2 = (decoder.readEnum());
                 TestEnum enumValue2 = null;
-                if (enumIndex2 == 0) {
-                    enumValue2 = TestEnum.values()[ 4 ];
-                } else {
-                    if (enumIndex2 == 1) {
+                switch (enumIndex2) {
+                    case  0 :
+                        enumValue2 = TestEnum.values()[ 4 ];
+                        break;
+                    case  1 :
                         enumValue2 = TestEnum.values()[ 3 ];
-                    } else {
-                        if (enumIndex2 == 2) {
-                            enumValue2 = TestEnum.values()[ 1 ];
-                        } else {
-                            if (enumIndex2 == 3) {
-                                enumValue2 = TestEnum.values()[ 2 ];
-                            } else {
-                                if (enumIndex2 == 4) {
-                                    enumValue2 = TestEnum.values()[ 0 ];
-                                }
-                            }
-                        }
-                    }
+                        break;
+                    case  2 :
+                        enumValue2 = TestEnum.values()[ 1 ];
+                        break;
+                    case  3 :
+                        enumValue2 = TestEnum.values()[ 2 ];
+                        break;
+                    case  4 :
+                        enumValue2 = TestEnum.values()[ 0 ];
+                        break;
+                    default:
+                        throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex2));
                 }
                 testEnumArray0 .add(enumValue2);
             }
@@ -387,24 +387,24 @@ public class TestRecord_SpecificDeserializer_6151968197633927516_458417529192593
                     {
                         int enumIndex3 = (decoder.readEnum());
                         TestEnum enumValue3 = null;
-                        if (enumIndex3 == 0) {
-                            enumValue3 = TestEnum.values()[ 4 ];
-                        } else {
-                            if (enumIndex3 == 1) {
+                        switch (enumIndex3) {
+                            case  0 :
+                                enumValue3 = TestEnum.values()[ 4 ];
+                                break;
+                            case  1 :
                                 enumValue3 = TestEnum.values()[ 3 ];
-                            } else {
-                                if (enumIndex3 == 2) {
-                                    enumValue3 = TestEnum.values()[ 1 ];
-                                } else {
-                                    if (enumIndex3 == 3) {
-                                        enumValue3 = TestEnum.values()[ 2 ];
-                                    } else {
-                                        if (enumIndex3 == 4) {
-                                            enumValue3 = TestEnum.values()[ 0 ];
-                                        }
-                                    }
-                                }
-                            }
+                                break;
+                            case  2 :
+                                enumValue3 = TestEnum.values()[ 1 ];
+                                break;
+                            case  3 :
+                                enumValue3 = TestEnum.values()[ 2 ];
+                                break;
+                            case  4 :
+                                enumValue3 = TestEnum.values()[ 0 ];
+                                break;
+                            default:
+                                throw new RuntimeException(("Illegal enum index for 'com.linkedin.avro.fastserde.generated.avro.TestEnum': "+ enumIndex3));
                         }
                         testEnumUnionArray0 .add(enumValue3);
                         break;

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/testRecord_GenericDeserializer_7253976692220671922_7760059578137488434.java
@@ -1,0 +1,56 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class testRecord_GenericDeserializer_7253976692220671922_7760059578137488434
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema testEnum0;
+
+    public testRecord_GenericDeserializer_7253976692220671922_7760059578137488434(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.testEnum0 = readerSchema.getField("testEnum").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializetestRecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord testRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            testRecord = ((IndexedRecord)(reuse));
+        } else {
+            testRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int enumIndex0 = (decoder.readEnum());
+        org.apache.avro.generic.GenericData.EnumSymbol enumValue0 = null;
+        switch (enumIndex0) {
+            case  0 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(0));
+                break;
+            case  1 :
+                enumValue0 = new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get(1));
+                break;
+            case  2 :
+                throw new AvroTypeException("com.adpilot.utils.generated.avro.testEnum: No match for C");
+            default:
+                throw new RuntimeException(("Illegal enum index for 'com.adpilot.utils.generated.avro.testEnum': "+ enumIndex0));
+        }
+        testRecord.put(0, enumValue0);
+        return testRecord;
+    }
+
+}

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDatumReaderTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDatumReaderTest.java
@@ -40,9 +40,6 @@ public class FastDatumReaderTest {
     FastDeserializer<TestRecord> fastSpecificDeserializer =
         (FastDeserializer<TestRecord>) cache.getFastSpecificDeserializer(TestRecord.SCHEMA$, TestRecord.SCHEMA$);
 
-    fastSpecificDeserializer =
-        (FastDeserializer<TestRecord>) cache.getFastSpecificDeserializer(TestRecord.SCHEMA$, TestRecord.SCHEMA$);
-
     Assert.assertNotNull(fastSpecificDeserializer);
     Assert.assertNotEquals(2, fastSpecificDeserializer.getClass().getDeclaredMethods().length);
     Assert.assertEquals(TestEnum.A, getField(fastSpecificDatumReader.read(null, specificDataAsDecoder(testRecord)), "testEnum"));
@@ -64,9 +61,6 @@ public class FastDatumReaderTest {
 
     // then
     FastDeserializer<TestRecord> fastSpecificDeserializer =
-        (FastDeserializer<TestRecord>) cache.getFastSpecificDeserializer(TestRecord.SCHEMA$, faultySchema);
-
-    fastSpecificDeserializer =
         (FastDeserializer<TestRecord>) cache.getFastSpecificDeserializer(TestRecord.SCHEMA$, faultySchema);
 
     Assert.assertNotNull(fastSpecificDeserializer);
@@ -92,9 +86,6 @@ public class FastDatumReaderTest {
 
     // then
     FastDeserializer<GenericRecord> fastGenericDeserializer =
-        (FastDeserializer<GenericRecord>) cache.getFastGenericDeserializer(recordSchema, recordSchema);
-
-    fastGenericDeserializer =
         (FastDeserializer<GenericRecord>) cache.getFastGenericDeserializer(recordSchema, recordSchema);
 
     Assert.assertNotNull(fastGenericDeserializer);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -263,21 +263,21 @@ public class FastGenericDeserializerGeneratorTest {
     Assert.assertEquals("D", ((List<GenericData.EnumSymbol>) record.get("testEnumUnionArray")).get(0).toString());
   }
 
-  @Test(expectedExceptions = FastDeserializerGeneratorException.class, groups = {"deserializationTest"})
-  public void shouldNotReadStrippedEnum() {
+  @Test(expectedExceptions = AvroTypeException.class, groups = {"deserializationTest"}, dataProvider = "Implementation")
+  public void shouldDecodeRecordAndOnlyFailWhenReadingStrippedEnum(Implementation implementation) {
     // given
     Schema enumSchema = createEnumSchema("testEnum", new String[]{"A", "B", "C"});
     Schema recordSchema = createRecord("testRecord", createField("testEnum", enumSchema));
 
     GenericRecord originalRecord = new GenericData.Record(recordSchema);
     originalRecord.put("testEnum",
-        AvroCompatibilityHelper.newEnumSymbol(null, "C"));//new GenericData.EnumSymbol("C"));
+        AvroCompatibilityHelper.newEnumSymbol(enumSchema, "C"));//new GenericData.EnumSymbol("C"));
 
     Schema enumSchema1 = createEnumSchema("testEnum", new String[]{"A", "B"});
     Schema recordSchema1 = createRecord("testRecord", createField("testEnum", enumSchema1));
 
     // when
-    GenericRecord record = decodeRecordWarmFast(recordSchema, recordSchema1, genericDataAsDecoder(originalRecord));
+    GenericRecord record = implementation.decode(recordSchema, recordSchema1, genericDataAsDecoder(originalRecord));
   }
 
   @Test(groups = {"deserializationTest"}, dataProvider = "Implementation")

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeTestsSupport.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSerdeTestsSupport.java
@@ -1,7 +1,6 @@
 package com.linkedin.avro.fastserde;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -22,7 +21,6 @@ import com.linkedin.avroutil1.compatibility.AvroVersion;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;


### PR DESCRIPTION
To behave consistently with vanilla avro, change from fail-at-compile time to fail-at-runtime (issue https://github.com/linkedin/avro-util/issues/191)

reference to previous PR https://github.com/linkedin/avro-util/pull/215

Vanilla avro throws AvroTypeException, and there is no behavior changes of GenericDatumReader.readEnum since 1.4
```
org.apache.avro.AvroTypeException: No match for C
	at org.apache.avro.io.ResolvingDecoder.readEnum(ResolvingDecoder.java:270)
	at org.apache.avro.generic.GenericDatumReader.readEnum(GenericDatumReader.java:267)
	at org.apache.avro.generic.GenericDatumReader.readWithoutConversion(GenericDatumReader.java:181)
```

Besides, this is not related to the default enum value feature added in 1.9