### PR TITLE
[AvscWriter] enforce uniform numeric defaults on write

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
@@ -29,7 +29,7 @@ import org.codehaus.jackson.node.TextNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Jackson1Utils {

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
@@ -11,12 +11,24 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import java.math.BigDecimal;
+import org.apache.avro.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.avro.Schema.Type.*;
 
 
 public class Jackson2Utils {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final JsonFactory JSON_FACTORY = new JsonFactory();
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Jackson2Utils.class);
 
   private Jackson2Utils() {
     // Util class; should not be instantiated.
@@ -61,5 +73,40 @@ public class Jackson2Utils {
       throw new IllegalStateException("while trying to serialize " + node + " (a " + node.getClass().getName() + ")",
           issue);
     }
+  }
+
+  /**
+   *  Enforces uniform numeric default values across Avro versions
+   */
+  static public JsonNode enforceUniformNumericDefaultValues(Schema.Field field, JsonNode genericDefaultValue) {
+    BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
+    Schema schema = field.schema();
+    // a default value for a union, must match the first element of the union
+    Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+    switch (defaultType) {
+      case INT:
+        if (!isAMathematicalInteger(numericDefaultValue)) {
+          LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
+          return genericDefaultValue;
+        }
+        return new IntNode(genericDefaultValue.intValue());
+      case LONG:
+        if (!isAMathematicalInteger(numericDefaultValue)) {
+          LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
+          return genericDefaultValue;
+        }
+        return new LongNode(genericDefaultValue.longValue());
+      case DOUBLE:
+        return new DoubleNode(genericDefaultValue.doubleValue());
+      case FLOAT:
+        return new FloatNode(genericDefaultValue.floatValue());
+      default:
+        return genericDefaultValue;
+    }
+  }
+
+  static private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+    return bigDecimal.stripTrailingZeros().scale() <= 0;
   }
 }

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
@@ -21,7 +21,7 @@ import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Jackson2Utils {

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -106,7 +108,11 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
         double numericDefaultValue = genericDefaultValue.doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericDefaultValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -70,9 +70,12 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writeDefaultValue(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
         if (field.hasDefaultValue()) {
-            JsonNode coercedDefaultValue = enforceUniformNumericDefaultValues(field);
+            JsonNode defaultValue = Accessor.defaultValue(field);
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
-            gen.getDelegate().writeTree(coercedDefaultValue);
+            gen.getDelegate().writeTree(defaultValue);
         }
     }
 
@@ -102,10 +105,6 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        if (!genericDefaultValue.isNumber()) {
-            LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
-            return genericDefaultValue;
-        }
         double numericDefaultValue = genericDefaultValue.doubleValue();
         switch (field.schema().getType()) {
             case INT:

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
+import java.math.BigDecimal;
 import org.apache.avro.Schema;
 import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
@@ -107,20 +108,20 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        double numericDefaultValue = genericDefaultValue.doubleValue();
+        BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
         Schema schema = field.schema();
         // a default value for a union, must match the first element of the union
         Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
         switch (defaultType) {
             case INT:
-                if (numericDefaultValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericDefaultValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
                     return genericDefaultValue;
                 }
                 return new IntNode(genericDefaultValue.intValue());
             case LONG:
-                if (numericDefaultValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericDefaultValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
                     return genericDefaultValue;
                 }
@@ -132,5 +133,9 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
             default:
                 return genericDefaultValue;
         }
+    }
+
+    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -10,31 +10,20 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.FloatNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
-import java.math.BigDecimal;
-import org.apache.avro.Schema;
-import org.apache.avro.util.internal.Accessor;
-import org.apache.avro.util.internal.JacksonUtils;
-
+import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
+import org.apache.avro.Schema;
+import org.apache.avro.util.internal.Accessor;
+import org.apache.avro.util.internal.JacksonUtils;
 
 
 public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro110AvscWriter.class);
 
     public Avro110AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -75,7 +64,7 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
         if (field.hasDefaultValue()) {
             JsonNode defaultValue = Accessor.defaultValue(field);
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson2Utils.enforceUniformNumericDefaultValues(field, defaultValue);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -101,41 +90,5 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
             Object o = entry.getValue();
             delegate.writeObjectField(entry.getKey(), JacksonUtils.toJsonNode(o));
         }
