### PR TITLE
[helper] Add microbenchmarks covering SpecificRecord creation.

### DIFF
--- a/helper/tests/helper-tests-110/build.gradle
+++ b/helper/tests/helper-tests-110/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
+++ b/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro110;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla18() {
+    return set(new by18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla19() {
+    return set(new by19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla110() {
+    return set(new by110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla111() {
+    return set(new by111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder16() {
+    return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder17() {
+    return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder18() {
+    return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder19() {
+    return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder110() {
+    return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder17() {
+    return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder18() {
+    return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder19() {
+    return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder110() {
+    return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+}

--- a/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
+++ b/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
@@ -45,127 +45,127 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect18() {
+  public SpecificRecord vanilla18Direct() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect19() {
+  public SpecificRecord vanilla19Direct() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect110() {
+  public SpecificRecord vanilla110Direct() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect111() {
+  public SpecificRecord vanilla111Direct() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder16() {
+  public SpecificRecord vanilla16Builder() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder17() {
+  public SpecificRecord vanilla17Builder() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder18() {
+  public SpecificRecord vanilla18Builder() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder19() {
+  public SpecificRecord vanilla19Builder() {
     return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder110() {
+  public SpecificRecord vanilla110Builder() {
     return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder17() {
+  public SpecificRecord processed17Builder() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder18() {
+  public SpecificRecord processed18Builder() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder19() {
+  public SpecificRecord processed19Builder() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder110() {
+  public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
+++ b/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
@@ -36,133 +36,136 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla18() {
+  public SpecificRecord vanillaDirect18() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla19() {
+  public SpecificRecord vanillaDirect19() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla110() {
+  public SpecificRecord vanillaDirect110() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla111() {
+  public SpecificRecord vanillaDirect111() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder16() {
+  public SpecificRecord vanillaBuilder16() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder17() {
+  public SpecificRecord vanillaBuilder17() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder18() {
+  public SpecificRecord vanillaBuilder18() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder19() {
+  public SpecificRecord vanillaBuilder19() {
     return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder110() {
+  public SpecificRecord vanillaBuilder110() {
     return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder17() {
+  public SpecificRecord processedBuilder17() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder18() {
+  public SpecificRecord processedBuilder18() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder19() {
+  public SpecificRecord processedBuilder19() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder110() {
+  public SpecificRecord processedBuilder110() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-111/build.gradle
+++ b/helper/tests/helper-tests-111/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-111/src/jmh/java/com/linkedin/avroutil1/compatibility/avro111/NewRecord.java
+++ b/helper/tests/helper-tests-111/src/jmh/java/com/linkedin/avroutil1/compatibility/avro111/NewRecord.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro111;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla18() {
+    return set(new by18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla19() {
+    return set(new by19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla110() {
+    return set(new by110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla111() {
+    return set(new by111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder16() {
+    return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder17() {
+    return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder18() {
+    return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder19() {
+    return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder110() {
+    return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder111() {
+    return by111.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder17() {
+    return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder18() {
+    return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder19() {
+    return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder110() {
+    return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder111() {
+    return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+}

--- a/helper/tests/helper-tests-111/src/jmh/java/com/linkedin/avroutil1/compatibility/avro111/NewRecord.java
+++ b/helper/tests/helper-tests-111/src/jmh/java/com/linkedin/avroutil1/compatibility/avro111/NewRecord.java
@@ -45,137 +45,137 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect18() {
+  public SpecificRecord vanilla18Direct() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect19() {
+  public SpecificRecord vanilla19Direct() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect110() {
+  public SpecificRecord vanilla110Direct() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect111() {
+  public SpecificRecord vanilla111Direct() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder16() {
+  public SpecificRecord vanilla16Builder() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder17() {
+  public SpecificRecord vanilla17Builder() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder18() {
+  public SpecificRecord vanilla18Builder() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder19() {
+  public SpecificRecord vanilla19Builder() {
     return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder110() {
+  public SpecificRecord vanilla110Builder() {
     return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder111() {
+  public SpecificRecord vanilla111Builder() {
     return by111.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder17() {
+  public SpecificRecord processed17Builder() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder18() {
+  public SpecificRecord processed18Builder() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder19() {
+  public SpecificRecord processed19Builder() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder110() {
+  public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder111() {
+  public SpecificRecord processed111Builder() {
     return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-111/src/jmh/java/com/linkedin/avroutil1/compatibility/avro111/NewRecord.java
+++ b/helper/tests/helper-tests-111/src/jmh/java/com/linkedin/avroutil1/compatibility/avro111/NewRecord.java
@@ -36,143 +36,146 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla18() {
+  public SpecificRecord vanillaDirect18() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla19() {
+  public SpecificRecord vanillaDirect19() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla110() {
+  public SpecificRecord vanillaDirect110() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla111() {
+  public SpecificRecord vanillaDirect111() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder16() {
+  public SpecificRecord vanillaBuilder16() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder17() {
+  public SpecificRecord vanillaBuilder17() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder18() {
+  public SpecificRecord vanillaBuilder18() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder19() {
+  public SpecificRecord vanillaBuilder19() {
     return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder110() {
+  public SpecificRecord vanillaBuilder110() {
     return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder111() {
+  public SpecificRecord vanillaBuilder111() {
     return by111.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder17() {
+  public SpecificRecord processedBuilder17() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder18() {
+  public SpecificRecord processedBuilder18() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder19() {
+  public SpecificRecord processedBuilder19() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder110() {
+  public SpecificRecord processedBuilder110() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder111() {
+  public SpecificRecord processedBuilder111() {
     return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-14/build.gradle
+++ b/helper/tests/helper-tests-14/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-14/src/jmh/java/com/linkedin/avroutil1/compatibility/avro14/NewRecord.java
+++ b/helper/tests/helper-tests-14/src/jmh/java/com/linkedin/avroutil1/compatibility/avro14/NewRecord.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro14;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+}

--- a/helper/tests/helper-tests-14/src/jmh/java/com/linkedin/avroutil1/compatibility/avro14/NewRecord.java
+++ b/helper/tests/helper-tests-14/src/jmh/java/com/linkedin/avroutil1/compatibility/avro14/NewRecord.java
@@ -36,58 +36,61 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 }

--- a/helper/tests/helper-tests-14/src/jmh/java/com/linkedin/avroutil1/compatibility/avro14/NewRecord.java
+++ b/helper/tests/helper-tests-14/src/jmh/java/com/linkedin/avroutil1/compatibility/avro14/NewRecord.java
@@ -45,52 +45,52 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 }

--- a/helper/tests/helper-tests-15/build.gradle
+++ b/helper/tests/helper-tests-15/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-15/src/jmh/java/com/linkedin/avroutil1/compatibility/avro15/NewRecord.java
+++ b/helper/tests/helper-tests-15/src/jmh/java/com/linkedin/avroutil1/compatibility/avro15/NewRecord.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro15;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+}

--- a/helper/tests/helper-tests-15/src/jmh/java/com/linkedin/avroutil1/compatibility/avro15/NewRecord.java
+++ b/helper/tests/helper-tests-15/src/jmh/java/com/linkedin/avroutil1/compatibility/avro15/NewRecord.java
@@ -36,68 +36,71 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 }

--- a/helper/tests/helper-tests-15/src/jmh/java/com/linkedin/avroutil1/compatibility/avro15/NewRecord.java
+++ b/helper/tests/helper-tests-15/src/jmh/java/com/linkedin/avroutil1/compatibility/avro15/NewRecord.java
@@ -45,62 +45,62 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 }

--- a/helper/tests/helper-tests-16/build.gradle
+++ b/helper/tests/helper-tests-16/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
+++ b/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
@@ -36,98 +36,101 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder16() {
+  public SpecificRecord vanillaBuilder16() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder17() {
+  public SpecificRecord vanillaBuilder17() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder17() {
+  public SpecificRecord processedBuilder17() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder18() {
+  public SpecificRecord processedBuilder18() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder19() {
+  public SpecificRecord processedBuilder19() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder110() {
+  public SpecificRecord processedBuilder110() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
+++ b/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
@@ -45,92 +45,92 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder16() {
+  public SpecificRecord vanilla16Builder() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder17() {
+  public SpecificRecord vanilla17Builder() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder17() {
+  public SpecificRecord processed17Builder() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder18() {
+  public SpecificRecord processed18Builder() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder19() {
+  public SpecificRecord processed19Builder() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder110() {
+  public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
+++ b/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro16;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder16() {
+    return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder17() {
+    return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder17() {
+    return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder18() {
+    return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder19() {
+    return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder110() {
+    return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+}

--- a/helper/tests/helper-tests-17/build.gradle
+++ b/helper/tests/helper-tests-17/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
+++ b/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
@@ -36,98 +36,101 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder16() {
+  public SpecificRecord vanillaBuilder16() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder17() {
+  public SpecificRecord vanillaBuilder17() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder17() {
+  public SpecificRecord processedBuilder17() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder18() {
+  public SpecificRecord processedBuilder18() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder19() {
+  public SpecificRecord processedBuilder19() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder110() {
+  public SpecificRecord processedBuilder110() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
+++ b/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro17;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder16() {
+    return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder17() {
+    return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder17() {
+    return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder18() {
+    return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder19() {
+    return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder110() {
+    return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+}

--- a/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
+++ b/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
@@ -45,92 +45,92 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder16() {
+  public SpecificRecord vanilla16Builder() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder17() {
+  public SpecificRecord vanilla17Builder() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder17() {
+  public SpecificRecord processed17Builder() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder18() {
+  public SpecificRecord processed18Builder() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder19() {
+  public SpecificRecord processed19Builder() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder110() {
+  public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-18/build.gradle
+++ b/helper/tests/helper-tests-18/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
+++ b/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
@@ -36,123 +36,126 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla18() {
+  public SpecificRecord vanillaDirect18() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla19() {
+  public SpecificRecord vanillaDirect19() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla110() {
+  public SpecificRecord vanillaDirect110() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla111() {
+  public SpecificRecord vanillaDirect111() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder16() {
+  public SpecificRecord vanillaBuilder16() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder17() {
+  public SpecificRecord vanillaBuilder17() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder18() {
+  public SpecificRecord vanillaBuilder18() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder17() {
+  public SpecificRecord processedBuilder17() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder18() {
+  public SpecificRecord processedBuilder18() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder19() {
+  public SpecificRecord processedBuilder19() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder110() {
+  public SpecificRecord processedBuilder110() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
+++ b/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
@@ -45,117 +45,117 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect18() {
+  public SpecificRecord vanilla18Direct() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect19() {
+  public SpecificRecord vanilla19Direct() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect110() {
+  public SpecificRecord vanilla110Direct() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect111() {
+  public SpecificRecord vanilla111Direct() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder16() {
+  public SpecificRecord vanilla16Builder() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder17() {
+  public SpecificRecord vanilla17Builder() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder18() {
+  public SpecificRecord vanilla18Builder() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder17() {
+  public SpecificRecord processed17Builder() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder18() {
+  public SpecificRecord processed18Builder() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder19() {
+  public SpecificRecord processed19Builder() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder110() {
+  public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
+++ b/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro18;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla18() {
+    return set(new by18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla19() {
+    return set(new by19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla110() {
+    return set(new by110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla111() {
+    return set(new by111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder16() {
+    return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder17() {
+    return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder18() {
+    return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder17() {
+    return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder18() {
+    return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder19() {
+    return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder110() {
+    return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+}

--- a/helper/tests/helper-tests-19/build.gradle
+++ b/helper/tests/helper-tests-19/build.gradle
@@ -8,6 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
+  id "me.champeau.gradle.jmh" version "0.5.3"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
+++ b/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
@@ -45,127 +45,127 @@ public class NewRecord {
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect14() {
+  public SpecificRecord vanilla14Direct() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect15() {
+  public SpecificRecord vanilla15Direct() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect16() {
+  public SpecificRecord vanilla16Direct() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect17() {
+  public SpecificRecord vanilla17Direct() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect18() {
+  public SpecificRecord vanilla18Direct() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect19() {
+  public SpecificRecord vanilla19Direct() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect110() {
+  public SpecificRecord vanilla110Direct() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaDirect111() {
+  public SpecificRecord vanilla111Direct() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder16() {
+  public SpecificRecord vanilla16Builder() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder17() {
+  public SpecificRecord vanilla17Builder() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder18() {
+  public SpecificRecord vanilla18Builder() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder19() {
+  public SpecificRecord vanilla19Builder() {
     return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord vanillaBuilder110() {
+  public SpecificRecord vanilla110Builder() {
     return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedDirect14() {
+  public SpecificRecord processed14Direct() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect15() {
+  public SpecificRecord processed15Direct() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect16() {
+  public SpecificRecord processed16Direct() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect17() {
+  public SpecificRecord processed17Direct() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect18() {
+  public SpecificRecord processed18Direct() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect19() {
+  public SpecificRecord processed19Direct() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect110() {
+  public SpecificRecord processed110Direct() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedDirect111() {
+  public SpecificRecord processed111Direct() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder17() {
+  public SpecificRecord processed17Builder() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder18() {
+  public SpecificRecord processed18Builder() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder19() {
+  public SpecificRecord processed19Builder() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord processedBuilder110() {
+  public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
+++ b/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro19;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.specific.SpecificRecord;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 1, time = 10, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 100, timeUnit = TimeUnit.MILLISECONDS)
+@OutputTimeUnit(value = TimeUnit.MILLISECONDS)
+public class NewRecord {
+  private static final String MESSAGE = "Hello, World!";
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder().include(NewRecord.class.getSimpleName()).build();
+    new Runner(opt).run();
+  }
+
+  private static SpecificRecord set(SpecificRecord record) {
+    record.put(0, MESSAGE);
+    return record;
+  }
+
+  @Benchmark
+  public SpecificRecord baseline() {
+    return null;
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla14() {
+    return set(new by14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla15() {
+    return set(new by15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla16() {
+    return set(new by16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla17() {
+    return set(new by17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla18() {
+    return set(new by18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla19() {
+    return set(new by19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla110() {
+    return set(new by110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeVanilla111() {
+    return set(new by111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder16() {
+    return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder17() {
+    return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder18() {
+    return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder19() {
+    return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord nativeBuilder110() {
+    return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla14() {
+    return set(new under14.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla15() {
+    return set(new under15.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla16() {
+    return set(new under16.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla17() {
+    return set(new under17.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla18() {
+    return set(new under18.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla19() {
+    return set(new under19.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla110() {
+    return set(new under110.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatVanilla111() {
+    return set(new under111.SimpleRecord());
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder17() {
+    return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder18() {
+    return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder19() {
+    return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+
+  @Benchmark
+  public SpecificRecord compatBuilder110() {
+    return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
+}

--- a/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
+++ b/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
@@ -36,133 +36,136 @@ public class NewRecord {
     return record;
   }
 
+  // A baseline to compare the rest of the measurements against.
+  // Useful as a ceiling of the possible performance and to get
+  // an idea of the inherent overhead/variance involved.
   @Benchmark
   public SpecificRecord baseline() {
     return null;
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla14() {
+  public SpecificRecord vanillaDirect14() {
     return set(new by14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla15() {
+  public SpecificRecord vanillaDirect15() {
     return set(new by15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla16() {
+  public SpecificRecord vanillaDirect16() {
     return set(new by16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla17() {
+  public SpecificRecord vanillaDirect17() {
     return set(new by17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla18() {
+  public SpecificRecord vanillaDirect18() {
     return set(new by18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla19() {
+  public SpecificRecord vanillaDirect19() {
     return set(new by19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla110() {
+  public SpecificRecord vanillaDirect110() {
     return set(new by110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeVanilla111() {
+  public SpecificRecord vanillaDirect111() {
     return set(new by111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder16() {
+  public SpecificRecord vanillaBuilder16() {
     return by16.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder17() {
+  public SpecificRecord vanillaBuilder17() {
     return by17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder18() {
+  public SpecificRecord vanillaBuilder18() {
     return by18.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder19() {
+  public SpecificRecord vanillaBuilder19() {
     return by19.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord nativeBuilder110() {
+  public SpecificRecord vanillaBuilder110() {
     return by110.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla14() {
+  public SpecificRecord processedDirect14() {
     return set(new under14.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla15() {
+  public SpecificRecord processedDirect15() {
     return set(new under15.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla16() {
+  public SpecificRecord processedDirect16() {
     return set(new under16.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla17() {
+  public SpecificRecord processedDirect17() {
     return set(new under17.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla18() {
+  public SpecificRecord processedDirect18() {
     return set(new under18.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla19() {
+  public SpecificRecord processedDirect19() {
     return set(new under19.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla110() {
+  public SpecificRecord processedDirect110() {
     return set(new under110.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatVanilla111() {
+  public SpecificRecord processedDirect111() {
     return set(new under111.SimpleRecord());
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder17() {
+  public SpecificRecord processedBuilder17() {
     return under17target17.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder18() {
+  public SpecificRecord processedBuilder18() {
     return under18wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder19() {
+  public SpecificRecord processedBuilder19() {
     return under19wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 
   @Benchmark
-  public SpecificRecord compatBuilder110() {
+  public SpecificRecord processedBuilder110() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
 }

--- a/helper/tests/helper-tests-allavro/build.gradle
+++ b/helper/tests/helper-tests-allavro/build.gradle
@@ -219,3 +219,14 @@ for (String avroVersion : avroVersions) {
   }
 
 }
+
+task jmh {
+  dependsOn ':helper:tests:helper-tests-14:jmh'
+  dependsOn ':helper:tests:helper-tests-15:jmh'
+  dependsOn ':helper:tests:helper-tests-16:jmh'
+  dependsOn ':helper:tests:helper-tests-17:jmh'
+  dependsOn ':helper:tests:helper-tests-18:jmh'
+  dependsOn ':helper:tests:helper-tests-19:jmh'
+  dependsOn ':helper:tests:helper-tests-110:jmh'
+  dependsOn ':helper:tests:helper-tests-111:jmh'
+}


### PR DESCRIPTION
To run an individual benchmark, for example:
`$ ./gradlew :helper:tests:helper-tests-111:jmh`

To run all the benchmarks:
`$ ./gradlew :helper:tests:helper-tests-allavro:jmh`

NOTE TO REVIEWERS: You only need to review the benchmark code for Avro 1.11. All the others are exact copies of that code, except that methods not supported in those versions have been removed.

Here's example output from running them on my laptop. The units are "operations per millisecond", so larger numbers indicate better performance. The naming convention is `NewRecord.<compat|native><Vanilla|Builder><version>`, where:
* `native` means using the SpecificRecords as generated by raw Avro; `compat` means using the SpecificRecords that were post-processed by the compat helper.
* `Vanilla` means creating the SpecificRecord directly; `Builder` means using the SpecificRecord's Builder.
* `version` is the Avro version that was used for codegen.

When using the Avro 1.11 runtime:
```
$ ./gradlew :helper:tests:helper-tests-111:jmh
...
Benchmark                    Mode  Cnt       Score        Error   Units
NewRecord.baseline          thrpt   10  483650.790 ±  41601.464  ops/ms
NewRecord.compatBuilder110  thrpt   10   18810.822 ±   9340.382  ops/ms
NewRecord.compatBuilder111  thrpt   10   33336.904 ±  15038.719  ops/ms
NewRecord.compatBuilder17   thrpt   10   19009.504 ±   7587.498  ops/ms
NewRecord.compatBuilder18   thrpt   10   19149.787 ±   7315.799  ops/ms
NewRecord.compatBuilder19   thrpt   10   19177.193 ±   8222.468  ops/ms
NewRecord.compatVanilla110  thrpt   10  188088.359 ± 103845.708  ops/ms
NewRecord.compatVanilla111  thrpt   10  187229.608 ± 106093.082  ops/ms
NewRecord.compatVanilla14   thrpt   10  186089.544 ± 101336.065  ops/ms
NewRecord.compatVanilla15   thrpt   10  186158.427 ± 110087.323  ops/ms
NewRecord.compatVanilla16   thrpt   10  185076.431 ± 106481.309  ops/ms
NewRecord.compatVanilla17   thrpt   10  184265.399 ± 107458.747  ops/ms
NewRecord.compatVanilla18   thrpt   10  184115.433 ± 109033.166  ops/ms
NewRecord.compatVanilla19   thrpt   10  187876.949 ± 109898.063  ops/ms
NewRecord.nativeBuilder110  thrpt   10   19295.950 ±   7689.354  ops/ms
NewRecord.nativeBuilder111  thrpt   10   33722.974 ±  17539.089  ops/ms
NewRecord.nativeBuilder16   thrpt   10   19296.831 ±   7214.881  ops/ms
NewRecord.nativeBuilder17   thrpt   10   18517.499 ±   9118.929  ops/ms
NewRecord.nativeBuilder18   thrpt   10   19141.935 ±   7796.391  ops/ms
NewRecord.nativeBuilder19   thrpt   10   18848.355 ±   7706.868  ops/ms
NewRecord.nativeVanilla110  thrpt   10  185131.595 ± 103540.740  ops/ms
NewRecord.nativeVanilla111  thrpt   10  187666.687 ± 105113.382  ops/ms
NewRecord.nativeVanilla14   thrpt   10  186239.172 ± 102077.582  ops/ms
NewRecord.nativeVanilla15   thrpt   10  188646.897 ± 105220.576  ops/ms
NewRecord.nativeVanilla16   thrpt   10  185604.358 ± 108418.229  ops/ms
NewRecord.nativeVanilla17   thrpt   10  190201.829 ± 102511.715  ops/ms
NewRecord.nativeVanilla18   thrpt   10  189993.731 ± 108394.791  ops/ms
NewRecord.nativeVanilla19   thrpt   10  189215.674 ± 100074.789  ops/ms
```

When using the Avro 1.10 runtime:
```
$ ./gradlew :helper:tests:helper-tests-110:jmh
...
Benchmark                    Mode  Cnt       Score        Error   Units
NewRecord.baseline          thrpt   10  475747.515 ±  59444.385  ops/ms
NewRecord.compatBuilder110  thrpt   10    1450.689 ±    257.760  ops/ms
NewRecord.compatBuilder17   thrpt   10    1489.353 ±    258.188  ops/ms
NewRecord.compatBuilder18   thrpt   10    1481.267 ±    277.494  ops/ms
NewRecord.compatBuilder19   thrpt   10    1530.024 ±    293.307  ops/ms
NewRecord.compatVanilla110  thrpt   10  187959.050 ± 101496.248  ops/ms
NewRecord.compatVanilla111  thrpt   10  188721.936 ± 102989.019  ops/ms
NewRecord.compatVanilla14   thrpt   10  188029.774 ± 107272.304  ops/ms
NewRecord.compatVanilla15   thrpt   10  184698.016 ±  97649.332  ops/ms
NewRecord.compatVanilla16   thrpt   10  187462.131 ± 101293.849  ops/ms
NewRecord.compatVanilla17   thrpt   10  188370.656 ± 109021.253  ops/ms
NewRecord.compatVanilla18   thrpt   10  185957.574 ± 105210.096  ops/ms
NewRecord.compatVanilla19   thrpt   10  186656.320 ± 105397.402  ops/ms
NewRecord.nativeBuilder110  thrpt   10    1685.580 ±    324.823  ops/ms
NewRecord.nativeBuilder16   thrpt   10     525.350 ±     95.779  ops/ms
NewRecord.nativeBuilder17   thrpt   10     503.257 ±     92.320  ops/ms
NewRecord.nativeBuilder18   thrpt   10    1756.536 ±    316.604  ops/ms
NewRecord.nativeBuilder19   thrpt   10    1760.708 ±    346.511  ops/ms
NewRecord.nativeVanilla110  thrpt   10  187141.275 ± 106350.629  ops/ms
NewRecord.nativeVanilla111  thrpt   10  188114.368 ± 106705.393  ops/ms
NewRecord.nativeVanilla14   thrpt   10  186783.767 ± 112835.014  ops/ms
NewRecord.nativeVanilla15   thrpt   10  187561.140 ± 104141.028  ops/ms
NewRecord.nativeVanilla16   thrpt   10  189445.889 ± 101170.446  ops/ms
NewRecord.nativeVanilla17   thrpt   10  187961.020 ± 107962.988  ops/ms
NewRecord.nativeVanilla18   thrpt   10  186099.852 ± 114916.116  ops/ms
NewRecord.nativeVanilla19   thrpt   10  189737.004 ± 106846.277  ops/ms
```

You can see:
* Using Builders under Avro 1.10 is an order of magnitude slower than under Avro 1.11. This is the issue in #220.
* Using Builders under any Avro is much slower than creating SpecificRecords directly. But Avro 1.11 manages to get ~2x speedup when using its codegen (because it avoids the slow path; see #220 for details).