### PR TITLE
introduce SchemaParseConfiguration.LOOSE_NUMERICS and allow control over validation of numeric default value types

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson1Utils.java
@@ -142,10 +142,21 @@ public class Jackson1Utils {
     }
   }
 
+  public static boolean isRoundNumber(JsonNode node) {
+    if (node == null || !node.isNumber()) {
+      return false;
+    }
+    if (node.isIntegralNumber()) {
+      return true;
+    }
+    double actual = node.getDoubleValue();
+    return Double.compare(Math.floor(actual), Math.ceil(actual)) == 0;
+  }
+
   /**
    *  Enforces uniform numeric default values across Avro versions
    */
-  static public JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
+  public static JsonNode enforceUniformNumericDefaultValues(Schema.Field field) {
     JsonNode defaultValue = field.defaultValue();
     BigDecimal numericValue = defaultValue.getDecimalValue();
     Schema schema = field.schema();
@@ -174,7 +185,7 @@ public class Jackson1Utils {
     }
   }
 
-  static private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+  private static boolean isAMathematicalInteger(BigDecimal bigDecimal) {
     return bigDecimal.stripTrailingZeros().scale() <= 0;
   }
 }

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
@@ -75,10 +75,21 @@ public class Jackson2Utils {
     }
   }
 
+  public static boolean isRoundNumber(JsonNode node) {
+    if (node == null || !node.isNumber()) {
+      return false;
+    }
+    if (node.isIntegralNumber()) {
+      return true;
+    }
+    double actual = node.asDouble();
+    return Double.compare(Math.floor(actual), Math.ceil(actual)) == 0;
+  }
+
   /**
    *  Enforces uniform numeric default values across Avro versions
    */