-    }
-
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
-
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericDefaultValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
-                    return genericDefaultValue;
-                }
-                return new IntNode(genericDefaultValue.intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericDefaultValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
-                    return genericDefaultValue;
-                }
-                return new LongNode(genericDefaultValue.longValue());
-            case DOUBLE:
-                return new DoubleNode(genericDefaultValue.doubleValue());
-            case FLOAT:
-                return new FloatNode(genericDefaultValue.floatValue());
-            default:
-                return genericDefaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -70,9 +70,12 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writeDefaultValue(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
         if (field.hasDefaultValue()) {
-            JsonNode coercedDefaultValue = enforceUniformNumericDefaultValues(field);
+            JsonNode defaultValue = Accessor.defaultValue(field);
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
-            gen.getDelegate().writeTree(coercedDefaultValue);
+            gen.getDelegate().writeTree(defaultValue);
         }
     }
 
@@ -102,10 +105,6 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        if (!genericDefaultValue.isNumber()) {
-            LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
-            return genericDefaultValue;
-        }
         double numericDefaultValue = genericDefaultValue.doubleValue();
         switch (field.schema().getType()) {
             case INT:

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -106,7 +108,11 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
         double numericDefaultValue = genericDefaultValue.doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericDefaultValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
+import java.math.BigDecimal;
 import org.apache.avro.Schema;
 import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
@@ -107,20 +108,20 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        double numericDefaultValue = genericDefaultValue.doubleValue();
+        BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
         Schema schema = field.schema();
         // a default value for a union, must match the first element of the union
         Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
         switch (defaultType) {
             case INT:
-                if (numericDefaultValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericDefaultValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
                     return genericDefaultValue;
                 }
                 return new IntNode(genericDefaultValue.intValue());
             case LONG:
-                if (numericDefaultValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericDefaultValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
                     return genericDefaultValue;
                 }
@@ -132,5 +133,9 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
             default:
                 return genericDefaultValue;
         }
+    }
+
+    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -8,19 +8,30 @@ package com.linkedin.avroutil1.compatibility.avro111;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
 import org.apache.avro.Schema;
+import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Avro111AvscWriter.class);
 
     public Avro111AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -59,9 +70,9 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writeDefaultValue(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
         if (field.hasDefaultValue()) {
+            JsonNode coercedDefaultValue = enforceUniformNumericDefaultValues(field);
             gen.writeFieldName("default");
-            Object o = field.defaultVal();
-            gen.getDelegate().writeTree(JacksonUtils.toJsonNode(o));
+            gen.getDelegate().writeTree(coercedDefaultValue);
         }
     }
 
@@ -83,6 +94,38 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
         for (Map.Entry<String, Object> entry : props.entrySet()) {
             Object o = entry.getValue();
             delegate.writeObjectField(entry.getKey(), JacksonUtils.toJsonNode(o));
+        }
+    }
+
+    /**
+     *  Enforces uniform numeric default values across Avro versions
+     */
+    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+        JsonNode genericDefaultValue = Accessor.defaultValue(field);
+        if (!genericDefaultValue.isNumber()) {
+            LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
+            return genericDefaultValue;
+        }
+        double numericDefaultValue = genericDefaultValue.doubleValue();
+        switch (field.schema().getType()) {
+            case INT:
+                if (numericDefaultValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
+                    return genericDefaultValue;
+                }
+                return new IntNode(genericDefaultValue.intValue());
+            case LONG:
+                if (numericDefaultValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
+                    return genericDefaultValue;
+                }
+                return new LongNode(genericDefaultValue.longValue());
+            case DOUBLE:
+                return new DoubleNode(genericDefaultValue.doubleValue());
+            case FLOAT:
+                return new FloatNode(genericDefaultValue.floatValue());
+            default:
+                return genericDefaultValue;
         }
     }
 }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -10,31 +10,20 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.FloatNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
-import java.math.BigDecimal;
-import org.apache.avro.Schema;
-import org.apache.avro.util.internal.Accessor;
-import org.apache.avro.util.internal.JacksonUtils;
-
+import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
+import org.apache.avro.Schema;
+import org.apache.avro.util.internal.Accessor;
+import org.apache.avro.util.internal.JacksonUtils;
 
 
 public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro111AvscWriter.class);
 
     public Avro111AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -75,7 +64,7 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
         if (field.hasDefaultValue()) {
             JsonNode defaultValue = Accessor.defaultValue(field);
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson2Utils.enforceUniformNumericDefaultValues(field, defaultValue);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -101,41 +90,5 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
             Object o = entry.getValue();
             delegate.writeObjectField(entry.getKey(), JacksonUtils.toJsonNode(o));
         }
