### PR TITLE
(badly) fix handling of escaped newlines and quotes in alternative avsc

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroGeneratedSourceCode.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroGeneratedSourceCode.java
@@ -29,6 +29,12 @@ public class AvroGeneratedSourceCode {
     this.contents = contents;
   }
 
+  public AvroGeneratedSourceCode(String path, String contents, String alternativeAvsc) {
+    this.path = path;
+    this.contents = contents;
+    this.alternativeAvsc = alternativeAvsc;
+  }
+
   /**
    * @return the path (relative to source root) under which this file is intended to be written
    */

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
@@ -386,7 +386,10 @@ public class CodeTransformations {
 
     //drop in alternative avsc?
     if (alternativeAvsc != null && !alternativeAvsc.isEmpty()) {
-      stringLiteral = StringEscapeUtils.escapeJava(alternativeAvsc);
+      //horrible hack to strip out escaped quotes and newlines in json literals (usually doc fields)
+      stringLiteral = alternativeAvsc.replaceAll("\\\\([n\"])", "");
+      //then escape the result to be a valida java string literal
+      stringLiteral = StringEscapeUtils.escapeJava(stringLiteral);
     }
 
     boolean largeString = stringLiteral.length() >= MAX_STRING_LITERAL_SIZE;

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -366,7 +366,7 @@ public class Avro14Adapter implements AvroAdapter {
               maxAvro,
               generated.getAlternativeAvsc()
       );
-      transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
+      transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed, generated.getAlternativeAvsc()));
     }
     return transformed;
   }

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/CodeTransformationsAvro14Test.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/CodeTransformationsAvro14Test.java
@@ -96,6 +96,23 @@ public class CodeTransformationsAvro14Test {
   }
 
   @Test
+  public void testAlternateAvscUnderAvro14WithEscaping() throws Exception {
+    String altAvsc = TestUtil.load("RecordWithMultilineDoc.avsc");
+    String avsc = TestUtil.load("RecordWithMultilineDoc.avsc");
+    Schema schema = AvroCompatibilityHelper.parse(avsc);
+    String originalCode = runNativeCodegen(schema);
+
+    String transformedCode = CodeTransformations.transformParseCalls(originalCode, AvroVersion.AVRO_1_4, AvroVersion.earliest(), AvroVersion.latest(), altAvsc);
+
+    Class<?> transformedClass = CompilerUtils.CACHED_COMPILER.loadFromJava(schema.getFullName(), transformedCode);
+    Assert.assertNotNull(transformedClass);
+
+    Schema inCode = (Schema) transformedClass.getField("SCHEMA$").get(null);
+
+    Assert.assertEquals(inCode, schema); //no (significant) harm done
+  }
+
+  @Test
   public void testFixAvro702() throws Exception {
     String avsc = TestUtil.load("MonsantoRecord.avsc");
     @SuppressWarnings("UnnecessaryLocalVariable")


### PR DESCRIPTION
i've tried multiple StringEscapeUtils invocations to no avail, and as this is causing issues for me downstream im settling for simply nuking escaped newlines and quotes for now :-( 