### PR TITLE
[helper] Transform null values within default values into null marker objects.

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroSchemaUtil.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroSchemaUtil.java
@@ -8,15 +8,10 @@ package com.linkedin.avroutil1.compatibility;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericFixed;
-import org.apache.avro.generic.IndexedRecord;
 
 
 public class AvroSchemaUtil {
@@ -82,42 +77,6 @@ public class AvroSchemaUtil {
           nonNullBranches.size()));
     }
     return nonNullBranches.get(0);
-  }
-
-  /**
-   * we want to be very generous with what we let users provide for default values.
-   * sadly, (modern) avro can only handle specific classes/collections/primitive-wrappers
-   * (see org.apache.avro.util.internal.JacksonUtils.toJson(Object, JsonGenerator) in 1.9+)
-   * @param mightNotBeFriendly a proposed field default value that might originate from
-   *                           a call like AvroCompatibilityHelper.getGenericDefaultValue()
-   * @return a representation of the input that avro likes for use as a field default value
-   */
-  public static Object avroFriendlyDefaultValue(Object mightNotBeFriendly) throws Exception {
-
-    //generic enums we turn to strings
-    if (mightNotBeFriendly instanceof GenericData.EnumSymbol) {
-      return mightNotBeFriendly.toString(); // == symbol string
-    }
-
-    //fixed (generic or specific) we turn to bytes
-    if (mightNotBeFriendly instanceof GenericFixed) {
-      return ((GenericFixed) mightNotBeFriendly).bytes();
-    }
-
-    //records (generic or specific) we turn to maps
-    if (mightNotBeFriendly instanceof IndexedRecord) {
-      IndexedRecord record = (IndexedRecord) mightNotBeFriendly;
-      Schema recordSchema = record.getSchema();
-
-      Map<String, Object> map = new HashMap<>();
-      for (Schema.Field field : recordSchema.getFields()) {
-        Object fieldValue = record.get(field.pos());
-        map.put(field.name(), avroFriendlyDefaultValue(fieldValue));
-        //TODO - extra props ?!
-      }
-      return map;
-    }
-    return mightNotBeFriendly;
   }
 
   /**

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/FieldBuilder111.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/FieldBuilder111.java
@@ -8,10 +8,15 @@ package com.linkedin.avroutil1.compatibility.avro111;
 
 import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import java.util.HashMap;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 
 import java.util.Map;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class FieldBuilder111 implements FieldBuilder {
@@ -97,7 +102,7 @@ public class FieldBuilder111 implements FieldBuilder {
   public Schema.Field build() {
     Object avroFriendlyDefault;
     try {
-      avroFriendlyDefault = AvroSchemaUtil.avroFriendlyDefaultValue(_defaultVal);
+      avroFriendlyDefault = avroFriendlyDefaultValue(_defaultVal);
     } catch (Exception e) {
       throw new IllegalArgumentException("unable to convert default value " + _defaultVal + " into something avro can handle", e);
     }
@@ -108,5 +113,46 @@ public class FieldBuilder111 implements FieldBuilder {
       }
     }
     return result;
+  }
+
+  /**
+   * we want to be very generous with what we let users provide for default values.
+   * sadly, (modern) avro can only handle specific classes/collections/primitive-wrappers
+   * (see org.apache.avro.util.internal.JacksonUtils.toJson(Object, JsonGenerator) in 1.9+)
+   * @param mightNotBeFriendly a proposed field default value that might originate from
+   *                           a call like AvroCompatibilityHelper.getGenericDefaultValue()
+   * @return a representation of the input that avro likes for use as a field default value
+   */
+  private static Object avroFriendlyDefaultValue(Object mightNotBeFriendly) throws Exception {
+
+    //generic enums we turn to strings
+    if (mightNotBeFriendly instanceof GenericData.EnumSymbol) {
+      return mightNotBeFriendly.toString(); // == symbol string
+    }
+
+    //fixed (generic or specific) we turn to bytes
+    if (mightNotBeFriendly instanceof GenericFixed) {
+      return ((GenericFixed) mightNotBeFriendly).bytes();
+    }
+
+    //records (generic or specific) we turn to maps
+    if (mightNotBeFriendly instanceof IndexedRecord) {
+      IndexedRecord record = (IndexedRecord) mightNotBeFriendly;
+      Schema recordSchema = record.getSchema();
+
+      Map<String, Object> map = new HashMap<>();
+      for (Schema.Field field : recordSchema.getFields()) {
+        Object fieldValue = record.get(field.pos());
+        if (fieldValue == null) {
+          fieldValue = JsonProperties.NULL_VALUE;
+        } else {
+          fieldValue = avroFriendlyDefaultValue(fieldValue);
+        }
+        map.put(field.name(), fieldValue);
+        //TODO - extra props ?!
+      }
+      return map;
+    }
+    return mightNotBeFriendly;
   }
 }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/FieldBuilder19.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/FieldBuilder19.java