-    }
-
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
-
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericDefaultValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
-                    return genericDefaultValue;
-                }
-                return new IntNode(genericDefaultValue.intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericDefaultValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
-                    return genericDefaultValue;
-                }
-                return new LongNode(genericDefaultValue.longValue());
-            case DOUBLE:
-                return new DoubleNode(genericDefaultValue.doubleValue());
-            case FLOAT:
-                return new FloatNode(genericDefaultValue.floatValue());
-            default:
-                return genericDefaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
@@ -8,7 +8,12 @@ package com.linkedin.avroutil1.compatibility.avro14;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
-import java.math.BigDecimal;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -16,24 +21,9 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.Set;
-import org.codehaus.jackson.node.DoubleNode;
-import org.codehaus.jackson.node.IntNode;
-import org.codehaus.jackson.node.LongNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
-
 
 public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro14AvscWriter.class);
 
     private static final Field SCHEMA_PROPS_FIELD;
     private static final Field FIELD_PROPS_FIELD;
@@ -93,7 +83,7 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson1Utils.enforceUniformNumericDefaultValues(field);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -152,41 +142,5 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
                 gen.writeStringField(propName, entry.getValue());
             }
         }
-    }
-
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode defaultValue = field.defaultValue();
-        BigDecimal numericValue = defaultValue.getDecimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
-
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new IntNode(defaultValue.getNumberValue().intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new LongNode(defaultValue.getNumberValue().longValue());
-            case DOUBLE:
-                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
-            case FLOAT:
-                return new DoubleNode(defaultValue.getNumberValue().floatValue());
-            default:
-                return defaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
@@ -26,7 +26,7 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
@@ -26,6 +26,8 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -157,7 +159,11 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
         double numericValue = defaultValue.getNumberValue().doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
@@ -20,9 +20,17 @@ import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Set;
+import org.codehaus.jackson.node.DoubleNode;
+import org.codehaus.jackson.node.IntNode;
+import org.codehaus.jackson.node.LongNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Avro14AvscWriter.class);
 
     private static final Field SCHEMA_PROPS_FIELD;
     private static final Field FIELD_PROPS_FIELD;
@@ -81,6 +89,9 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     protected void writeDefaultValue(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
         }
@@ -137,6 +148,34 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             if (propNameFilter == null || propNameFilter.test(propName)) {
                 gen.writeStringField(propName, entry.getValue());
             }
+        }
+    }
+
+    /**
+     *  Enforces uniform numeric default values across Avro versions
+     */
+    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+        JsonNode defaultValue = field.defaultValue();
+        double numericValue = defaultValue.getNumberValue().doubleValue();
+        switch (field.schema().getType()) {
+            case INT:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new IntNode(defaultValue.getNumberValue().intValue());
+            case LONG:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new LongNode(defaultValue.getNumberValue().longValue());
+            case DOUBLE:
+                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
+            case FLOAT:
+                return new DoubleNode(defaultValue.getNumberValue().floatValue());
+            default:
+                return defaultValue;
         }
     }
 }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -8,6 +8,7 @@ package com.linkedin.avroutil1.compatibility.avro15;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import java.math.BigDecimal;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -158,20 +159,20 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
-        double numericValue = defaultValue.getNumberValue().doubleValue();
+        BigDecimal numericValue = defaultValue.getDecimalValue();
         Schema schema = field.schema();
         // a default value for a union, must match the first element of the union
         Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
         switch (defaultType) {
             case INT:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
                 return new IntNode(defaultValue.getNumberValue().intValue());
             case LONG:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
@@ -183,5 +184,9 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             default:
                 return defaultValue;
         }
+    }
+
+    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -8,7 +8,12 @@ package com.linkedin.avroutil1.compatibility.avro15;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
-import java.math.BigDecimal;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -16,24 +21,9 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.lang.reflect.Field;
-import java.util.Map;
-import java.util.Set;
-import org.codehaus.jackson.node.DoubleNode;
-import org.codehaus.jackson.node.IntNode;
-import org.codehaus.jackson.node.LongNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
-
 
 public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro15AvscWriter.class);
 
     private static final Field SCHEMA_PROPS_FIELD;
     private static final Field FIELD_PROPS_FIELD;
@@ -93,7 +83,7 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson1Utils.enforceUniformNumericDefaultValues(field);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -152,41 +142,5 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
                 gen.writeStringField(propName, entry.getValue());
             }
         }
