### PR TITLE
[helper] Avoid expensive calls in Builder constructors.

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
@@ -914,13 +914,15 @@ public class CodeTransformations {
 
     // Add the cached instance. It's important to add it after the SCHEMA$ and MODEL$ definitions, since the creation
     // of the cached instance may try to look up those fields.
-    int model$EndPosition = code.indexOf(MODEL_DECL_REPLACEMENT);
-    if (model$EndPosition < 0) {
-      throw new IllegalStateException("cannot locate MODEL$ declaration in " + code);
+    int insertPosition = code.indexOf(MODEL_DECL_REPLACEMENT);
+    if (insertPosition < 0) {
+      // This must be because the max targeted Avro version is <= 1.8, which doesn't use MODEL$. Use SCHEMA$ instead.
+      insertPosition = findEndOfSchemaDeclaration(code);
+    } else {
+      insertPosition += MODEL_DECL_REPLACEMENT.length();
     }
-    model$EndPosition += MODEL_DECL_REPLACEMENT.length();
-    return code.substring(0, model$EndPosition) + "\nprivate static final " + builderClassName +
-        " " + BUILDER_INSTANCE_NAME + " = new " + builderClassName + "(false);\n" + code.substring(model$EndPosition);
+    return code.substring(0, insertPosition) + "\nprivate static final " + builderClassName +
+        " " + BUILDER_INSTANCE_NAME + " = new " + builderClassName + "(false);\n" + code.substring(insertPosition);
   }
 
   private static String addImports(String code, Collection<String> importStatements) {

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
@@ -887,8 +887,8 @@ public class CodeTransformations {
   // * Make the other constructors call that instead, using the cached builder instance.
   //
   // Avro 1.11 codegen produces Builder constructors that call `super(SCHEMA$, MODEL$)`. Such a method doesn't exist in
-  // the super-class (SpecificRecordBase) in any older Avro. So, we transform those as well. This has the benefit that
-  // Avro 1.11 codegen (post-processed by us) can still be used with runtime Avro 1.6 through 1.10.
+  // the super-class (SpecificRecordBuilderBase) in any older Avro. So, we transform those as well. This has the benefit
+  // that Avro 1.11 codegen (post-processed by us) can still be used with runtime Avro 1.6 through 1.10.
   private static String fixBuilderConstructors(String code) {
     Matcher builderClassMatcher = BUILDER_CLASS_PATTERN.matcher(code);
     if (!builderClassMatcher.find()) {

--- a/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
+++ b/helper/tests/helper-tests-110/src/jmh/java/com/linkedin/avroutil1/compatibility/avro110/NewRecord.java
@@ -168,4 +168,9 @@ public class NewRecord {
   public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
+
+  @Benchmark
+  public SpecificRecord processed111Builder() {
+    return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
 }

--- a/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
+++ b/helper/tests/helper-tests-16/src/jmh/java/com/linkedin/avroutil1/compatibility/avro16/NewRecord.java
@@ -133,4 +133,9 @@ public class NewRecord {
   public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
+
+  @Benchmark
+  public SpecificRecord processed111Builder() {
+    return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
 }

--- a/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
+++ b/helper/tests/helper-tests-17/src/jmh/java/com/linkedin/avroutil1/compatibility/avro17/NewRecord.java
@@ -133,4 +133,9 @@ public class NewRecord {
   public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
+
+  @Benchmark
+  public SpecificRecord processed111Builder() {
+    return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
 }

--- a/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
+++ b/helper/tests/helper-tests-18/src/jmh/java/com/linkedin/avroutil1/compatibility/avro18/NewRecord.java
@@ -158,4 +158,9 @@ public class NewRecord {
   public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
+
+  @Benchmark
+  public SpecificRecord processed111Builder() {
+    return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
 }

--- a/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
+++ b/helper/tests/helper-tests-19/src/jmh/java/com/linkedin/avroutil1/compatibility/avro19/NewRecord.java
@@ -168,4 +168,9 @@ public class NewRecord {
   public SpecificRecord processed110Builder() {
     return under110wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
   }
+
+  @Benchmark
+  public SpecificRecord processed111Builder() {
+    return under111wbuilders.SimpleRecord.newBuilder().setStringField(MESSAGE).build();
+  }
 }


### PR DESCRIPTION
The introduction of a `private Builder(boolean)` constructor is ugly,
but it's the simplest way I found to deal with this issue. It's private
and not exposed, so the ugliness shouldn't bleed into anything else.

Fixes #220. In addition, since 1.11 codegen can now be processed into
being compatible with older runtimes, add some benchmark methods that
weren't possible before.

Here's the benchmark output from my laptop, only the interesting bits
(the parts that changed):

Before:
```
$ ./gradlew :helper:tests:helper-tests-110:jmh
...
NewRecord.processed110Builder  thrpt   10    1307.549 ±    282.097  ops/ms
NewRecord.processed17Builder   thrpt   10    1070.114 ±    259.597  ops/ms
NewRecord.processed18Builder   thrpt   10    1231.135 ±    204.276  ops/ms
NewRecord.processed19Builder   thrpt   10    1338.624 ±    267.086  ops/ms
```

After:
```
$ ./gradlew :helper:tests:helper-tests-110:jmh
...
Benchmark                       Mode  Cnt       Score        Error   Units
NewRecord.processed110Builder  thrpt   10   29914.824 ±  20403.631  ops/ms
NewRecord.processed17Builder   thrpt   10   33792.257 ±  18056.973  ops/ms
NewRecord.processed18Builder   thrpt   10   33543.303 ±  19317.861  ops/ms
NewRecord.processed19Builder   thrpt   10   30624.449 ±  14613.924  ops/ms
```

Roughly a 25x improvement.