### PR TITLE
An option to stop deserializing record when all read fields are done

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8448286306974311127_4248237275125625650(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684.java
@@ -1,0 +1,62 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly_GenericDeserializer_8273243328577643558_404527301978058684(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = ((IndexedRecord)(reuse));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(0, (decoder.readInt()));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0((FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly), (decoder));
+        return FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly;
+    }
+
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex0 == 1) {
+                decoder.readInt();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'testIntUnion': "+ unionIndex0));
+            }
+        }
+        Object oldString0 = FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.get(1);
+        if (oldString0 instanceof Utf8) {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(((Utf8) oldString0)));
+        } else {
+            FastGenericDeserializerGeneratorTest_shouldBeAbleToBreakEarly.put(1, (decoder).readString(null));
+        }
+    }
+
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -295,6 +295,9 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
     }
 
     int fieldCount = 0;
+
+    Set<String> readNames = recordReaderSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toSet());
+    long expectedFieldsToWrite = recordWriterSchema.getFields().stream().filter(f -> readNames.contains(f.name())).count();
     int fieldsWrittenToTarget = 0;
     JBlock popMethodBody = methodBody;
     JMethod popMethod = null;
@@ -353,7 +356,7 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
         }
       }
 
-      if (breakEarly && isTopLevel && (fieldsWrittenToTarget == recordReaderSchema.getFields().size())) {
+      if (breakEarly && isTopLevel && (fieldsWrittenToTarget == expectedFieldsToWrite)) {
         break;
       }
     }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -296,8 +296,11 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
 
     int fieldCount = 0;
 
-    Set<String> readNames = recordReaderSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toSet());
-    long expectedFieldsToWrite = recordWriterSchema.getFields().stream().filter(f -> readNames.contains(f.name())).count();
+    long expectedFieldsToWrite = 0;
+    if (recordReaderSchema != null) {
+      Set<String> readNames = recordReaderSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toSet());
+      expectedFieldsToWrite = recordWriterSchema.getFields().stream().filter(f -> readNames.contains(f.name())).count();
+    }
     int fieldsWrittenToTarget = 0;
     JBlock popMethodBody = methodBody;
     JMethod popMethod = null;

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -186,10 +186,11 @@ public class FastGenericDeserializerGeneratorTest {
             createField("testLong", Schema.create(Schema.Type.LONG)),
             createPrimitiveUnionFieldSchema("testLongUnion", Schema.Type.LONG));
 
-    // Create a read schema with only part of the fields
+    // Create a read schema with only part of the fields (but also extra fields that should be ignored)
     Schema readSchema = createRecord(
             createField("testInt", Schema.create(Schema.Type.INT)),
-            createField("testString", Schema.create(Schema.Type.STRING)));
+            createField("testString", Schema.create(Schema.Type.STRING)),
+            createPrimitiveUnionFieldSchema("somethingMissing", Schema.Type.LONG));
 
     // To test the decoder isn't reading the last fields will create a schema with mistakes in it as  writter schema
     Schema wrongSchema = createRecord(
@@ -216,6 +217,7 @@ public class FastGenericDeserializerGeneratorTest {
       // then
       Assert.assertEquals(1, decodedRecord.get("testInt"));
       Assert.assertEquals(new Utf8("aaa"), decodedRecord.get("testString"));
+      Assert.assertEquals(null, decodedRecord.get("somethingMissing"));
     } finally {
       if (def != null) {
         System.setProperty("AVRO_FAST_DESERIALIZER_BREAK_EARLY", def);


### PR DESCRIPTION
In cases where the read schema is much smaller than the write schema, it could have huge performance benefits to just processing the record when the deserializer already got all the fields required by the read schema.
this option is false by default and needs to be turned on via a system property AVRO_FAST_DESERIALIZER_BREAK_EARLY