-  static public JsonNode enforceUniformNumericDefaultValues(Schema.Field field, JsonNode genericDefaultValue) {
+  public static JsonNode enforceUniformNumericDefaultValues(Schema.Field field, JsonNode genericDefaultValue) {
     BigDecimal numericDefaultValue = genericDefaultValue.decimalValue();
     Schema schema = field.schema();
     // a default value for a union, must match the first element of the union
@@ -106,7 +117,7 @@ public class Jackson2Utils {
     }
   }
 
-  static private boolean isAMathematicalInteger(BigDecimal bigDecimal) {
+  private static boolean isAMathematicalInteger(BigDecimal bigDecimal) {
     return bigDecimal.stripTrailingZeros().scale() <= 0;
   }
 }

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaParseConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaParseConfiguration.java
@@ -13,22 +13,53 @@ import java.util.Objects;
  * various configuration parameters used by various avro versions when parsing schemas
  */
 public class SchemaParseConfiguration {
-  public final static SchemaParseConfiguration STRICT = new SchemaParseConfiguration(true, true);
-  public final static SchemaParseConfiguration LOOSE = new SchemaParseConfiguration(false, false);
+  public final static SchemaParseConfiguration STRICT = new SchemaParseConfiguration(
+      true, true, true
+  );
+  public final static SchemaParseConfiguration LOOSE_NUMERICS = new SchemaParseConfiguration(
+      true, true, false
+  );
+  public final static SchemaParseConfiguration LOOSE = new SchemaParseConfiguration(
+      false, false, false
+  );
 
   /**
-   * validate that names for named types (records, enums, fixed types, fields) are
-   * valid identifiers according to the avro specification. natively supported under avro 1.5+
+   * validate that names for named types (records, enums, fixed types) and fields are
+   * valid identifiers according to the avro specification (same rules as java identifiers).
+   * natively supported under avro 1.5+
    */
   private final boolean validateNames;
   /**
-   * validate that default values for fields are correct. natively supported under avro 1.7+
+   * validate that default values for fields match the declared field type, and that defaults
+   * for union fields match the 1st branch in the union. tolerates ints as default values for
+   * floating point types and vice versa.
+   * natively supported under avro 1.7+
    */
   private final boolean validateDefaultValues;
+  /**
+   * for default numeric values (ints, floats, etc) checks that the default value type STRICTLY
+   * matches the field type - so 0.0 is not a valid default for ints and 0 not valid for floats.
+   * requires that validateDefaultValues above be enabled.
+   * no version of avro currently natively supports this validation.
+   */
+  private final boolean validateNumericDefaultValueTypes;
 
-  public SchemaParseConfiguration(boolean validateNames, boolean validateDefaultValues) {
+  public SchemaParseConfiguration(
+      boolean validateNames,
+      boolean validateDefaultValues,
+      boolean validateNumericDefaultValueTypes
+  ) {
+    if (validateNumericDefaultValueTypes && !validateDefaultValues) {
+      throw new IllegalArgumentException("validateNumericDefaultValueTypes requires validateDefaultValues");
+    }
     this.validateNames = validateNames;
     this.validateDefaultValues = validateDefaultValues;
+    this.validateNumericDefaultValueTypes = validateNumericDefaultValueTypes;
+  }
+
+  @Deprecated
+  public SchemaParseConfiguration(boolean validateNames, boolean validateDefaultValues) {
+    this(validateNames, validateDefaultValues, validateDefaultValues);
   }
 
   public boolean validateNames() {
@@ -37,6 +68,10 @@ public class SchemaParseConfiguration {
 
   public boolean validateDefaultValues() {
     return validateDefaultValues;
+  }
+
+  public boolean validateNumericDefaultValueTypes() {
+    return validateNumericDefaultValueTypes;
   }
 
   @Override
@@ -48,11 +83,12 @@ public class SchemaParseConfiguration {
       return false;
     }
     SchemaParseConfiguration that = (SchemaParseConfiguration) o;
-    return validateNames == that.validateNames && validateDefaultValues == that.validateDefaultValues;
+    return validateNames == that.validateNames && validateDefaultValues == that.validateDefaultValues
+        && validateNumericDefaultValueTypes == that.validateNumericDefaultValueTypes;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(validateNames, validateDefaultValues);
+    return Objects.hash(validateNames, validateDefaultValues, validateNumericDefaultValueTypes);
   }
 }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110SchemaValidator.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110SchemaValidator.java
@@ -9,6 +9,7 @@ package com.linkedin.avroutil1.compatibility.avro110;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -25,18 +26,33 @@ import org.apache.avro.util.internal.Accessor;
 
 
 public class Avro110SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -91,7 +107,7 @@ public class Avro110SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = Accessor.defaultValue(field);
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -127,10 +143,12 @@ public class Avro110SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
+      //means no default value
       return false;
     }
     Schema.Type avroType = schema.getType();
@@ -144,8 +162,21 @@ public class Avro110SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.numberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        //noinspection RedundantIfStatement
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.numberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson2Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -154,18 +185,18 @@ public class Avro110SchemaValidator implements SchemaVisitor {
         if (!defaultValue.isArray())
           return false;
         for (JsonNode element : defaultValue)
-          if (!isValidDefault(schema.getElementType(), element))
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes))
             return false;
         return true;
       case MAP:
         if (!defaultValue.isObject())
           return false;
         for (JsonNode value : defaultValue)
-          if (!isValidDefault(schema.getValueType(), value))
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes))
             return false;
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject())
           return false;