-    }
-
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode defaultValue = field.defaultValue();
-        BigDecimal numericValue = defaultValue.getDecimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
-
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new IntNode(defaultValue.getNumberValue().intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new LongNode(defaultValue.getNumberValue().longValue());
-            case DOUBLE:
-                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
-            case FLOAT:
-                return new DoubleNode(defaultValue.getNumberValue().floatValue());
-            default:
-                return defaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -26,6 +26,8 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -157,7 +159,11 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
         double numericValue = defaultValue.getNumberValue().doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -26,7 +26,7 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -20,9 +20,17 @@ import java.io.StringWriter;
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Set;
+import org.codehaus.jackson.node.DoubleNode;
+import org.codehaus.jackson.node.IntNode;
+import org.codehaus.jackson.node.LongNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Avro15AvscWriter.class);
 
     private static final Field SCHEMA_PROPS_FIELD;
     private static final Field FIELD_PROPS_FIELD;
@@ -81,6 +89,9 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     protected void writeDefaultValue(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
         }
@@ -137,6 +148,34 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             if (propNameFilter == null || propNameFilter.test(propName)) {
                 gen.writeStringField(propName, entry.getValue());
             }
+        }
+    }
+
+    /**
+     *  Enforces uniform numeric default values across Avro versions
+     */
+    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+        JsonNode defaultValue = field.defaultValue();
+        double numericValue = defaultValue.getNumberValue().doubleValue();
+        switch (field.schema().getType()) {
+            case INT:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new IntNode(defaultValue.getNumberValue().intValue());
+            case LONG:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new LongNode(defaultValue.getNumberValue().longValue());
+            case DOUBLE:
+                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
+            case FLOAT:
+                return new DoubleNode(defaultValue.getNumberValue().floatValue());
+            default:
+                return defaultValue;
         }
     }
 }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
@@ -19,9 +19,17 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
+import org.codehaus.jackson.node.DoubleNode;
+import org.codehaus.jackson.node.IntNode;
+import org.codehaus.jackson.node.LongNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Avro16AvscWriter.class);
 
     public Avro16AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -63,6 +71,9 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     protected void writeDefaultValue(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
         }
@@ -96,6 +107,34 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             if (propNameFilter == null || propNameFilter.test(propName)) {
                 gen.writeStringField(propName, entry.getValue());
             }
+        }
+    }
+
+    /**
+     *  Enforces uniform numeric default values across Avro versions
+     */
+    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+        JsonNode defaultValue = field.defaultValue();
+        double numericValue = defaultValue.getNumberValue().doubleValue();
+        switch (field.schema().getType()) {
+            case INT:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new IntNode(defaultValue.getNumberValue().intValue());
+            case LONG:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new LongNode(defaultValue.getNumberValue().longValue());
+            case DOUBLE:
+                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
+            case FLOAT:
+                return new DoubleNode(defaultValue.getNumberValue().floatValue());
+            default:
+                return defaultValue;
         }
     }
 }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
@@ -25,7 +25,7 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
@@ -8,6 +8,7 @@ package com.linkedin.avroutil1.compatibility.avro16;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import java.math.BigDecimal;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -117,20 +118,20 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
-        double numericValue = defaultValue.getNumberValue().doubleValue();
+        BigDecimal numericValue = defaultValue.getDecimalValue();
         Schema schema = field.schema();
         // a default value for a union, must match the first element of the union
         Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
         switch (defaultType) {
             case INT:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
                 return new IntNode(defaultValue.getNumberValue().intValue());
             case LONG:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
@@ -142,5 +143,9 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             default:
                 return defaultValue;
         }
+    }
+
+    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
@@ -25,6 +25,8 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -116,7 +118,11 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
         double numericValue = defaultValue.getNumberValue().doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -25,6 +25,8 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -122,7 +124,11 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
         double numericValue = defaultValue.getNumberValue().doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -25,7 +25,7 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -8,6 +8,7 @@ package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import java.math.BigDecimal;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -123,20 +124,20 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
-        double numericValue = defaultValue.getNumberValue().doubleValue();
+        BigDecimal numericValue = defaultValue.getDecimalValue();
         Schema schema = field.schema();
         // a default value for a union, must match the first element of the union
         Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
         switch (defaultType) {
             case INT:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
                 return new IntNode(defaultValue.getNumberValue().intValue());
             case LONG:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
@@ -148,5 +149,9 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             default:
                 return defaultValue;
         }
