### PR TITLE
Fix bug in PrimitiveArrayList add method

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveArrayList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/primitive/PrimitiveArrayList.java
@@ -177,7 +177,7 @@ public abstract class PrimitiveArrayList<T, L, A> extends AbstractList<T>
       A newElements = newArray((size * 3)/2 + 1);
       if (location > 0) {
         // Copy the elements before the insertion location, if any, with same index
-        System.arraycopy(elementsArray, 0, newElements, 0, location - 1);
+        System.arraycopy(elementsArray, 0, newElements, 0, location);
       }
       // Copy the elements after the insertion location, with index offset by 1
       System.arraycopy(elementsArray, location, newElements, location + 1, size - location);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/PrimitiveArrayListTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/PrimitiveArrayListTest.java
@@ -1,0 +1,30 @@
+package com.linkedin.avro.fastserde;
+
+import com.linkedin.avro.fastserde.primitive.PrimitiveFloatArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PrimitiveArrayListTest {
+  @Test
+  public void testPrimitiveLongArrayAdd() {
+    List<Long> newVector = new PrimitiveLongArrayList(1);
+    newVector.add(0, 1L);
+    newVector.add(1, 2L);
+    newVector.add(2, 3L);
+    List<Long> expectedVector = Arrays.asList(1L, 2L, 3L);
+    Assert.assertEquals(newVector, expectedVector);
+  }
+  @Test
+  public void testPrimitiveFloatArrayAdd() {
+    List<Float> newVector = new PrimitiveFloatArrayList(1);
+    newVector.add(0, 1.0f);
+    newVector.add(1, 2.0f);
+    newVector.add(2, 3.0f);
+    List<Float> expectedVector = Arrays.asList(1.0f, 2.0f, 3.0f);
+    Assert.assertEquals(newVector, expectedVector);
+  }
+}


### PR DESCRIPTION
This line is the issue:
System.arraycopy(elementsArray, 0, newElements, 0, location - 1);
The fifth input is the length of the elements to copy.
Assuming the size of previous array is 2, like [111, 222]; and we call PrimitiveLongArrayList.add(2, 0L) , position is 2, so we end up running System.arraycopy(elementsArray, 0, newElements, 0, 2 - 1) , only copying the first element from the previous backing array to the new backing array.
In another word, as long as we call PrimitiveLongArrayList.add(PrimitiveLongArrayList.size(), 0) to expand the array list, we will lose the last element from the original list. The correct implementation should be:
System.arraycopy(elementsArray, 0, newElements, 0, location);