@@ -8,10 +8,15 @@ package com.linkedin.avroutil1.compatibility.avro19;
 
 import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import java.util.HashMap;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field.Order;
 
 import java.util.Map;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class FieldBuilder19 implements FieldBuilder {
@@ -97,7 +102,7 @@ public class FieldBuilder19 implements FieldBuilder {
   public Schema.Field build() {
     Object avroFriendlyDefault;
     try {
-      avroFriendlyDefault = AvroSchemaUtil.avroFriendlyDefaultValue(_defaultVal);
+      avroFriendlyDefault = avroFriendlyDefaultValue(_defaultVal);
     } catch (Exception e) {
       throw new IllegalArgumentException("unable to convert default value " + _defaultVal + " into something avro can handle", e);
     }
@@ -108,5 +113,46 @@ public class FieldBuilder19 implements FieldBuilder {
       }
     }
     return result;
+  }
+
+  /**
+   * we want to be very generous with what we let users provide for default values.
+   * sadly, (modern) avro can only handle specific classes/collections/primitive-wrappers
+   * (see org.apache.avro.util.internal.JacksonUtils.toJson(Object, JsonGenerator) in 1.9+)
+   * @param mightNotBeFriendly a proposed field default value that might originate from
+   *                           a call like AvroCompatibilityHelper.getGenericDefaultValue()
+   * @return a representation of the input that avro likes for use as a field default value
+   */
+  private static Object avroFriendlyDefaultValue(Object mightNotBeFriendly) throws Exception {
+
+    //generic enums we turn to strings
+    if (mightNotBeFriendly instanceof GenericData.EnumSymbol) {
+      return mightNotBeFriendly.toString(); // == symbol string
+    }
+
+    //fixed (generic or specific) we turn to bytes
+    if (mightNotBeFriendly instanceof GenericFixed) {
+      return ((GenericFixed) mightNotBeFriendly).bytes();
+    }
+
+    //records (generic or specific) we turn to maps
+    if (mightNotBeFriendly instanceof IndexedRecord) {
+      IndexedRecord record = (IndexedRecord) mightNotBeFriendly;
+      Schema recordSchema = record.getSchema();
+
+      Map<String, Object> map = new HashMap<>();
+      for (Schema.Field field : recordSchema.getFields()) {
+        Object fieldValue = record.get(field.pos());
+        if (fieldValue == null) {
+          fieldValue = JsonProperties.NULL_VALUE;
+        } else {
+          fieldValue = avroFriendlyDefaultValue(fieldValue);
+        }
+        map.put(field.name(), fieldValue);
+        //TODO - extra props ?!
+      }
+      return map;
+    }
+    return mightNotBeFriendly;
   }
 }

--- a/helper/tests/codegen-14/src/main/compat-avro/under14/RecordWithComplexDefaults.avsc
+++ b/helper/tests/codegen-14/src/main/compat-avro/under14/RecordWithComplexDefaults.avsc
@@ -60,6 +60,22 @@
       "default": {
         "intField": 9
       }
+    },
+    {
+      "name": "recordFieldWithInnerUnion",
+      "type": {
+        "type": "record",
+        "name": "OuterRecordType",
+        "fields": [
+          {
+            "name": "innerUnionField",
+            "type": ["null", "string"]
+          }
+        ]
+      },
+      "default": {
+        "innerUnionField": null
+      }
     }
   ]
 }

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/FieldBuilderTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/FieldBuilderTest.java
@@ -65,6 +65,7 @@ public class FieldBuilderTest {
         setDefaultValues(schema.getField("fieldWithDefaultRecord"));
         setDefaultValues(schema.getField("fieldWithDefaultIntArray"));
         setDefaultValues(schema.getField("unionFieldWithDefaultRecord"));
+        setDefaultValues(schema.getField("recordFieldWithInnerUnion"));
     }
 
     @Test


### PR DESCRIPTION
When transforming a default value that has a map somewhere inside, and
when that map has null values in it, we need to transform those nulls
into actual objects. Otherwise, Avro croaks like so:
```
java.lang.NullPointerException
    at org.apache.avro.util.internal.JacksonUtils.toJson(JacksonUtils.java:96)
    at org.apache.avro.util.internal.JacksonUtils.toJson(JacksonUtils.java:68)
    at org.apache.avro.util.internal.JacksonUtils.toJsonNode(JacksonUtils.java:53)
    at org.apache.avro.Schema$Field.<init>(Schema.java:596)
    at com.linkedin.avroutil1.compatibility.avro110.FieldBuilder110.build(FieldBuilder110.java:104)
    at com.linkedin.avroutil1.compatibility.FieldBuilderTest.setDefaultValues(FieldBuilderTest.java:118)
    at com.linkedin.avroutil1.compatibility.FieldBuilderTest.testDefaultValuesInterop(FieldBuilderTest.java:68)
```

Schema.Field's constructor calls JacksonUtils.toJsonNode(defaultValue).
If the defaultValue is itself null, it's okay. From JacksonUtils.java:
```
public static JsonNode toJsonNode(Object datum) {
  if (datum == null) {
    return null;
  }
  ...
```

But if the defaultValue is not null, it descends into the toJson()
method, which doesn't expect to see null anywhere within. When it sees
anything it doesn't recognize, it tries to throw AvroRuntimeException,
but the call to datum.getClass() (to construct the message for the
exception) causes the NPE.

The correct way to resolve this involves transforming nulls into
JsonProperties.NULL_VALUE. That only exists in Avro >= 1.8, so the
avroFriendlyDefaultValue() method has to be hoisted out of common and
into each of the relevant FieldBuilderNN classes, resulting in some
code duplication.