+    }
+
+    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -8,7 +8,11 @@ package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
-import java.math.BigDecimal;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -16,23 +20,9 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Map;
-import java.util.Set;
-import org.codehaus.jackson.node.DoubleNode;
-import org.codehaus.jackson.node.IntNode;
-import org.codehaus.jackson.node.LongNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
-
 
 public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro17AvscWriter.class);
 
     public Avro17AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -80,7 +70,7 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson1Utils.enforceUniformNumericDefaultValues(field);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -117,41 +107,5 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
                 delegate.writeObjectField(entry.getKey(), entry.getValue());
             }
         }
-    }
-
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode defaultValue = field.defaultValue();
-        BigDecimal numericValue = defaultValue.getDecimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
-
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new IntNode(defaultValue.getNumberValue().intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new LongNode(defaultValue.getNumberValue().longValue());
-            case DOUBLE:
-                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
-            case FLOAT:
-                return new DoubleNode(defaultValue.getNumberValue().floatValue());
-            default:
-                return defaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -8,6 +8,7 @@ package com.linkedin.avroutil1.compatibility.avro18;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import java.math.BigDecimal;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -123,20 +124,20 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
-        double numericValue = defaultValue.getNumberValue().doubleValue();
+        BigDecimal numericValue = defaultValue.getDecimalValue();
         Schema schema = field.schema();
         // a default value for a union, must match the first element of the union
         Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
         switch (defaultType) {
             case INT:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
                 return new IntNode(defaultValue.getNumberValue().intValue());
             case LONG:
-                if (numericValue % 1 != 0) {
+                if (!isAMathematicalInteger(numericValue)) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
                     return defaultValue;
                 }
@@ -148,5 +149,9 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             default:
                 return defaultValue;
         }
+    }
+
+    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -19,9 +19,17 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
+import org.codehaus.jackson.node.DoubleNode;
+import org.codehaus.jackson.node.IntNode;
+import org.codehaus.jackson.node.LongNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Avro18AvscWriter.class);
 
     public Avro18AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -68,6 +76,9 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     protected void writeDefaultValue(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
         }
@@ -102,6 +113,34 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
             if (propNameFilter == null || propNameFilter.test(propName)) {
                 delegate.writeObjectField(entry.getKey(), entry.getValue());
             }
+        }
+    }
+
+    /**
+     *  Enforces uniform numeric default values across Avro versions
+     */
+    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+        JsonNode defaultValue = field.defaultValue();
+        double numericValue = defaultValue.getNumberValue().doubleValue();
+        switch (field.schema().getType()) {
+            case INT:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new IntNode(defaultValue.getNumberValue().intValue());
+            case LONG:
+                if (numericValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
+                    return defaultValue;
+                }
+                return new LongNode(defaultValue.getNumberValue().longValue());
+            case DOUBLE:
+                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
+            case FLOAT:
+                return new DoubleNode(defaultValue.getNumberValue().floatValue());
+            default:
+                return defaultValue;
         }
     }
 }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -25,6 +25,8 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -122,7 +124,11 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode defaultValue = field.defaultValue();
         double numericValue = defaultValue.getNumberValue().doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -25,7 +25,7 @@ import org.codehaus.jackson.node.LongNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -8,7 +8,11 @@ package com.linkedin.avroutil1.compatibility.avro18;
 
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
-import java.math.BigDecimal;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Predicate;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonFactory;
@@ -16,23 +20,9 @@ import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.util.Map;
-import java.util.Set;
-import org.codehaus.jackson.node.DoubleNode;
-import org.codehaus.jackson.node.IntNode;
-import org.codehaus.jackson.node.LongNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
-
 
 public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro18AvscWriter.class);
 
     public Avro18AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -80,7 +70,7 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         JsonNode defaultValue = field.defaultValue();
         if (defaultValue != null) {
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson1Utils.enforceUniformNumericDefaultValues(field);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -117,41 +107,5 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
                 delegate.writeObjectField(entry.getKey(), entry.getValue());
             }
         }
-    }
-
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode defaultValue = field.defaultValue();
-        BigDecimal numericValue = defaultValue.getDecimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
-
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new IntNode(defaultValue.getNumberValue().intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", field.defaultValue(), field.name()));
-                    return defaultValue;
-                }
-                return new LongNode(defaultValue.getNumberValue().longValue());
-            case DOUBLE:
-                return new DoubleNode(defaultValue.getNumberValue().doubleValue());
-            case FLOAT:
-                return new DoubleNode(defaultValue.getNumberValue().floatValue());
-            default:
-                return defaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
     }
 }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -27,7 +27,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.avro.Schema.Type.*;
