### PR TITLE
Added getCompatibleDefaultValue method and un-deprecation of createSchemaField

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -603,9 +603,9 @@ public class AvroCompatibilityHelper {
    * @param field a schema field
    * @return the default value of the field (if such a value exists),
    *         as a generic record class. Returns null if there is no default value.
-   *         null default also means union field with null. If null default value
-   *         is returned, if needed choose appropriate default value based on
-   *         schema type.
+   *         A null default also means that field is of type NULL or union field with null 
+   *         and null being the first member. If null default value is returned, 
+   *         if needed choose appropriate default value based on schema type.
    */
   public static Object getNullableGenericDefaultValue(Schema.Field field) {
     return fieldHasDefault(field) ? getGenericDefaultValue(field) : null;

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -596,6 +596,22 @@ public class AvroCompatibilityHelper {
   }
 
   /**
+   * returns the default value for a schema field, as a generic record class
+   * (if the default value is complex enough - say records, enums, fixed fields etc)
+   * or as a JDK/Avro class (for simple values like Strings or booleans). <br>
+   *
+   * @param field a schema field
+   * @return the default value of the field (if such a value exists),
+   *         as a generic record class. Returns null if there is no default value.
+   *         null default also means union field with null. If null default value
+   *         is returned, if needed choose appropriate default value based on
+   *         schema type.
+   */
+  public static Object getCompatibleDefaultValue(Schema.Field field) {
+    return fieldHasDefault(field) ? getGenericDefaultValue(field) : null;
+  }
+
+  /**
    * returns a new FieldBuilder, optionally copying the initial values from a given Schema$Field
    * @param other (optional) a field from which to set the initial values for the returned builder
    * @return a new field builder
@@ -799,9 +815,7 @@ public class AvroCompatibilityHelper {
    *                     For avro 1.9 and newer, user should pass in the default value object directly.
    * @param order the order of the field.
    * @return fully constructed Field instance
-   * @deprecated use {@link #newField(Schema.Field)}
    */
-  @Deprecated
   public static Schema.Field createSchemaField(String name, Schema schema, String doc, Object defaultValue, Schema.Field.Order order) {
     return newField(null)
             .setName(name)

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -607,7 +607,7 @@ public class AvroCompatibilityHelper {
    *         is returned, if needed choose appropriate default value based on
    *         schema type.
    */
-  public static Object getCompatibleDefaultValue(Schema.Field field) {
+  public static Object getNullableGenericDefaultValue(Schema.Field field) {
     return fieldHasDefault(field) ? getGenericDefaultValue(field) : null;
   }
 

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperDefaultsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperDefaultsTest.java
@@ -56,13 +56,13 @@ public class AvroCompatibilityHelperDefaultsTest {
     SchemaParseResult result = AvroCompatibilityHelper.parse(avsc, SchemaParseConfiguration.STRICT, null);
     Schema schema = result.getMainSchema();
 
-    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("nullField")));
-    Assert.assertTrue((Boolean) AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("boolField")));
+    Assert.assertNull(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("nullField")));
+    Assert.assertTrue((Boolean) AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("boolField")));
     //returns a Utf8
-    Assert.assertEquals(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("strField")).toString(), "default");
-    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("unionWithNullDefault")));
+    Assert.assertEquals(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("strField")).toString(), "default");
+    Assert.assertNull(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("unionWithNullDefault")));
     //Utf8
-    Assert.assertEquals(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("unionWithStringDefault")).toString(), "def");
+    Assert.assertEquals(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("unionWithStringDefault")).toString(), "def");
   }
 
   @Test
@@ -142,9 +142,9 @@ public class AvroCompatibilityHelperDefaultsTest {
     SchemaParseResult result = AvroCompatibilityHelper.parse(avsc, SchemaParseConfiguration.STRICT, null);
     Schema schema = result.getMainSchema();
     
-    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("nullWithoutDefault")));
-    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("boolWithoutDefault")));
-    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("unionWithStringNoDefault")));
+    Assert.assertNull(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("nullWithoutDefault")));
+    Assert.assertNull(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("boolWithoutDefault")));
+    Assert.assertNull(AvroCompatibilityHelper.getNullableGenericDefaultValue(schema.getField("unionWithStringNoDefault")));
   }
 
   @Test

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperDefaultsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperDefaultsTest.java
@@ -51,6 +51,21 @@ public class AvroCompatibilityHelperDefaultsTest {
   }
 
   @Test
+  public void testGetCompatibleDefaultValue() throws Exception {
+    String avsc = TestUtil.load("RecordWithDefaults.avsc");
+    SchemaParseResult result = AvroCompatibilityHelper.parse(avsc, SchemaParseConfiguration.STRICT, null);
+    Schema schema = result.getMainSchema();
+
+    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("nullField")));
+    Assert.assertTrue((Boolean) AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("boolField")));
+    //returns a Utf8
+    Assert.assertEquals(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("strField")).toString(), "default");
+    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("unionWithNullDefault")));
+    //Utf8
+    Assert.assertEquals(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("unionWithStringDefault")).toString(), "def");
+  }
+
+  @Test
   public void testGetFieldDefaultsAsJson() throws Exception {
     String avsc = TestUtil.load("RecordWithDefaults.avsc");
     SchemaParseResult result = AvroCompatibilityHelper.parse(avsc, SchemaParseConfiguration.STRICT, null);
@@ -119,6 +134,17 @@ public class AvroCompatibilityHelperDefaultsTest {
       Throwable root = Throwables.getRootCause(expected);
       Assert.assertTrue(root.getMessage().contains("unionWithStringNoDefault"));
     }
+  }
+
+  @Test
+  public void testGetCompatibleDefaultValueWithoutDefaults() throws Exception {
+    String avsc = TestUtil.load("RecordWithDefaults.avsc");
+    SchemaParseResult result = AvroCompatibilityHelper.parse(avsc, SchemaParseConfiguration.STRICT, null);
+    Schema schema = result.getMainSchema();
+    
+    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("nullWithoutDefault")));
+    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("boolWithoutDefault")));
+    Assert.assertNull(AvroCompatibilityHelper.getCompatibleDefaultValue(schema.getField("unionWithStringNoDefault")));
   }
 
   @Test


### PR DESCRIPTION
1. Added getNullableGenericDefaultValue to check if schema field has default value. If so returns the default value otherwise returns null. So, null means that the field does not have default value or field is of type NULL or union field with null and null being the first member.
2. Un deprecated createSchemaField as it is easier to invoke compared to newField if there there are more usage within a file or within a single method. This will help make code more readable and reduce the code size.
3. Added some test for the newly added methods.