### PR TITLE
Change util method name from isGenericRecord to isGenericDataRecord and update its Javadoc accordingly

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -455,15 +455,26 @@ public class AvroCompatibilityHelper {
   // methods for dealing with generic records
 
   /**
-   * Return true if the {@link IndexedRecord} is a {@link org.apache.avro.generic.GenericRecord}.
+   * This method is deprecated. Please use {@link AvroCompatibilityHelper#isGenericDataRecord} instead.
    *
-   * This can be a source of confusion in avro 1.7+ because SpecificRecordBase implements GenericRecord
+   * @param indexedRecord a record
+   * @return true if argument is a {@link GenericData.Record}.
+   */
+  @Deprecated
+  public static boolean isGenericRecord(IndexedRecord indexedRecord) {
+    return isGenericDataRecord(indexedRecord);
+  }
+
+  /**
+   * Return true if the {@link IndexedRecord} is a {@link GenericData.Record}.
+   *
+   * This can be a source of confusion in avro 1.7+ because SpecificRecordBase implements {@link org.apache.avro.generic.GenericRecord}
    * so it would be wrong to check for instanceof GenericRecord!
    *
    * @param indexedRecord a record
-   * @return true if argument is a generic record
+   * @return true if argument is a {@link GenericData.Record}.
    */
-  public static boolean isGenericRecord(IndexedRecord indexedRecord) {
+  public static boolean isGenericDataRecord(IndexedRecord indexedRecord) {
     return !(isSpecificRecord(indexedRecord));
   }
 

--- a/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
+++ b/spotbugs-plugin/src/test/java/com/linkedin/avroutil1/spotbugs/GoodClass.java
@@ -46,7 +46,7 @@ public class GoodClass {
     public void instanceOfGenericRecord() throws Exception {
         SpecificRecordBase someRecord = null;
         //noinspection ConstantConditions
-        if (AvroCompatibilityHelper.isGenericRecord(someRecord)) {
+        if (AvroCompatibilityHelper.isGenericDataRecord(someRecord)) {
             System.err.println("boom");
         }
     }


### PR DESCRIPTION
This util method is actually checking if a record is a `GenericData.Record` instead of an `org.apache.avro.generic.GenericRecord`. So, update its method name and doc to be more precise.