+import static org.apache.avro.Schema.Type.UNION;
 
 
 public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -10,31 +10,20 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.DoubleNode;
-import com.fasterxml.jackson.databind.node.FloatNode;
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
-import java.math.BigDecimal;
-import org.apache.avro.Schema;
-import org.apache.avro.util.internal.Accessor;
-import org.apache.avro.util.internal.JacksonUtils;
-
+import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static org.apache.avro.Schema.Type.UNION;
+import org.apache.avro.Schema;
+import org.apache.avro.util.internal.Accessor;
+import org.apache.avro.util.internal.JacksonUtils;
 
 
 public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Avro19AvscWriter.class);
 
     public Avro19AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -75,7 +64,7 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
         if (field.hasDefaultValue()) {
             JsonNode defaultValue = Accessor.defaultValue(field);
             if (defaultValue.isNumber()) {
-                defaultValue = enforceUniformNumericDefaultValues(field);
+                defaultValue = Jackson2Utils.enforceUniformNumericDefaultValues(field, defaultValue);
             }
             gen.writeFieldName("default");
             gen.getDelegate().writeTree(defaultValue);
@@ -103,39 +92,5 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
         }
     }
 
-    /**
-     *  Enforces uniform numeric default values across Avro versions
-     */
-    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
-        JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
-        Schema schema = field.schema();
-        // a default value for a union, must match the first element of the union
-        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
 
-        switch (defaultType) {
-            case INT:
-                if (!isAMathematicalInteger(numericDefaultValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
-                    return genericDefaultValue;
-                }
-                return new IntNode(genericDefaultValue.intValue());
-            case LONG:
-                if (!isAMathematicalInteger(numericDefaultValue)) {
-                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
-                    return genericDefaultValue;
-                }
-                return new LongNode(genericDefaultValue.longValue());
-            case DOUBLE:
-              return new DoubleNode(genericDefaultValue.doubleValue());
-            case FLOAT:
-              return new FloatNode(genericDefaultValue.floatValue());
-            default:
-                return genericDefaultValue;
-        }
-    }
-
-    private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
-        return bigDecimal.stripTrailingZeros().scale() <= 0;
-    }
 }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -8,19 +8,30 @@ package com.linkedin.avroutil1.compatibility.avro19;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
 import com.linkedin.avroutil1.compatibility.AvscWriter;
 import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
 import org.apache.avro.Schema;
+import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Avro19AvscWriter.class);
 
     public Avro19AvscWriter(boolean pretty, boolean preAvro702, boolean addAliasesForAvro702) {
         super(pretty, preAvro702, addAliasesForAvro702);
@@ -59,9 +70,9 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     @Override
     protected void writeDefaultValue(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
         if (field.hasDefaultValue()) {
+            JsonNode coercedDefaultValue = enforceUniformNumericDefaultValues(field);
             gen.writeFieldName("default");
-            Object o = field.defaultVal();
-            gen.getDelegate().writeTree(JacksonUtils.toJsonNode(o));
+            gen.getDelegate().writeTree(coercedDefaultValue);
         }
     }
 
@@ -83,6 +94,38 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
         for (Map.Entry<String, Object> entry : props.entrySet()) {
             Object o = entry.getValue();
             delegate.writeObjectField(entry.getKey(), JacksonUtils.toJsonNode(o));
+        }
+    }
+
+    /**
+     *  Enforces uniform numeric default values across Avro versions
+     */
+    private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+        JsonNode genericDefaultValue = Accessor.defaultValue(field);
+        if (!genericDefaultValue.isNumber()) {
+            LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
+            return genericDefaultValue;
+        }
+        double numericDefaultValue = genericDefaultValue.doubleValue();
+        switch (field.schema().getType()) {
+            case INT:
+                if (numericDefaultValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));
+                    return genericDefaultValue;
+                }
+                return new IntNode(genericDefaultValue.intValue());
+            case LONG:
+                if (numericDefaultValue % 1 != 0) {
+                    LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
+                    return genericDefaultValue;
+                }
+                return new LongNode(genericDefaultValue.longValue());
+            case DOUBLE:
+              return new DoubleNode(genericDefaultValue.doubleValue());
+            case FLOAT:
+              return new FloatNode(genericDefaultValue.floatValue());
+            default:
+                return genericDefaultValue;
         }
     }
 }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -70,9 +70,12 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     @Override
     protected void writeDefaultValue(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
         if (field.hasDefaultValue()) {
-            JsonNode coercedDefaultValue = enforceUniformNumericDefaultValues(field);
+            JsonNode defaultValue = Accessor.defaultValue(field);
+            if (defaultValue.isNumber()) {
+                defaultValue = enforceUniformNumericDefaultValues(field);
+            }
             gen.writeFieldName("default");
-            gen.getDelegate().writeTree(coercedDefaultValue);
+            gen.getDelegate().writeTree(defaultValue);
         }
     }
 
