### PR TITLE
[helper] Fix broken escaping in codegen by Avro 1.4/1.5.

### DIFF
--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/CodeTransformationsAvro14Test.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/CodeTransformationsAvro14Test.java
@@ -131,6 +131,23 @@ public class CodeTransformationsAvro14Test {
     Assert.assertEquals(inCode, schema);
   }
 
+  @Test
+  public void testAlternateAvscUnderAvro14WithEscaping() throws Exception {
+    String altAvsc = TestUtil.load("RecordWithMultilineDoc.avsc");
+    String avsc = TestUtil.load("RecordWithMultilineDoc.avsc");
+    Schema schema = AvroCompatibilityHelper.parse(avsc);
+    String originalCode = runNativeCodegen(schema);
+
+    String transformedCode = CodeTransformations.transformParseCalls(originalCode, AvroVersion.AVRO_1_4, AvroVersion.earliest(), AvroVersion.latest(), altAvsc);
+
+    Class<?> transformedClass = CompilerUtils.CACHED_COMPILER.loadFromJava(schema.getFullName(), transformedCode);
+    Assert.assertNotNull(transformedClass);
+
+    Schema inCode = (Schema) transformedClass.getField("SCHEMA$").get(null);
+
+    Assert.assertEquals(inCode, schema); //no (significant) harm done
+  }
+
   private String runNativeCodegen(Schema schema) throws Exception {
     File outputRoot = Files.createTempDirectory(null).toFile();
     return runNativeCodegen(schema, outputRoot);


### PR DESCRIPTION
Avro 1.4/1.5 generate broken (uncompilable) code when the schema has
escaped chars in strings. We fix such code in the compat helper by:
* First, undoing the damage (unescaping `\"` back to `"`),
* Then, escaping backslashes (escaping `\` to `\\`), and
* Finally, re-escaping the quotes (from `"` to `\"`).

If we are replacing the schema with an "alternative", since the alt
comes directly from JSON, and not from codegen, we escape it using
a standard function (`StringEscapeUtils.escapeJava`), and don't bother
fixing up the original broken code.

If the code was generated by Avro 1.6 or later, it would be correctly
escaped to begin with, so there's nothing more to do.

The test was copied from PR #252, courtesy of @radai-rosenblatt.

Fixes #253.