@@ -173,7 +204,8 @@ public class Avro110SchemaValidator implements SchemaVisitor {
           JsonNode fieldDefaultNode = Accessor.defaultValue(field);
           if (!isValidDefault(
               field.schema(),
-              defaultValue.has(field.name()) ? defaultValue.get(field.name()) : fieldDefaultNode
+              defaultValue.has(field.name()) ? defaultValue.get(field.name()) : fieldDefaultNode,
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/backports/Avro110DefaultValuesCache.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/backports/Avro110DefaultValuesCache.java
@@ -71,7 +71,7 @@ public class Avro110DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro110SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro110SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -216,12 +216,20 @@ public class Avro111Adapter implements AvroAdapter {
         Schema.Parser parser = new Schema.Parser();
         boolean validateNames = true;
         boolean validateDefaults = true;
+        boolean validateNumericDefaultValueTypes = false;
         if (desiredConf != null) {
             validateNames = desiredConf.validateNames();
             validateDefaults = desiredConf.validateDefaultValues();
+            validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
         }
         parser.setValidate(validateNames);
-        parser.setValidateDefaults(validateDefaults);
+        //avro 1.11 default validation also validates numeric types, so if we want to be
+        //more nuanced we cant use avro's default value validation
+        if (validateDefaults && validateNumericDefaultValueTypes) {
+            parser.setValidateDefaults(true);
+        } else {
+            parser.setValidateDefaults(false);
+        }
         if (known != null && !known.isEmpty()) {
             Map<String, Schema> knownByFullName = new HashMap<>(known.size());
             for (Schema s : known) {
@@ -231,9 +239,9 @@ public class Avro111Adapter implements AvroAdapter {
         }
         Schema mainSchema = parser.parse(schemaJson);
         Map<String, Schema> knownByFullName = parser.getTypes();
-        SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+        SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
         if (configUsed.validateDefaultValues()) {
-            //dont trust avro, also run our own
+            //dont trust avro, also run our own. also we might have told avro not to validate over numerics
             Avro111SchemaValidator validator = new Avro111SchemaValidator(configUsed, known);
             AvroSchemaUtil.traverseSchema(mainSchema, validator);
         }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111SchemaValidator.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111SchemaValidator.java
@@ -9,6 +9,7 @@ package com.linkedin.avroutil1.compatibility.avro111;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -25,18 +26,33 @@ import org.apache.avro.util.internal.Accessor;
 
 
 public class Avro111SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -91,7 +107,7 @@ public class Avro111SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = Accessor.defaultValue(field);
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -127,10 +143,12 @@ public class Avro111SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
+      //means no default value
       return false;
     }
     Schema.Type avroType = schema.getType();
@@ -144,8 +162,21 @@ public class Avro111SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.numberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        //noinspection RedundantIfStatement
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.numberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson2Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -154,18 +185,18 @@ public class Avro111SchemaValidator implements SchemaVisitor {
         if (!defaultValue.isArray())
           return false;
         for (JsonNode element : defaultValue)
-          if (!isValidDefault(schema.getElementType(), element))
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes))
             return false;
         return true;
       case MAP:
         if (!defaultValue.isObject())
           return false;
         for (JsonNode value : defaultValue)
-          if (!isValidDefault(schema.getValueType(), value))
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes))
             return false;
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject())
           return false;
@@ -173,7 +204,8 @@ public class Avro111SchemaValidator implements SchemaVisitor {
           JsonNode fieldDefaultNode = Accessor.defaultValue(field);
           if (!isValidDefault(
               field.schema(),
-              defaultValue.has(field.name()) ? defaultValue.get(field.name()) : fieldDefaultNode
+              defaultValue.has(field.name()) ? defaultValue.get(field.name()) : fieldDefaultNode,
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/backports/Avro111DefaultValuesCache.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/backports/Avro111DefaultValuesCache.java
@@ -71,7 +71,7 @@ public class Avro111DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro111SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro111SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14SchemaValidator.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14SchemaValidator.java
@@ -7,6 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro14;
 
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -24,18 +25,33 @@ import org.codehaus.jackson.JsonParser;
 
 
 public class Avro14SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -90,7 +106,7 @@ public class Avro14SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = field.defaultValue();
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -126,9 +142,10 @@ public class Avro14SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
       //means no default value
       return false;
@@ -144,8 +161,20 @@ public class Avro14SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.getNumberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.getNumberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson1Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -155,7 +184,7 @@ public class Avro14SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode element : defaultValue) {
-          if (!isValidDefault(schema.getElementType(), element)) {
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes)) {
             return false;
           }
         }
@@ -165,13 +194,13 @@ public class Avro14SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode value : defaultValue) {
-          if (!isValidDefault(schema.getValueType(), value)) {
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes)) {
             return false;
           }
         }
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject()) {
           return false;
@@ -179,7 +208,8 @@ public class Avro14SchemaValidator implements SchemaVisitor {
         for (Schema.Field field : schema.getFields()) {
           if (!isValidDefault(
               field.schema(),
-              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue()
+              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue(),
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/backports/Avro14DefaultValuesCache.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/backports/Avro14DefaultValuesCache.java
@@ -69,7 +69,7 @@ public class Avro14DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro14SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro14SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -215,11 +215,13 @@ public class Avro15Adapter implements AvroAdapter {
     Schema.Parser parser = new Schema.Parser();
     boolean validateNames = true;
     boolean validateDefaults = false;
+    boolean validateNumericDefaultValueTypes = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
 
     parser.setValidate(validateNames);
     if (known != null && !known.isEmpty()) {

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15SchemaValidator.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15SchemaValidator.java
@@ -7,6 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro15;
 
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -24,18 +25,33 @@ import org.codehaus.jackson.JsonParser;
 
 
 public class Avro15SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -90,7 +106,7 @@ public class Avro15SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = field.defaultValue();
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -126,9 +142,10 @@ public class Avro15SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
       //means no default value
       return false;
@@ -144,8 +161,20 @@ public class Avro15SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.getNumberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.getNumberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson1Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -155,7 +184,7 @@ public class Avro15SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode element : defaultValue) {
-          if (!isValidDefault(schema.getElementType(), element)) {
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes)) {
             return false;
           }
         }
@@ -165,13 +194,13 @@ public class Avro15SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode value : defaultValue) {
-          if (!isValidDefault(schema.getValueType(), value)) {
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes)) {
             return false;
           }
         }
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject()) {
           return false;
@@ -179,7 +208,8 @@ public class Avro15SchemaValidator implements SchemaVisitor {
         for (Schema.Field field : schema.getFields()) {
           if (!isValidDefault(
               field.schema(),
-              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue()
+              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue(),
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/backports/Avro15DefaultValuesCache.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/backports/Avro15DefaultValuesCache.java
@@ -69,7 +69,7 @@ public class Avro15DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro15SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro15SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -220,11 +220,13 @@ public class Avro16Adapter implements AvroAdapter {
     Schema.Parser parser = new Schema.Parser();
     boolean validateNames = true;
     boolean validateDefaults = false;
+    boolean validateNumericDefaultValueTypes = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
 
     parser.setValidate(validateNames);
     if (known != null && !known.isEmpty()) {

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16SchemaValidator.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16SchemaValidator.java
@@ -7,6 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro16;
 
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -24,18 +25,33 @@ import org.codehaus.jackson.JsonParser;
 
 
 public class Avro16SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -90,7 +106,7 @@ public class Avro16SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = field.defaultValue();
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -126,9 +142,10 @@ public class Avro16SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
       //means no default value
       return false;
@@ -144,8 +161,20 @@ public class Avro16SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.getNumberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.getNumberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson1Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -155,7 +184,7 @@ public class Avro16SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode element : defaultValue) {
-          if (!isValidDefault(schema.getElementType(), element)) {
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes)) {
             return false;
           }
         }
@@ -165,13 +194,13 @@ public class Avro16SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode value : defaultValue) {
-          if (!isValidDefault(schema.getValueType(), value)) {
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes)) {
             return false;
           }
         }
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject()) {
           return false;
@@ -179,7 +208,8 @@ public class Avro16SchemaValidator implements SchemaVisitor {
         for (Schema.Field field : schema.getFields()) {
           if (!isValidDefault(
               field.schema(),
-              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue()
+              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue(),
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/backports/Avro16DefaultValuesCache.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/backports/Avro16DefaultValuesCache.java
@@ -69,7 +69,7 @@ public class Avro16DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro16SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro16SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -255,11 +255,13 @@ public class Avro17Adapter implements AvroAdapter {
     Schema.Parser parser = new Schema.Parser();
     boolean validateNames = true;
     boolean validateDefaults = true;
+    boolean validateNumericDefaultValueTypes = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
 
     parser.setValidate(validateNames);
 
@@ -278,6 +280,7 @@ public class Avro17Adapter implements AvroAdapter {
     Schema mainSchema = parser.parse(schemaJson);
     Map<String, Schema> knownByFullName = parser.getTypes();
     if (configUsed.validateDefaultValues()) {
+      //dont trust avro, also run our own
       Avro17SchemaValidator validator = new Avro17SchemaValidator(configUsed, known);
       AvroSchemaUtil.traverseSchema(mainSchema, validator);
     }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17SchemaValidator.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17SchemaValidator.java
@@ -7,6 +7,7 @@
 package com.linkedin.avroutil1.compatibility.avro17;
 
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -24,18 +25,33 @@ import org.codehaus.jackson.JsonParser;
 
 
 public class Avro17SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -90,7 +106,7 @@ public class Avro17SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = field.defaultValue();
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -126,9 +142,10 @@ public class Avro17SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
       //means no default value
       return false;
@@ -144,8 +161,20 @@ public class Avro17SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.getNumberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.getNumberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson1Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -155,7 +184,7 @@ public class Avro17SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode element : defaultValue) {
-          if (!isValidDefault(schema.getElementType(), element)) {
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes)) {
             return false;
           }
         }
@@ -165,13 +194,13 @@ public class Avro17SchemaValidator implements SchemaVisitor {
           return false;
         }
         for (JsonNode value : defaultValue) {
-          if (!isValidDefault(schema.getValueType(), value)) {
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes)) {
             return false;
           }
         }
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject()) {
           return false;
@@ -179,7 +208,8 @@ public class Avro17SchemaValidator implements SchemaVisitor {
         for (Schema.Field field : schema.getFields()) {
           if (!isValidDefault(
               field.schema(),
-              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue()
+              defaultValue.get(field.name()) != null ? defaultValue.get(field.name()) : field.defaultValue(),
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/backports/Avro17DefaultValuesCache.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/backports/Avro17DefaultValuesCache.java
@@ -71,7 +71,7 @@ public class Avro17DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro17SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro17SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -218,9 +218,11 @@ public class Avro18Adapter implements AvroAdapter {
     Schema.Parser parser = new Schema.Parser();
     boolean validateNames = true;
     boolean validateDefaults = true;
+    boolean validateNumericDefaultValueTypes = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
     }
     parser.setValidate(validateNames);
     parser.setValidateDefaults(validateDefaults);
@@ -233,13 +235,13 @@ public class Avro18Adapter implements AvroAdapter {
     }
     Schema mainSchema = parser.parse(schemaJson);
     Map<String, Schema> knownByFullName = parser.getTypes();
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
     if (configUsed.validateDefaultValues()) {
       //dont trust avro, also run our own
       Avro18SchemaValidator validator = new Avro18SchemaValidator(configUsed, known);
       AvroSchemaUtil.traverseSchema(mainSchema, validator);
     }
-    return new SchemaParseResult(mainSchema, knownByFullName, new SchemaParseConfiguration(validateNames, validateDefaults));
+    return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
   }
 
   @Override

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/backports/Avro18DefaultValuesCache.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/backports/Avro18DefaultValuesCache.java
@@ -70,7 +70,7 @@ public class Avro18DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro18SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro18SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -220,9 +220,11 @@ public class Avro19Adapter implements AvroAdapter {
     Schema.Parser parser = new Schema.Parser();
     boolean validateNames = true;
     boolean validateDefaults = true;
+    boolean validateNumericDefaultValueTypes = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
     }
     parser.setValidate(validateNames);
     parser.setValidateDefaults(validateDefaults);
@@ -235,7 +237,7 @@ public class Avro19Adapter implements AvroAdapter {
     }
     Schema mainSchema = parser.parse(schemaJson);
     Map<String, Schema> knownByFullName = parser.getTypes();
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
     if (configUsed.validateDefaultValues()) {
       //dont trust avro, also run our own
       Avro19SchemaValidator validator = new Avro19SchemaValidator(configUsed, known);

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19SchemaValidator.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19SchemaValidator.java
@@ -9,6 +9,7 @@ package com.linkedin.avroutil1.compatibility.avro19;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.avroutil1.compatibility.HelperConsts;
+import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaVisitor;
 import java.util.Arrays;
@@ -25,18 +26,33 @@ import org.apache.avro.util.internal.Accessor;
 
 
 public class Avro19SchemaValidator implements SchemaVisitor {
-  private final static Map<Schema.Type, List<JsonParser.NumberType>> JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+  private final static Map<Schema.Type, List<JsonParser.NumberType>> LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
 
   static {
-    Map<Schema.Type, List<JsonParser.NumberType>> temp = new HashMap<>();
-    //noinspection ArraysAsListWithZeroOrOneArgument
-    temp.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT)));
-    temp.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
-    //jackson (used by avro) seems to like parsing everything as DoubleNode
-    temp.put(Schema.Type.FLOAT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
-    temp.put(Schema.Type.DOUBLE, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    Map<Schema.Type, List<JsonParser.NumberType>> strict = new HashMap<>(4);
+    Map<Schema.Type, List<JsonParser.NumberType>> loose = new HashMap<>(4);
 
-    JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(temp);
+    List<JsonParser.NumberType> allFloats = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+    List<JsonParser.NumberType> allNumerics = Collections.unmodifiableList(Arrays.asList(
+        JsonParser.NumberType.INT, JsonParser.NumberType.LONG, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE
+    ));
+
+    strict.put(Schema.Type.INT, Collections.singletonList(JsonParser.NumberType.INT));
+    strict.put(Schema.Type.LONG, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.LONG)));
+    //jackson (used by avro) seems to like parsing everything as DoubleNode
+    strict.put(Schema.Type.FLOAT, allFloats);
+    strict.put(Schema.Type.DOUBLE, allFloats);
+
+    loose.put(Schema.Type.INT, Collections.unmodifiableList(Arrays.asList(JsonParser.NumberType.INT, JsonParser.NumberType.FLOAT, JsonParser.NumberType.DOUBLE)));
+    loose.put(Schema.Type.LONG, allNumerics);
+    loose.put(Schema.Type.FLOAT, allNumerics);
+    loose.put(Schema.Type.DOUBLE, allNumerics);
+
+    STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(strict);
+    LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE = Collections.unmodifiableMap(loose);
   }
 
   private final SchemaParseConfiguration validationSpec;
@@ -91,7 +107,7 @@ public class Avro19SchemaValidator implements SchemaVisitor {
     JsonNode defaultValue = Accessor.defaultValue(field);
     if (validationSpec.validateDefaultValues() && defaultValue != null) {
       Schema fieldSchema = field.schema();
-      boolean validDefault = isValidDefault(fieldSchema, defaultValue);
+      boolean validDefault = isValidDefault(fieldSchema, defaultValue, validationSpec.validateNumericDefaultValueTypes());
       if (!validDefault) {
         //throw ~the same exception avro would
         String message = "Invalid default for field " + parent.getFullName() + "." + field.name() + ": "
@@ -127,10 +143,12 @@ public class Avro19SchemaValidator implements SchemaVisitor {
    * validation logic taken out of class {@link Schema} with adaptations
    * @param schema schema (type) of a field
    * @param defaultValue default value provided for said field in the parent schema
+   * @param validateNumericTypes true to use strict numeric type matching between value and schema
    * @throws SchemaParseException is name is invalid
    */
-  public static boolean isValidDefault(Schema schema, JsonNode defaultValue) {
+  public static boolean isValidDefault(Schema schema, JsonNode defaultValue, boolean validateNumericTypes) {
     if (defaultValue == null) {
+      //means no default value
       return false;
     }
     Schema.Type avroType = schema.getType();
@@ -144,8 +162,20 @@ public class Avro19SchemaValidator implements SchemaVisitor {
       case LONG:
       case FLOAT:
       case DOUBLE:
-        List<JsonParser.NumberType> jsonTypes = JSON_NUMERIC_TYPES_PER_AVRO_TYPE.get(avroType);
-        return jsonTypes != null && jsonTypes.contains(defaultValue.numberType());
+        Map<Schema.Type, List<JsonParser.NumberType>> lookupTable = validateNumericTypes ?
+            STRICT_JSON_NUMERIC_TYPES_PER_AVRO_TYPE : LOOSE_JSON_NUMERIC_TYPES_PER_AVRO_TYPE;
+        List<JsonParser.NumberType> allowedTypes = lookupTable.get(avroType);
+        if (allowedTypes == null || !allowedTypes.contains(defaultValue.numberType())) {
+          return false;
+        }
+        if (avroType == Schema.Type.INT || avroType == Schema.Type.LONG) {
+          //dont allow true non-round numbers for ints
+          if (!Jackson2Utils.isRoundNumber(defaultValue)) {
+            return false;
+          }
+        }
+        //TODO - check values out of range (like 5*MAX_INT for int field)
+        return true;
       case BOOLEAN:
         return defaultValue.isBoolean();
       case NULL:
@@ -154,18 +184,18 @@ public class Avro19SchemaValidator implements SchemaVisitor {
         if (!defaultValue.isArray())
           return false;
         for (JsonNode element : defaultValue)
-          if (!isValidDefault(schema.getElementType(), element))
+          if (!isValidDefault(schema.getElementType(), element, validateNumericTypes))
             return false;
         return true;
       case MAP:
         if (!defaultValue.isObject())
           return false;
         for (JsonNode value : defaultValue)
-          if (!isValidDefault(schema.getValueType(), value))
+          if (!isValidDefault(schema.getValueType(), value, validateNumericTypes))
             return false;
         return true;
       case UNION: // union default: first branch
-        return isValidDefault(schema.getTypes().get(0), defaultValue);
+        return isValidDefault(schema.getTypes().get(0), defaultValue, validateNumericTypes);
       case RECORD:
         if (!defaultValue.isObject())
           return false;
@@ -173,7 +203,8 @@ public class Avro19SchemaValidator implements SchemaVisitor {
           JsonNode fieldDefaultNode = Accessor.defaultValue(field);
           if (!isValidDefault(
               field.schema(),
-              defaultValue.has(field.name()) ? defaultValue.get(field.name()) : fieldDefaultNode
+              defaultValue.has(field.name()) ? defaultValue.get(field.name()) : fieldDefaultNode,
+              validateNumericTypes
           )) {
             return false;
           }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/backports/Avro19DefaultValuesCache.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/backports/Avro19DefaultValuesCache.java
@@ -71,7 +71,7 @@ public class Avro19DefaultValuesCache {
 
     //validate the default JsonNode vs the fieldSchema, because old avro doesnt validate
     //and applying the logic below to decode will return very weird results
-    if (!Avro19SchemaValidator.isValidDefault(schema, json)) {
+    if (!Avro19SchemaValidator.isValidDefault(schema, json, true)) {
       //throw ~the same exception modern avro would
       String message = "Invalid default for field " + field.name() + ": "
           + json + " (a " + json.getClass().getSimpleName() + ") is not a " + schema;


### PR DESCRIPTION
this allows configuring validation of numeric default value types separately from the more "coarse" validation of default values.

this allows accepting 0.0 for integers and 0 for floating points.

note that modern avro (>= 1.10) performs this validation as part of default value validation (if enabled)