@@ -102,10 +105,6 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
      */
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
-        if (!genericDefaultValue.isNumber()) {
-            LOGGER.warn(String.format("Invalid default value: %s for \"long\" field: %s", genericDefaultValue, field.name()));
-            return genericDefaultValue;
-        }
         double numericDefaultValue = genericDefaultValue.doubleValue();
         switch (field.schema().getType()) {
             case INT:

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.avro.Schema.Type.*;
+
 
 public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private static final JsonFactory FACTORY = new JsonFactory().setCodec(new ObjectMapper());
@@ -106,7 +108,11 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     private JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
         JsonNode genericDefaultValue = Accessor.defaultValue(field);
         double numericDefaultValue = genericDefaultValue.doubleValue();
-        switch (field.schema().getType()) {
+        Schema schema = field.schema();
+        // a default value for a union, must match the first element of the union
+        Schema.Type defaultType = schema.getType() == UNION ? schema.getTypes().get(0).getType() : schema.getType();
+
+        switch (defaultType) {
             case INT:
                 if (numericDefaultValue % 1 != 0) {
                     LOGGER.warn(String.format("Invalid default value: %s for \"int\" field: %s", genericDefaultValue, field.name()));

--- a/helper/tests/helper-tests-allavro/build.gradle
+++ b/helper/tests/helper-tests-allavro/build.gradle
@@ -89,7 +89,6 @@ dependencies {
   testImplementation "com.fasterxml.jackson.core:jackson-databind:2.11.3"
   testImplementation "org.apache.commons:commons-text:1.9"
   testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-
   avro14 ("org.apache.avro:avro:1.4.1") {
     exclude group: "org.mortbay.jetty"
     exclude group: "org.apache.velocity"

--- a/helper/tests/helper-tests-allavro/build.gradle
+++ b/helper/tests/helper-tests-allavro/build.gradle
@@ -88,6 +88,7 @@ dependencies {
   //required for json-unit
   testImplementation "com.fasterxml.jackson.core:jackson-databind:2.11.3"
   testImplementation "org.apache.commons:commons-text:1.9"
+  testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 
   avro14 ("org.apache.avro:avro:1.4.1") {
     exclude group: "org.mortbay.jetty"

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvscWriterDefaultNumericsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvscWriterDefaultNumericsTest.java
@@ -33,8 +33,8 @@ public class AvscWriterDefaultNumericsTest {
   @Test
   public void testWriteBadUnionDefaultValues() throws Exception {
     runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "-1", "-1", false);
-    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "-1.0", "-1", true);
-    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "0.0", "0", true);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "-1.0", "-1", false);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "0.0", "0", false);
     runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "0", "0", false);
 
     runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.LONG, "-1.0", "-1", true);

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvscWriterDefaultNumericsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvscWriterDefaultNumericsTest.java
@@ -1,0 +1,91 @@
+package com.linkedin.avroutil1.compatibility;
+
+import java.util.Locale;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.testng.annotations.Test;
+
+
+public class AvscWriterDefaultNumericsTest {
+  @Test
+  public void testWriteBadNumericDefaultValues() throws Exception {
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.INT, "-1.0", "-1", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.INT, "0.0", "0", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.INT, "1", "1", false);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.INT, "3.14159", "3.14159", false);
+
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.LONG, "-1.0", "-1", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.LONG, "0.0", "0", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.LONG, "1", "1", false);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.LONG, "3.14159", "3.14159", false);
+
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.FLOAT, "-1", "-1.0", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.FLOAT, "0", "0.0", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.FLOAT, "0.0", "0.0", false);
+
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.DOUBLE, "-1", "-1.0", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.DOUBLE, "0", "0.0", true);
+    runAvscWriterOnBadNumericDefaultValues(Schema.Type.DOUBLE, "0.0", "0.0", false);
+  }
+
+  @Test
+  public void testWriteBadUnionDefaultValues() throws Exception {
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "-1", "-1", false);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "-1.0", "-1", true);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "0.0", "0", true);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.INT, "0", "0", false);
+
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.LONG, "-1.0", "-1", true);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.LONG, "0.0", "0", true);
+
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.FLOAT, "-1", "-1.0", true);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.FLOAT, "0", "0.0", true);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.FLOAT, "1.0", "1.0", false);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.FLOAT, "0.0", "0.0", false);
+
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.DOUBLE, "1", "1.0", false);
+    runAvscWriterOnBadUnionWithNumericDefaultValues(Schema.Type.DOUBLE, "0", "0.0", false);
+
+  }
+
+  public void runAvscWriterOnBadNumericDefaultValues(Type avroType, String defaultValue, String expectedDefaultValue, boolean allowFail) throws Exception {
+    String avscTemplate = "{\"type\": \"record\", \"name\": \"HasBadDefaults\", \"fields\": "
+        + "[{\"name\": \"age\", \"type\": \"%s\", \"default\":%s}]}";
+    try {
+      String expectedAvsc = String.format(avscTemplate, avroType.toString().toLowerCase(Locale.ROOT), expectedDefaultValue);
+
+      String inputAvsc = String.format(avscTemplate, avroType.toString().toLowerCase(Locale.ROOT), defaultValue);
+      Schema parsed = AvroCompatibilityHelper.parse(inputAvsc, SchemaParseConfiguration.LOOSE, null).getMainSchema();
+      String processedAvsc = AvroCompatibilityHelper.toAvsc(parsed, AvscGenerationConfig.CORRECT_MITIGATED_PRETTY);
+
+      JSONAssert.assertEquals(expectedAvsc, processedAvsc, true);
+    } catch (AvroTypeException expected) {
+      if (allowFail && expected.getMessage().contains("Invalid default")) {
+        return;
+      }
+      throw expected;
+    }
+  }
+
+  public void runAvscWriterOnBadUnionWithNumericDefaultValues(Type avroType, String defaultValue, String expectedDefaultValue, boolean allowFail) throws Exception {
+    String avscTemplate = "{\"type\": \"record\", \"name\": \"HasBadDefaults\", \"fields\": "
+        + "[{\"name\": \"age\", \"type\": [\"%s\", \"null\"], \"default\":%s}]}";
+
+    try {
+      String expectedAvsc = String.format(avscTemplate, avroType.toString().toLowerCase(Locale.ROOT), expectedDefaultValue);
+
+      String inputAvsc = String.format(avscTemplate, avroType.toString().toLowerCase(Locale.ROOT), defaultValue);
+      Schema parsed = AvroCompatibilityHelper.parse(inputAvsc, SchemaParseConfiguration.LOOSE, null).getMainSchema();
+      String processedAvsc = AvroCompatibilityHelper.toAvsc(parsed, AvscGenerationConfig.CORRECT_MITIGATED_PRETTY);
+      JSONAssert.assertEquals(expectedAvsc, processedAvsc, true);
+    } catch (AvroTypeException expected) {
+      if (allowFail && expected.getMessage().contains("Invalid default")) {
+        return;
+      }
+      throw expected;
+    }
+  }
+
+}

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvscWriterDefaultNumericsTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvscWriterDefaultNumericsTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2020 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
 package com.linkedin.avroutil1.compatibility;
 
 import java.util.Locale;

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ rootProject.name = 'avro-util'
 include 'test-common'
 include 'parser'
 include 'avro-codegen'
-//include 'avro-fastserde'
+include 'avro-fastserde'
 
 include 'helper:helper-common'
 include 'helper:impls:helper-impl-14'

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,7 @@ rootProject.name = 'avro-util'
 include 'test-common'
 include 'parser'
 include 'avro-codegen'
-include 'avro-fastserde'
+//include 'avro-fastserde'
 
 include 'helper:helper-common'
 include 'helper:impls:helper-impl-14'


### PR DESCRIPTION
fixes #289

### Expected functionality for default values:
For `int`s and `long`s, integer values that are represented as `float`s/`double`s (i.e. `-1.0`, `0.0`) will be converted to an `int`/`long` (i.e. `-1`, `0`). If the number is a true double (i.e. `3.14159`) we will warn and passthrough.

For `float`s and `double`s, integer values (i.e. `-1`, `0`) are represented with a decimal point and a trailing 0 (i.e. `-1.0`, `0.0`).