### PR TITLE
Update Log4j to 2.17.0 to address CVE-2021-45105

### DIFF
--- a/avro-codegen/build.gradle
+++ b/avro-codegen/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     implementation project(":parser")
 
     implementation "commons-io:commons-io:2.6"
-    implementation "org.apache.logging.log4j:log4j-api:2.14.1"
+    implementation "org.apache.logging.log4j:log4j-api:2.17.0"
     implementation "com.beust:jcommander:1.78"
     implementation "org.apache.ant:ant:1.10.7"
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ subprojects {
       testImplementation "org.testng:testng:6.14.3"
 
       //redirect logging to log4j2 for tests
-      testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.14.1"
-      testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+      testRuntimeOnly "org.apache.logging.log4j:log4j-core:2.17.0"
+      testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
     }
 
     test {

--- a/helper/tests/codegen-110/build.gradle
+++ b/helper/tests/codegen-110/build.gradle
@@ -127,7 +127,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-111/build.gradle
+++ b/helper/tests/codegen-111/build.gradle
@@ -127,7 +127,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-14/build.gradle
+++ b/helper/tests/codegen-14/build.gradle
@@ -97,8 +97,8 @@ dependencies {
   codegen project(":helper:tests:helper-tests-common")
   codegen project(":helper:helper")
   //redirect logging to log4j2 for code generation
-  codegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  codegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  codegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  codegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   codegen files('../codegenClasspath')
 
   //required because generated code depends on the helper
@@ -114,7 +114,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-15/build.gradle
+++ b/helper/tests/codegen-15/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-16/build.gradle
+++ b/helper/tests/codegen-16/build.gradle
@@ -104,7 +104,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-17/build.gradle
+++ b/helper/tests/codegen-17/build.gradle
@@ -128,7 +128,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-18/build.gradle
+++ b/helper/tests/codegen-18/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }

--- a/helper/tests/codegen-19/build.gradle
+++ b/helper/tests/codegen-19/build.gradle
@@ -126,7 +126,7 @@ dependencies {
   //this block required for resource generation code
   implementation project(":helper:tests:helper-tests-common")
   //redirect logging to log4j2 for resource generation
-  resourcegen "org.apache.logging.log4j:log4j-core:2.14.1"
-  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.14.1"
+  resourcegen "org.apache.logging.log4j:log4j-core:2.17.0"
+  resourcegen "org.apache.logging.log4j:log4j-slf4j-impl:2.17.0"
   resourcegen files('../codegenClasspath')
 }


### PR DESCRIPTION
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105