### PR TITLE
Un-deprecate overloaded createSchemaField method.

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -825,11 +825,7 @@ public class AvroCompatibilityHelper {
             .setOrder(order)
             .build();
   }
-
-  /**
-   * @deprecated use {@link #newField(Schema.Field)}
-   */
-  @Deprecated
+  
   public static Schema.Field createSchemaField(String name, Schema schema, String doc, Object defaultValue) {
     return createSchemaField(name, schema, doc, defaultValue, Schema.Field.Order.ASCENDING);
   }


### PR DESCRIPTION
Un-deprecate overloaded createSchemaField method. Usage of this method will help reduce consumer code size and make more readable when used multiple times within a class or method.