### PR TITLE
work on more customizable avsc generation and avro-702 mitigation

### DIFF
--- a/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/AvroRandomDataGenerator.java
+++ b/avro-fastserde/src/jmh/java/com/linkedin/avro/fastserde/generator/AvroRandomDataGenerator.java
@@ -16,7 +16,6 @@
 
 package com.linkedin.avro.fastserde.generator;
 
-import com.linkedin.avro.fastserde.generator.GenericRecordBuilder;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
@@ -38,6 +36,7 @@ import org.apache.avro.generic.GenericRecord;
  * Generates Java objects according to an {@link Schema Avro Schema}.
  */
 @SuppressWarnings("WeakerAccess")
+@Deprecated //functionality to be ported over to RandomRecordGenerator in "core" helper
 public class AvroRandomDataGenerator {
 
   /**

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -129,7 +129,7 @@ public interface AvroAdapter {
     return Schema.createEnum(name, doc, namespace, values);
   }
 
-  String toAvsc(Schema schema, boolean pretty, boolean retainPreAvro702Logic);
+  String toAvsc(Schema schema, AvscGenerationConfig config);
 
   //code generation
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscGenerationConfig.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscGenerationConfig.java
@@ -46,10 +46,22 @@ public class AvscGenerationConfig {
             true, false, true, Optional.of(Boolean.FALSE), false
     );
     /**
+     * always generates correct, pretty avsc, with aliases fo "bad" fullnames for better compatibility with avro 1.4
+     */
+    public static final AvscGenerationConfig CORRECT_MITIGATED_PRETTY = new AvscGenerationConfig(
+            false, false, true, Optional.of(Boolean.FALSE), true
+    );
+    /**
      * always generates correct, one-line avsc, with aliases fo "bad" fullnames for better compatibility with avro 1.4
      */
     public static final AvscGenerationConfig CORRECT_MITIGATED_ONELINE = new AvscGenerationConfig(
             false, false, false, Optional.of(Boolean.FALSE), true
+    );
+    /**
+     * always generates avro-702 impacted (but pretty) avsc. only use if you know what you're doing.
+     */
+    public static final AvscGenerationConfig LEGACY_PRETTY = new AvscGenerationConfig(
+            false, false, true, Optional.of(Boolean.TRUE), false
     );
     /**
      * always generates avro-702 impacted (but pretty) avsc, and adds aliases to the correct full names of

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscGenerationConfig.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscGenerationConfig.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import org.apache.avro.Schema;
+
+import java.util.Optional;
+
+/**
+ * config class packing various configuration parameters and settings for the generation of
+ * avsc (json) strings out of {@link org.apache.avro.Schema} objects
+ */
+public class AvscGenerationConfig {
+    /**
+     * always punts to runtime avro to produce pretty output.
+     * result might suffer from @see <a href="https://issues.apache.org/jira/browse/AVRO-702">AVRO-702</a> under 1.4
+     * and also from incorrectly escaped json under versions smaller than 1.6
+     * (@see <a href="https://issues.apache.org/jira/browse/AVRO-886">AVRO-886</a>)
+     */
+    public static final AvscGenerationConfig VANILLA_PRETTY = new AvscGenerationConfig(
+            true, true, true, Optional.empty(), false
+    );
+    /**
+     * always punts to runtime avro to produce terse output.
+     * result might suffer from @see <a href="https://issues.apache.org/jira/browse/AVRO-702">AVRO-702</a> under 1.4
+     * and also from incorrectly escaped json under versions smaller than 1.6
+     * (@see <a href="https://issues.apache.org/jira/browse/AVRO-886">AVRO-886</a>)
+     */
+    public static final AvscGenerationConfig VANILLA_ONELINE  = new AvscGenerationConfig(
+            true, false, false, Optional.empty(), false
+    );
+    /**
+     * always generates correct, pretty-printed avsc. delegates this to runtime avro where possible
+     */
+    public static final AvscGenerationConfig CORRECT_PRETTY = new AvscGenerationConfig(
+            true, false, true, Optional.of(Boolean.FALSE), false
+    );
+    /**
+     * always generates correct, one-line avsc. delegates this to runtime avro where possible
+     */
+    public static final AvscGenerationConfig CORRECT_ONELINE = new AvscGenerationConfig(
+            true, false, true, Optional.of(Boolean.FALSE), false
+    );
+    /**
+     * always generates correct, one-line avsc, with aliases fo "bad" fullnames for better compatibility with avro 1.4
+     */
+    public static final AvscGenerationConfig CORRECT_MITIGATED_ONELINE = new AvscGenerationConfig(
+            false, false, false, Optional.of(Boolean.FALSE), true
+    );
+    /**
+     * always generates avro-702 impacted (but pretty) avsc, and adds aliases to the correct full names of
+     * impacted named types. only use if you know what you're doing.
+     */
+    public static final AvscGenerationConfig LEGACY_MITIGATED_PRETTY = new AvscGenerationConfig(
+            false, false, true, Optional.of(Boolean.TRUE), true
+    );
+    /**
+     * always generates avro-702 impacted (but pretty) avsc, and adds aliases to the correct full names of
+     * impacted named types. only use if you know what you're doing.
+     */
+    public static final AvscGenerationConfig LEGACY_MITIGATED_ONELINE = new AvscGenerationConfig(
+            false, false, false, Optional.of(Boolean.TRUE), true
+    );
+
+    /**
+     * if this value is set to true, and the rest of the values on this config object
+     * are within runtime avro's capabilities, delegates the work to {@link Schema#toString()}.
+     * otherwise uses our own avsc generation code.
+     * ignored if {@link #forceUseOfRuntimeAvro} is set
+     */
+    private final boolean preferUseOfRuntimeAvro;
+    /**
+     * similar to {@link #preferUseOfRuntimeAvro}, but instead throws an exception if its
+     * not possible to delegate the work to vanilla runtime avro
+     */
+    private final boolean forceUseOfRuntimeAvro;
+    /**
+     * if true produces nicely indented json. otherwise produces a single-line json
+     * with no newlines or spaces for indentation
+     */
+    private final boolean prettyPrint;
+    /**
+     * true to produce potentially bad avsc for compatibility with avro 1.4 output (under any runtime avro version)
+     * false to produce proper, correct, avsc (again under any runtime avro version)
+     * null to comply with the behaviour of runtime avro (which is bad under 1.4)
+     * @see <a href="https://issues.apache.org/jira/browse/AVRO-702">AVRO-702</a>
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private final Optional<Boolean> retainPreAvro702Logic;
+    /**
+     * true adds aliases to all named types (record, enum, fixed) to their "other fullname".
+     * "other fullname" is either the correct one of the avro702-impacted one, depending
+     * on the value of {@link #retainPreAvro702Logic}.
+     * it is useful to have aliases to these "other fullnames" on schemas in scenarios
+     * where application code is in the process of migrating away from avro 1.4 but has to
+     * do so gradually and without compatibility breaks or global coordinated deployments.
+     */
+    private final boolean addAvro702Aliases;
+
+    public AvscGenerationConfig(
+            boolean preferUseOfRuntimeAvro,
+            boolean forceUseOfRuntimeAvro,
+            boolean prettyPrint,
+            @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+            Optional<Boolean> retainPreAvro702Logic,
+            boolean addAvro702Aliases
+    ) {
+        //noinspection OptionalAssignedToNull
+        if (retainPreAvro702Logic == null) {
+            throw new IllegalArgumentException("retainPreAvro702Logic cannot be null");
+        }
+        this.preferUseOfRuntimeAvro = preferUseOfRuntimeAvro;
+        this.forceUseOfRuntimeAvro = forceUseOfRuntimeAvro;
+        this.prettyPrint = prettyPrint;
+        this.retainPreAvro702Logic = retainPreAvro702Logic;
+        this.addAvro702Aliases = addAvro702Aliases;
+    }
+
+    public boolean isPreferUseOfRuntimeAvro() {
+        return preferUseOfRuntimeAvro;
+    }
+
+    public boolean isForceUseOfRuntimeAvro() {
+        return forceUseOfRuntimeAvro;
+    }
+
+    public boolean isPrettyPrint() {
+        return prettyPrint;
+    }
+
+    public Optional<Boolean> getRetainPreAvro702Logic() {
+        return retainPreAvro702Logic;
+    }
+
+    public boolean isAddAvro702Aliases() {
+        return addAvro702Aliases;
+    }
+}

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscGenerationConfig.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscGenerationConfig.java
@@ -64,6 +64,12 @@ public class AvscGenerationConfig {
             false, false, true, Optional.of(Boolean.TRUE), false
     );
     /**
+     * always generates avro-702 impacted, terse avsc. only use if you know what you're doing.
+     */
+    public static final AvscGenerationConfig LEGACY_ONELINE = new AvscGenerationConfig(
+            false, false, false, Optional.of(Boolean.TRUE), false
+    );
+    /**
      * always generates avro-702 impacted (but pretty) avsc, and adds aliases to the correct full names of
      * impacted named types. only use if you know what you're doing.
      */

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscWriter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvscWriter.java
@@ -16,7 +16,7 @@ import java.io.StringWriter;
 import java.util.List;
 import java.util.Set;
 
-public abstract class AvscWriter<G extends JsonGeneratorWrapper> {
+public abstract class AvscWriter<G extends JsonGeneratorWrapper<?>> {
     /**
      * true for pretty-printing (newlines and indentation)
      * false foa one-liner (good for SCHEMA$)
@@ -27,10 +27,17 @@ public abstract class AvscWriter<G extends JsonGeneratorWrapper> {
      * false to produce proper, correct, avsc.
      */
     protected final boolean preAvro702;
+    /**
+     * true adds aliases to all named types (record, enum, fixed) to their "other fullname".
+     * "other fullname" is either the correct one of the avro702-impacted one, depending
+     * on the value of {@link #preAvro702}
+     */
+    protected final boolean addAliasesForAvro702;
 
-    protected AvscWriter(boolean pretty, boolean preAvro702) {
+    protected AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         this.pretty = pretty;
         this.preAvro702 = preAvro702;
+        this.addAliasesForAvro702 = addAliasesForAvro702;
     }
 
     public String toAvsc(Schema schema) {
@@ -102,7 +109,7 @@ public abstract class AvscWriter<G extends JsonGeneratorWrapper> {
                 String savedSpace = names.space(); // save namespace
                 // set default namespace
                 if (preAvro702) {
-                    //avro 1.4 only ever sets namespace if thecurrent is null
+                    //avro 1.4 only ever sets namespace if the current is null
                     if (savedSpace == null) {
                         names.space(name.getSpace());
                     }

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/backports/AvroName.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/backports/AvroName.java
@@ -6,16 +6,29 @@
 
 package com.linkedin.avroutil1.compatibility.backports;
 
+import com.linkedin.avroutil1.compatibility.HelperConsts;
 import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Objects;
 
 public class AvroName {
+    public static final Comparator<AvroName> BY_FULLNAME = Comparator.comparing(AvroName::getFull);
+
     private final String name;
     private final String space;
     private final String full;
+
+    public static AvroName of(Schema schema) {
+        Schema.Type type = schema.getType();
+        if (!HelperConsts.NAMED_TYPES.contains(type)) {
+            throw new IllegalArgumentException("dont know how to build an AvroName out of " + type + " " + schema);
+        }
+        return new AvroName(schema.getFullName(), null); //will handle namespace parsing internally
+    }
 
     public AvroName(String name, String space) {
         if (name == null) { // anonymous
@@ -74,21 +87,57 @@ public class AvroName {
         return full;
     }
 
-    public void writeName(AvroNames names, JsonGeneratorWrapper<?> gen) throws IOException {
+    /**
+     * writes this name (as a name prop and optionally a namespace prop) to an underlying json genrator
+     * @param names the set of "known fullnames" and current "inherited" namespace used by the current avsc
+     *              generation operation
+     * @param gen json output to write to
+     * @return an alternate name to this, if names and alternativeNames would result in different output from
+     * this object. more specifically - if the "effective full name" (simple name + either explicitly printed
+     * or inherited namespace) for this AvroName would be different under alternativeNames, the fullname
+     * under alternativeNames is returned.
+     * if the result of this method would have been the exact same under alternativeNames returns null
+     * @throws IOException
+     */
+    public AvroName writeName(AvroNames names, boolean preAvro702, JsonGeneratorWrapper<?> gen) throws IOException {
+        //always emit a name (if we have one?)
         if (name != null) {
             gen.writeStringField("name", name);
         }
-        if (space != null) {
-            if (!space.equals(names.space())) {
-                gen.writeStringField("namespace", space);
-            }
-        } else if (names.space() != null) { // null within non-null
-            gen.writeStringField("namespace", "");
+        boolean shouldEmitNSPre702 = shouldEmitNamespace(names.badSpace());
+        boolean shouldEmitNSNormally = shouldEmitNamespace(names.correctSpace());
+        boolean emitNS = preAvro702 ? shouldEmitNSPre702 : shouldEmitNSNormally;
+        if (emitNS) {
+            String toEmit = space == null ? "" : space;
+            gen.writeStringField("namespace", toEmit);
         }
+        //even under 702, if we emit a NS explicitly we get the correct fullname (==this)
+        //otherwise we are creating (effectively) a fullname that is our simpleName combined
+        //with the (correct!) current "context" namespace
+        AvroName effectiveNameUnder702 = shouldEmitNSPre702 ? this : new AvroName(this.name, names.correctSpace());
+        //if our (effective) name under 702 is different than our correct name we need to return an alias
+        if (!effectiveNameUnder702.equals(this)) {
+            //if we are generating pre-702 output it means we just emitted effectiveNameUnder702 and need to return
+            //ourselves (the correct fullname) as an alias. otherwise the opposite
+            return preAvro702 ? this : effectiveNameUnder702;
+        }
+        return null;
     }
 
     public String getQualified(String defaultSpace) {
         return (space == null || space.equals(defaultSpace)) ? name : full;
+    }
+
+    private boolean shouldEmitNamespace(String contextNamespace) {
+        if (space != null) { //do we have a namespace?
+            //is our namespace different than the current context one?
+            //(also works when the context namespace is null)
+            return !space.equals(contextNamespace);
+        } else {
+            //we're in the default namespace. if context is something else
+            //we will need to emit (an empty) namespace
+            return contextNamespace != null;
+        }
     }
 
     private static String validateName(String name) {

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/Avro702Checker.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/Avro702Checker.java
@@ -18,7 +18,7 @@ public class Avro702Checker {
     }
 
     public static boolean isSusceptible(Schema schema) {
-        String badAvsc = AvroCompatibilityHelper.toBadAvsc(schema, true);
+        String badAvsc = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.LEGACY_PRETTY);
         boolean parseFailed = false;
         Schema evilTwin = null;
         try {

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/Avro702Checker.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/Avro702Checker.java
@@ -18,7 +18,7 @@ public class Avro702Checker {
     }
 
     public static boolean isSusceptible(Schema schema) {
-        String badAvsc = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.LEGACY_PRETTY);
+        String badAvsc = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.LEGACY_ONELINE);
         boolean parseFailed = false;
         Schema evilTwin = null;
         try {

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCodecUtil.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCodecUtil.java
@@ -20,6 +20,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -28,7 +29,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class AvroCodecUtil {
 
-    public static byte[] serializeBinary(IndexedRecord record) throws Exception {
+    public static byte[] serializeBinary(IndexedRecord record) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         BinaryEncoder binaryEncoder = AvroCompatibilityHelper.newBinaryEncoder(os);
         DatumWriter<IndexedRecord> writer = AvroCompatibilityHelper.isSpecificRecord(record) ?
@@ -40,7 +41,7 @@ public class AvroCodecUtil {
         return os.toByteArray();
     }
 
-    public static String serializeJson(IndexedRecord record, AvroVersion format) throws Exception {
+    public static String serializeJson(IndexedRecord record, AvroVersion format) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         Encoder encoder = AvroCompatibilityHelper.newJsonEncoder(record.getSchema(), os, true, format);
         DatumWriter<IndexedRecord> writer = AvroCompatibilityHelper.isSpecificRecord(record) ?
@@ -54,7 +55,7 @@ public class AvroCodecUtil {
         return new String(os.toByteArray(), StandardCharsets.UTF_8);
     }
 
-    public static GenericRecord deserializeAsGeneric(byte[] binarySerialized, Schema writerSchema, Schema readerSchema) throws Exception {
+    public static GenericRecord deserializeAsGeneric(byte[] binarySerialized, Schema writerSchema, Schema readerSchema) throws IOException {
         ByteArrayInputStream is = new ByteArrayInputStream(binarySerialized);
         BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(is, false, null);
         GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(writerSchema, readerSchema);
@@ -66,7 +67,7 @@ public class AvroCodecUtil {
         return result;
     }
 
-    public static GenericRecord deserializeAsGeneric(String jsonSerialized, Schema writerSchema, Schema readerSchema) throws Exception {
+    public static GenericRecord deserializeAsGeneric(String jsonSerialized, Schema writerSchema, Schema readerSchema) throws IOException {
         InputStream is = new ByteArrayInputStream(jsonSerialized.getBytes(StandardCharsets.UTF_8));
         Decoder decoder = AvroCompatibilityHelper.newCompatibleJsonDecoder(writerSchema, is);
         GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(writerSchema, readerSchema);

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -992,8 +992,8 @@ public class AvroCompatibilityHelper {
     assertAvroAvailable();
     return ADAPTER.toAvsc(schema,
             pretty ?
-                    AvscGenerationConfig.LEGACY_MITIGATED_PRETTY
-                  : AvscGenerationConfig.LEGACY_MITIGATED_ONELINE
+                    AvscGenerationConfig.LEGACY_PRETTY
+                  : AvscGenerationConfig.LEGACY_ONELINE
     );
   }
 }

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -936,21 +936,46 @@ public class AvroCompatibilityHelper {
   }
 
   /**
+   * given a schema, returns a (exploded, fully-inlined, self-contained, however you want to call it)
+   * avsc representation of the schema.
+   * this is logically the same as {@link Schema#toString(boolean)} except not full of horrible bugs.
+   * specifically, under all versions of avro, we support:
+   * <ul>
+   *     <li>output free of avro-702, even under avro 1.4</li>
+   *     <li>escaped characters in docs and default values remain properly escaped (avro-886)</li>
+   * </ul>
+   * (unless of course you choose to delegate to vanilla avro, at which point youre at the mercy of
+   * the runtime version thereof)
+   * @param schema a schema to serialize to avsc
+   * @param config configuration for avsc generation. see {@link AvscGenerationConfig} for available knobs
+   * @return avsc
+   */
+  public static String toAvsc(Schema schema, AvscGenerationConfig config) {
+    assertAvroAvailable();
+    if (config == null) {
+      throw new IllegalArgumentException("config must be provided");
+    }
+    return ADAPTER.toAvsc(schema, config);
+  }
+
+  /**
    * given a schema, returns a (exploded, fully-inlined, self-container, however you want to call it)
    * avsc representation of the schema.
    * this is logically the same as {@link Schema#toString(boolean)} except not full of horrible bugs.
    * specifically, under all versions of avro:
    * <ul>
    *     <li>the output is free of avro-702, even under avro 1.4</li>
-   *     <li>escapes characters in docs and default values remain properly escaped under avro &lt; 1.6</li>
+   *     <li>escaped characters in docs and default values remain properly escaped under avro &lt; 1.6</li>
    * </ul>
    * @param schema a schema to serialize to avsc
    * @param pretty true to return a pretty-printed schema, false for single-line
    * @return avsc
+   * @deprecated please use {@link #toAvsc(Schema, AvscGenerationConfig)} directly
    */
+  @Deprecated
   public static String toAvsc(Schema schema, boolean pretty) {
     assertAvroAvailable();
-    return ADAPTER.toAvsc(schema, pretty, false);
+    return ADAPTER.toAvsc(schema, pretty ? AvscGenerationConfig.CORRECT_PRETTY : AvscGenerationConfig.CORRECT_ONELINE);
   }
 
   /**
@@ -960,9 +985,15 @@ public class AvroCompatibilityHelper {
    * @param schema a schema to serialize to (possibly bad) avsc
    * @param pretty true to return a pretty-printed schema, false for single-line
    * @return possibly bad avsc
+   * @deprecated please use {@link #toAvsc(Schema, AvscGenerationConfig)} directly
    */
+  @Deprecated
   public static String toBadAvsc(Schema schema, boolean pretty) {
     assertAvroAvailable();
-    return ADAPTER.toAvsc(schema, pretty, true);
+    return ADAPTER.toAvsc(schema,
+            pretty ?
+                    AvscGenerationConfig.LEGACY_MITIGATED_PRETTY
+                  : AvscGenerationConfig.LEGACY_MITIGATED_ONELINE
+    );
   }
 }

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/RandomRecordGenerator.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/RandomRecordGenerator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * utility class for generating random (valid) records given a schema.
+ * useful for testing
+ */
+public class RandomRecordGenerator {
+
+  /**
+   * creates a random (generic) instance of a schema
+   * @param of schema to generate a random specimen of
+   * @return a random specimen
+   */
+  public Object randomGeneric(Schema of) {
+    return randomGeneric(of, RecordGenerationConfig.newConfig());
+  }
+
+  public Object randomGeneric(Schema of, RecordGenerationConfig config) {
+    return newRandomGeneric(of, config);
+  }
+
+  private Object newRandomGeneric(Schema of, RecordGenerationConfig config) {
+    Random random = config.random();
+    int size;
+    byte[] randomBytes;
+    int index;
+    switch (of.getType()) {
+      case NULL:
+        return null;
+      case BOOLEAN:
+        return random.nextBoolean();
+      case INT:
+        return random.nextInt();
+      case LONG:
+        return random.nextLong();
+      case FLOAT:
+        return random.nextFloat();
+      case DOUBLE:
+        return random.nextDouble();
+      case BYTES:
+        size = random.nextInt(11); //[0, 10]
+        randomBytes = new byte[size];
+        random.nextBytes(randomBytes);
+        return ByteBuffer.wrap(randomBytes);
+      case STRING:
+        size = random.nextInt(11); //[0, 10]
+        StringBuilder sb = new StringBuilder(size);
+        //return alphanumeric string of size
+        random.ints(size, '0', 'z' + 1).forEachOrdered(sb::appendCodePoint);
+        return sb.toString();
+      case FIXED:
+        size = of.getFixedSize();
+        randomBytes = new byte[size];
+        random.nextBytes(randomBytes);
+        return AvroCompatibilityHelper.newFixed(of, randomBytes);
+      case ENUM:
+        List<String> symbols = of.getEnumSymbols();
+        index = random.nextInt(symbols.size());
+        return AvroCompatibilityHelper.newEnumSymbol(of, symbols.get(index));
+      case RECORD:
+        GenericData.Record record = new GenericData.Record(of);
+        for (Schema.Field field : of.getFields()) {
+          //TODO - extend to allow (multiple-hop-long) self-references to complete the experience :-)
+          Schema fieldSchema = field.schema();
+          Object randomValue = newRandomGeneric(fieldSchema, config);
+          record.put(field.pos(), randomValue);
+        }
+        return record;
+      case ARRAY:
+        size = random.nextInt(11); //[0, 10]
+        GenericData.Array<Object> array = new GenericData.Array<>(size, of);
+        Schema elementType = of.getElementType();
+        for (int i = 0; i < size; i++) {
+          array.add(newRandomGeneric(elementType, config));
+        }
+        return array;
+      case MAP:
+        size = random.nextInt(11); //[0, 10]
+        HashMap<String, Object> map = new HashMap<>(size);
+        Schema valueType = of.getValueType();
+        for (int i = 0; i < size; i++) {
+          String key = "key-" + i; //TODO - better randomness (yet results should be unique)
+          map.put(key, newRandomGeneric(valueType, config));
+        }
+        return map;
+      case UNION:
+        List<Schema> branches = of.getTypes();
+        index = random.nextInt(branches.size());
+        Schema branch = branches.get(index);
+        return newRandomGeneric(branch, config);
+      default:
+        throw new UnsupportedOperationException("unhandled: " + of.getType());
+    }
+  }
+}

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/RecordGenerationConfig.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/RecordGenerationConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import java.util.Random;
+
+/**
+ * configuration for use with {@link RandomRecordGenerator}
+ */
+public class RecordGenerationConfig {
+    private final long seed;
+    private final Random random;
+
+    private final Random randomToUse;
+
+    public RecordGenerationConfig(long seed, Random random) {
+        this.seed = seed;
+        this.random = random;
+
+        this.randomToUse = this.random != null ? this.random : new Random(this.seed);
+    }
+
+    public RecordGenerationConfig(RecordGenerationConfig toCopy) {
+        if (toCopy == null) {
+            throw new IllegalArgumentException("argument cannot be null");
+        }
+        this.seed = toCopy.seed;
+        this.random = toCopy.random;
+
+        this.randomToUse = this.random != null ? this.random : new Random(this.seed);
+    }
+
+    public Random random() {
+        return randomToUse;
+    }
+
+    // "builder-style" copy-setters
+
+    public static RecordGenerationConfig newConfig() {
+        //we provide seed and not Random so that copies of this config get their own random
+        //instances. this is done so the defaults produce consistent behaviour even under MT use
+        return new RecordGenerationConfig(System.currentTimeMillis(), null);
+    }
+
+    public RecordGenerationConfig withSeed(long seed) {
+        return new RecordGenerationConfig(
+                seed,
+                this.random
+        );
+    }
+
+    public RecordGenerationConfig withRandom(Random random) {
+        return new RecordGenerationConfig(
+                this.seed,
+                random
+        );
+    }
+
+}

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.avroutil1.compatibility.AvroAdapter;
 import com.linkedin.avroutil1.compatibility.AvroGeneratedSourceCode;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
@@ -58,6 +59,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -326,13 +328,30 @@ public class Avro110Adapter implements AvroAdapter {
     }
 
     @Override
-    public String toAvsc(Schema schema, boolean pretty, boolean retainPreAvro702Logic) {
-        if (!retainPreAvro702Logic) {
-            //TODO - remove when we have more confidence in AvscWriter
-            return schema.toString(pretty);
+    public String toAvsc(Schema schema, AvscGenerationConfig config) {
+        boolean useRuntime;
+        if (!isRuntimeAvroCapableOf(config)) {
+            if (config.isForceUseOfRuntimeAvro()) {
+                throw new UnsupportedOperationException("desired configuration " + config
+                        + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+            }
+            useRuntime = false;
+        } else {
+            useRuntime = config.isPreferUseOfRuntimeAvro();
         }
-        Avro110AvscWriter writer = new Avro110AvscWriter(pretty, retainPreAvro702Logic);
-        return writer.toAvsc(schema);
+
+        if (useRuntime) {
+            return schema.toString(config.isPrettyPrint());
+        } else {
+            //if the user does not specify do whatever runtime avro would (which for 1.10 means produce correct schema)
+            boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+            Avro110AvscWriter writer = new Avro110AvscWriter(
+                    config.isPrettyPrint(),
+                    usePre702Logic,
+                    config.isAddAvro702Aliases()
+            );
+            return writer.toAvsc(schema);
+        }
     }
 
     @Override
@@ -422,5 +441,21 @@ public class Avro110Adapter implements AvroAdapter {
         } catch (Exception e) {
             throw new IllegalStateException("cant extract contents from avro OutputFile", e);
         }
+    }
+
+    private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("config cannot be null");
+        }
+        if (config.isAddAvro702Aliases()) {
+            return false;
+        }
+        Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+        //noinspection RedundantIfStatement
+        if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+            //avro 1.10 can only do correct avsc
+            return false;
+        }
+        return true;
     }
 }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
 
-    public Avro110AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro110AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linkedin.avroutil1.compatibility.AvroAdapter;
 import com.linkedin.avroutil1.compatibility.AvroGeneratedSourceCode;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
@@ -58,6 +59,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -326,13 +328,30 @@ public class Avro111Adapter implements AvroAdapter {
     }
 
     @Override
-    public String toAvsc(Schema schema, boolean pretty, boolean retainPreAvro702Logic) {
-        if (!retainPreAvro702Logic) {
-            //TODO - remove when we have more confidence in AvscWriter
-            return schema.toString(pretty);
+    public String toAvsc(Schema schema, AvscGenerationConfig config) {
+        boolean useRuntime;
+        if (!isRuntimeAvroCapableOf(config)) {
+            if (config.isForceUseOfRuntimeAvro()) {
+                throw new UnsupportedOperationException("desired configuration " + config
+                        + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+            }
+            useRuntime = false;
+        } else {
+            useRuntime = config.isPreferUseOfRuntimeAvro();
         }
-        Avro111AvscWriter writer = new Avro111AvscWriter(pretty, retainPreAvro702Logic);
-        return writer.toAvsc(schema);
+
+        if (useRuntime) {
+            return schema.toString(config.isPrettyPrint());
+        } else {
+            //if the user does not specify do whatever runtime avro would (which for 1.11 means produce correct schema)
+            boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+            Avro111AvscWriter writer = new Avro111AvscWriter(
+                    config.isPrettyPrint(),
+                    usePre702Logic,
+                    config.isAddAvro702Aliases()
+            );
+            return writer.toAvsc(schema);
+        }
     }
 
     @Override
@@ -422,5 +441,21 @@ public class Avro111Adapter implements AvroAdapter {
         } catch (Exception e) {
             throw new IllegalStateException("cant extract contents from avro OutputFile", e);
         }
+    }
+
+    private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("config cannot be null");
+        }
+        if (config.isAddAvro702Aliases()) {
+            return false;
+        }
+        Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+        //noinspection RedundantIfStatement
+        if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+            //avro 1.11 can only do correct avsc
+            return false;
+        }
+        return true;
     }
 }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
 
-    public Avro111AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro111AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
@@ -40,8 +40,8 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         }
     }
 
-    public Avro14AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro14AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -11,6 +11,7 @@ import com.linkedin.avroutil1.compatibility.AvroAdapter;
 import com.linkedin.avroutil1.compatibility.AvroGeneratedSourceCode;
 import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -306,13 +308,30 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
-  public String toAvsc(Schema schema, boolean pretty, boolean retainPreAvro702Logic) {
-    if (!retainPreAvro702Logic) {
-      //TODO - remove when we have more confidence in AvscWriter
-      return schema.toString(pretty);
+  public String toAvsc(Schema schema, AvscGenerationConfig config) {
+    boolean useRuntime;
+    if (!isRuntimeAvroCapableOf(config)) {
+      if (config.isForceUseOfRuntimeAvro()) {
+        throw new UnsupportedOperationException("desired configuration " + config
+                + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+      }
+      useRuntime = false;
+    } else {
+      useRuntime = config.isPreferUseOfRuntimeAvro();
     }
-    Avro15AvscWriter writer = new Avro15AvscWriter(pretty, retainPreAvro702Logic);
-    return writer.toAvsc(schema);
+
+    if (useRuntime) {
+      return schema.toString(config.isPrettyPrint());
+    } else {
+      //if the user does not specify do whatever runtime avro would (which for 1.5 means produce correct schema)
+      boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+      Avro15AvscWriter writer = new Avro15AvscWriter(
+              config.isPrettyPrint(),
+              usePre702Logic,
+              config.isAddAvro702Aliases()
+      );
+      return writer.toAvsc(schema);
+    }
   }
 
   @Override
@@ -384,5 +403,21 @@ public class Avro15Adapter implements AvroAdapter {
     } catch (Exception e) {
       throw new IllegalStateException("cant extract contents from avro OutputFile", e);
     }
+  }
+
+  private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    if (config.isAddAvro702Aliases()) {
+      return false;
+    }
+    Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+    //noinspection RedundantIfStatement
+    if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+      //avro 1.5 can only do correct avsc
+      return false;
+    }
+    return true;
   }
 }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -40,8 +40,8 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         }
     }
 
-    public Avro15AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro15AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -10,6 +10,7 @@ import com.linkedin.avroutil1.compatibility.AvroAdapter;
 import com.linkedin.avroutil1.compatibility.AvroGeneratedSourceCode;
 import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
@@ -44,6 +45,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -318,13 +320,30 @@ public class Avro16Adapter implements AvroAdapter {
   }
 
   @Override
-  public String toAvsc(Schema schema, boolean pretty, boolean retainPreAvro702Logic) {
-    if (!retainPreAvro702Logic) {
-      //TODO - remove when we have more confidence in AvscWriter
-      return schema.toString(pretty);
+  public String toAvsc(Schema schema, AvscGenerationConfig config) {
+    boolean useRuntime;
+    if (!isRuntimeAvroCapableOf(config)) {
+      if (config.isForceUseOfRuntimeAvro()) {
+        throw new UnsupportedOperationException("desired configuration " + config
+                + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+      }
+      useRuntime = false;
+    } else {
+      useRuntime = config.isPreferUseOfRuntimeAvro();
     }
-    Avro16AvscWriter writer = new Avro16AvscWriter(pretty, retainPreAvro702Logic);
-    return writer.toAvsc(schema);
+
+    if (useRuntime) {
+      return schema.toString(config.isPrettyPrint());
+    } else {
+      //if the user does not specify do whatever runtime avro would (which for 1.6 means produce correct schema)
+      boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+      Avro16AvscWriter writer = new Avro16AvscWriter(
+              config.isPrettyPrint(),
+              usePre702Logic,
+              config.isAddAvro702Aliases()
+      );
+      return writer.toAvsc(schema);
+    }
   }
 
   @Override
@@ -411,5 +430,21 @@ public class Avro16Adapter implements AvroAdapter {
     } catch (Exception e) {
       throw new IllegalStateException("cant extract contents from avro OutputFile", e);
     }
+  }
+
+  private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    if (config.isAddAvro702Aliases()) {
+      return false;
+    }
+    Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+    //noinspection RedundantIfStatement
+    if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+      //avro 1.6 can only do correct avsc
+      return false;
+    }
+    return true;
   }
 }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
 
-    public Avro16AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro16AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -10,6 +10,7 @@ import com.linkedin.avroutil1.compatibility.AvroAdapter;
 import com.linkedin.avroutil1.compatibility.AvroGeneratedSourceCode;
 import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -373,13 +375,30 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
-  public String toAvsc(Schema schema, boolean pretty, boolean retainPreAvro702Logic) {
-    if (!retainPreAvro702Logic) {
-      //TODO - remove when we have more confidence in AvscWriter
-      return schema.toString(pretty);
+  public String toAvsc(Schema schema, AvscGenerationConfig config) {
+    boolean useRuntime;
+    if (!isRuntimeAvroCapableOf(config)) {
+      if (config.isForceUseOfRuntimeAvro()) {
+        throw new UnsupportedOperationException("desired configuration " + config
+                + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+      }
+      useRuntime = false;
+    } else {
+      useRuntime = config.isPreferUseOfRuntimeAvro();
     }
-    Avro17AvscWriter writer = new Avro17AvscWriter(pretty, retainPreAvro702Logic);
-    return writer.toAvsc(schema);
+
+    if (useRuntime) {
+      return schema.toString(config.isPrettyPrint());
+    } else {
+      //if the user does not specify do whatever runtime avro would (which for 1.7 means produce correct schema)
+      boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+      Avro17AvscWriter writer = new Avro17AvscWriter(
+              config.isPrettyPrint(),
+              usePre702Logic,
+              config.isAddAvro702Aliases()
+      );
+      return writer.toAvsc(schema);
+    }
   }
 
   @Override
@@ -469,5 +488,21 @@ public class Avro17Adapter implements AvroAdapter {
     } catch (Exception e) {
       throw new IllegalStateException("cant extract contents from avro OutputFile", e);
     }
+  }
+
+  private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config cannot be null");
+    }
+    if (config.isAddAvro702Aliases()) {
+      return false;
+    }
+    Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+    //noinspection RedundantIfStatement
+    if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+      //avro 1.7 can only do correct avsc
+      return false;
+    }
+    return true;
   }
 }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
 
-    public Avro17AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro17AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
 
-    public Avro18AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro18AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
 
-    public Avro19AvscWriter(boolean pretty, boolean preAvro702) {
-        super(pretty, preAvro702);
+    public Avro19AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
+        super(pretty, preAvro702, addAliasesForAvro702);
     }
 
     @Override

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/Avro702CheckerTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/Avro702CheckerTest.java
@@ -15,9 +15,13 @@ import org.testng.annotations.Test;
 public class Avro702CheckerTest {
 
   @Test
-  public void testMonsantoSchema() throws Exception {
-    String avsc = TestUtil.load("MonsantoRecord.avsc");
-    testSchema(avsc, true);
+  public void testImpactedSchemas() throws Exception {
+    testSchema(TestUtil.load("MonsantoRecord.avsc"), true);
+    testSchema(TestUtil.load("avro702/Avro702DemoEnum-good.avsc"), true);
+    testSchema(TestUtil.load("avro702/Avro702DemoHorribleEnum-good.avsc"), true);
+    testSchema(TestUtil.load("avro702/Avro702DemoFixed-good.avsc"), true);
+    testSchema(TestUtil.load("avro702/Avro702DemoRecord-good.avsc"), true);
+    testSchema(TestUtil.load("avro702/Avro702DemoUnion-good.avsc"), true);
   }
 
   @Test

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperToAvscTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperToAvscTest.java
@@ -7,7 +7,11 @@
 package com.linkedin.avroutil1.compatibility;
 
 import com.linkedin.avroutil1.testcommon.TestUtil;
+import net.javacrumbs.jsonunit.assertj.JsonAssertions;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -23,7 +27,7 @@ public class AvroCompatibilityHelperToAvscTest {
     testSchema(avsc);
 
     Schema schema = Schema.parse(avsc);
-    String badAvsc = AvroCompatibilityHelper.toBadAvsc(schema, true);
+    String badAvsc = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.LEGACY_PRETTY);
     Schema evilClone = Schema.parse(badAvsc);
 
     //show avro-702
@@ -43,15 +47,74 @@ public class AvroCompatibilityHelperToAvscTest {
     testSchema(TestUtil.load("RecordWithLogicalTypes.avsc"));
   }
 
+  @Test
+  public void testAliasInjectionOnBadSchema() throws Exception {
+    long seed = System.currentTimeMillis();
+    AvroVersion runtimeVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+
+    String originalAvsc = TestUtil.load("avro702/Avro702DemoEnum-good.avsc");
+    Schema originalSchema = Schema.parse(originalAvsc);
+    String expectedBadAvsc = TestUtil.load("avro702/Avro702DemoEnum-bad.avsc");
+    Schema expectedBadSchema = Schema.parse(expectedBadAvsc);
+
+    //demonstrate we can produce the same bad avsc that vanilla 1.4 does
+    String badAvsc = AvroCompatibilityHelper.toAvsc(originalSchema, AvscGenerationConfig.LEGACY_PRETTY);
+    JsonAssertions.assertThatJson(badAvsc).isEqualTo(expectedBadAvsc);
+    Schema badSchema = Schema.parse(badAvsc);
+    Assert.assertEquals(badSchema, expectedBadSchema);
+
+    //demonstrate that bad and original schemas cannot interop by default on avro 1.5+
+    RandomRecordGenerator gen = new RandomRecordGenerator();
+    //write with good schema, read with bad
+    GenericRecord goodRecord = (GenericRecord) gen.randomGeneric(originalSchema, RecordGenerationConfig.newConfig().withSeed(seed));
+    testBinaryEncodingCycle(goodRecord, badSchema, runtimeVersion.earlierThan(AvroVersion.AVRO_1_5));
+    //write with bad schema, read with good
+    GenericRecord badRecord = (GenericRecord) gen.randomGeneric(badSchema, RecordGenerationConfig.newConfig().withSeed(seed));
+    testBinaryEncodingCycle(badRecord, originalSchema, runtimeVersion.earlierThan(AvroVersion.AVRO_1_5));
+
+    //now generate both good and bad schemas with avro-702-mitigation aliases
+    String badAvscWithAliases = AvroCompatibilityHelper.toAvsc(originalSchema, AvscGenerationConfig.LEGACY_MITIGATED_PRETTY);
+    Schema badSchemaWithAliases = Schema.parse(badAvscWithAliases);
+    String goodAvscWithAliases = AvroCompatibilityHelper.toAvsc(originalSchema, AvscGenerationConfig.CORRECT_MITIGATED_PRETTY);
+    Schema goodSchemaWithAliases = Schema.parse(goodAvscWithAliases);
+    //and show they can be used to inter-op with their counterparts
+    testBinaryEncodingCycle(goodRecord, badSchemaWithAliases, true);
+    testBinaryEncodingCycle(badRecord, goodSchemaWithAliases, true);
+  }
+
+  /**
+   * show that we can "serialize" a schema and parse it back without issues - the the
+   * resulting schema is equals() to the original schema
+   * @param avsc avsc to run through a parse --> toAvsc --> parse cycle
+   * @throws Exception if anything goes wrong
+   */
   private void testSchema(String avsc) throws Exception {
     Schema schema = Schema.parse(avsc);
-    String oneLine = AvroCompatibilityHelper.toAvsc(schema, false);
-    String pretty = AvroCompatibilityHelper.toAvsc(schema, true);
+    String oneLine = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.CORRECT_ONELINE);
+    String pretty = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.CORRECT_PRETTY);
 
     Schema copy = Schema.parse(oneLine);
     Assert.assertEquals(copy, schema);
 
     copy = Schema.parse(pretty);
     Assert.assertEquals(copy, schema);
+  }
+
+  /**
+   * runs an encode + decode cycle on a record and verifies that the results match expectation
+   * @param record payload to serialize and decode back. also defines writer schema
+   * @param readerSchema schema to decode with
+   * @param expectedToWork true if expected to work
+   * @throws Exception if anything goes wrong
+   */
+  private void testBinaryEncodingCycle(IndexedRecord record, Schema readerSchema, boolean expectedToWork) throws Exception {
+    byte[] serialized = AvroCodecUtil.serializeBinary(record);
+    try {
+      AvroCodecUtil.deserializeAsGeneric(serialized, record.getSchema(), readerSchema);
+      //worked.
+      Assert.assertTrue(expectedToWork, "was expected to throw");
+    } catch (AvroTypeException issue) {
+      Assert.assertFalse(expectedToWork, "was expected to succeed");
+    }
   }
 }

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoEnum-bad.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoEnum-bad.avsc
@@ -1,0 +1,27 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "doc": "this record demonstrates https://issues.apache.org/jira/browse/AVRO-702",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "enum",
+              "name": "InnerEnum",
+              "doc": "this enum's namespace gets messed up under avro 1.4",
+              "symbols": ["A", "B"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoEnum-good.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoEnum-good.avsc
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "doc": "this record demonstrates https://issues.apache.org/jira/browse/AVRO-702",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "enum",
+              "name": "InnerEnum",
+              "namespace": "com.acme.outer",
+              "doc": "this enum's namespace gets messed up under avro 1.4",
+              "symbols": ["A", "B"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoFixed-bad.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoFixed-bad.avsc
@@ -1,0 +1,25 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "fixed",
+              "name": "InnerFixed",
+              "size": 7
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoFixed-good.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoFixed-good.avsc
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "doc": "this record demonstrates https://issues.apache.org/jira/browse/AVRO-702",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "fixed",
+              "name": "InnerFixed",
+              "namespace": "com.acme.outer",
+              "doc": "this fixed's namespace gets messed up under avro 1.4",
+              "size": 7
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoHorribleEnum-good.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoHorribleEnum-good.avsc
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "doc": "this record demonstrates https://issues.apache.org/jira/browse/AVRO-702",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord1",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "enum",
+              "name": "InnerEnum",
+              "namespace": "com.acme.outer",
+              "doc": "this enums namespace gets messed up under avro 1.4",
+              "symbols": ["A", "B"]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "outerField2",
+      "type": "com.acme.outer.InnerEnum",
+      "doc": "this wont even parse() after 1.4 is done with it (as InnerEnum will be renamed above)"
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoRecord-bad.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoRecord-bad.avsc
@@ -1,0 +1,30 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "record",
+              "name": "InnerRecord",
+              "fields": [
+                {
+                  "name": "innerField",
+                  "type": "int"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoRecord-good.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoRecord-good.avsc
@@ -1,0 +1,33 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "doc": "this record demonstrates https://issues.apache.org/jira/browse/AVRO-702",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": {
+              "type": "record",
+              "name": "InnerRecord",
+              "namespace": "com.acme.outer",
+              "doc": "this records namespace gets messed up under avro 1.4",
+              "fields": [
+                {
+                  "name": "innerField",
+                  "type": "int"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoUnion-good.avsc
+++ b/helper/tests/helper-tests-common/src/main/resources/avro702/Avro702DemoUnion-good.avsc
@@ -1,0 +1,36 @@
+{
+  "type": "record",
+  "namespace": "com.acme.outer",
+  "name": "OuterRecord",
+  "doc": "this record demonstrates https://issues.apache.org/jira/browse/AVRO-702",
+  "fields": [
+    {
+      "name": "outerField",
+      "type": {
+        "type": "record",
+        "name": "MiddleRecord",
+        "namespace": "com.acme.middle",
+        "fields": [
+          {
+            "name": "middleField",
+            "type": [
+              "null",
+              {
+                "type": "record",
+                "name": "InnerRecord",
+                "namespace": "com.acme.outer",
+                "doc": "this records namespace gets messed up under avro 1.4",
+                "fields": [
+                  {
+                    "name": "innerField",
+                    "type": "int"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
this PR will add configuration options to the avsc generation method(s) of helper to allow for mitigation of avro-702.
planned changes:

- expend the configuration space for avsc generation to cover preferred/required use of vanilla avro, and "injecting" aliases to named types to better interop with their avro-702 mirror images 
- write code to inject avro-702 aliases in impacted schemas - add "correct" aliases when generating bad avsc, and "bad" aliases when generating correct avsc
- add tests demonstrating that alias injection above allows for good reader schemas to decode payloads written with bad schemas and vice versa (especially when enums and fixed types are impacted)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/linkedin/avro-util/265)
<!-- Reviewable:end -->
