### PR TITLE
add ConfigurableSchemaComparator class to allow for nuance when testing for schema equality

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -103,7 +103,7 @@ public interface AvroAdapter {
 
   boolean fieldHasDefault(Schema.Field field);
 
-  boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics);
+  boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics);
 
   Set<String> getFieldAliases(Schema.Field field);
 
@@ -136,12 +136,30 @@ public interface AvroAdapter {
 
   void setFieldPropFromJsonString(Schema.Field field, String propName, String valueAsJsonLiteral, boolean strict);
 
+  /**
+   * compare json properties on 2 schema fields for equality.
+   * @param a a field
+   * @param b another field
+   * @param compareStringProps true to compare string properties (otherwise ignored)
+   * @param compareNonStringProps true to compare all other properties (otherwise ignored). this exists because avro 1.4
+   *                              doesnt handle non-string props at all and we want to be able to match that behaviour under any avro
+   * @return if field properties are equal, under the configuration parameters above
+   */
   boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps);
 
   String getSchemaPropAsJsonString(Schema schema, String propName);
 
   void setSchemaPropFromJsonString(Schema field, String propName, String valueAsJsonLiteral, boolean strict);
 
+  /**
+   * compare json properties on 2 schemas for equality.
+   * @param a a schema
+   * @param b another schema
+   * @param compareStringProps true to compare string properties (otherwise ignored)
+   * @param compareNonStringProps true to compare all other properties (otherwise ignored). this exists because avro 1.4
+   *                              doesnt handle non-string props at all and we want to be able to match that behaviour under any avro
+   * @return if schema properties are equal, under the configuration parameters above
+   */
   boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps);
 
   String getEnumDefault(Schema s);

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -103,6 +103,8 @@ public interface AvroAdapter {
 
   boolean fieldHasDefault(Schema.Field field);
 
+  boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics);
+
   Set<String> getFieldAliases(Schema.Field field);
 
   @Deprecated
@@ -134,9 +136,13 @@ public interface AvroAdapter {
 
   void setFieldPropFromJsonString(Schema.Field field, String propName, String valueAsJsonLiteral, boolean strict);
 
+  boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps);
+
   String getSchemaPropAsJsonString(Schema schema, String propName);
 
   void setSchemaPropFromJsonString(Schema field, String propName, String valueAsJsonLiteral, boolean strict);
+
+  boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps);
 
   String getEnumDefault(Schema s);
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/Jackson2Utils.java
@@ -17,6 +17,8 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.avro.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +77,42 @@ public class Jackson2Utils {
     }
   }
 
+  /**
+   * compares 2 JsonNodes for equality, potentially allowing comparison of round floating point numbers and integers
+   * of different types.
+   * this implementation treats null as equals to null.
+   * @param aVal a {@link JsonNode}, or null
+   * @param bVal a {@link JsonNode}, or null
+   * @param looseNumerics allow "loose" numeric comparisons (int node to long node, int nodes to round floating points etc)
+   * @return true if both nodes are null or otherwise equal
+   */
+  public static boolean JsonNodesEqual(JsonNode aVal, JsonNode bVal, boolean looseNumerics) {
+    if (aVal == null || bVal == null) {
+      return aVal == null && bVal == null;
+    }
+    boolean numerics = aVal.isNumber() && bVal.isNumber(); //any cross-type comparison is going to be false anyway
+    if (!numerics || !looseNumerics) {
+      return Objects.equals(aVal, bVal);
+    }
+    //loose numerics
+    if (aVal.isIntegralNumber()) {
+      if (bVal.isIntegralNumber() || Jackson2Utils.isRoundNumber(bVal)) {
+        //we dont care about numbers larger than 64 bit
+        return aVal.longValue() == bVal.longValue();
+      }
+      return false; //b isnt round
+    } else {
+      //a is float
+      if (!bVal.isIntegralNumber()) {
+        //a and b are floats
+        //this has issues with rounding and precision, but i'd rather stick to this until someone complains
+        return aVal.doubleValue() == bVal.doubleValue();
+      }
+      //b is integral
+      return Jackson2Utils.isRoundNumber(aVal) && (aVal.longValue() == bVal.longValue());
+    }
+  }
+
   public static boolean isRoundNumber(JsonNode node) {
     if (node == null || !node.isNumber()) {
       return false;
@@ -115,6 +153,48 @@ public class Jackson2Utils {
       default:
         return genericDefaultValue;
     }
+  }
+
+  public static boolean compareJsonProperties(
+      Map<String, JsonNode> jsonPropsA,
+      Map<String, JsonNode> jsonPropsB,
+      boolean compareStringProps,
+      boolean compareNonStringProps
+  ) {
+    if (compareStringProps && compareNonStringProps) {
+      return Objects.equals(jsonPropsA, jsonPropsB);
+    }
+    //compare all entries in A to B
+    for (Map.Entry<String, JsonNode> aEnt : jsonPropsA.entrySet()) {
+      String key = aEnt.getKey();
+      JsonNode valueA = aEnt.getValue(); // != null
+      JsonNode valueB = jsonPropsB.get(key); // might be null
+      if (valueA.isTextual()) {
+        if (compareStringProps && ! valueA.equals(valueB)) {
+          return false;
+        }
+      } else {
+        if (compareNonStringProps && !valueA.equals(valueB)) {
+          return false;
+        }
+      }
+    }
+    //go over B looking for keys not in A, fail if any found.
+    for (Map.Entry<String, JsonNode> bEnt : jsonPropsB.entrySet()) {
+      String key = bEnt.getKey();
+      JsonNode valueA = jsonPropsA.get(key); // null if no such key in A
+      JsonNode valueB = bEnt.getValue(); // != null
+      if (valueB.isTextual()) {
+        if (compareStringProps && valueA == null) {
+          return false;
+        }
+      } else {
+        if (compareNonStringProps && valueA == null) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   private static boolean isAMathematicalInteger(BigDecimal bigDecimal) {

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -609,6 +609,11 @@ public class AvroCompatibilityHelper {
     return ADAPTER.fieldHasDefault(field);
   }
 
+  public static boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    assertAvroAvailable();
+    return ADAPTER.defaultValuesEqual(a, b, looseNumerics);
+  }
+
   public static Set<String> getFieldAliases(Schema.Field field) {
     assertAvroAvailable();
     return ADAPTER.getFieldAliases(field);
@@ -1068,6 +1073,11 @@ public class AvroCompatibilityHelper {
     ADAPTER.setFieldPropFromJsonString(field, propName, valueAsJsonLiteral, strict);
   }
 
+  public static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    assertAvroAvailable();
+    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+  }
+
   /**
    * returns the value of the specified schema prop as a json literal.
    * returns null if the schema has no such property.
@@ -1123,6 +1133,11 @@ public class AvroCompatibilityHelper {
   public static void setSchemaPropFromJsonString(Schema schema, String propName, String valueAsJsonLiteral, boolean strict) {
     assertAvroAvailable();
     ADAPTER.setSchemaPropFromJsonString(schema, propName, valueAsJsonLiteral, strict);
+  }
+
+  public static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    assertAvroAvailable();
+    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
   }
 
   /**

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.avro.Schema;
+
+
+/**
+ * a more configurable alternative to {@link org.apache.avro.Schema#equals(Object)}
+ */
+public class ConfigurableSchemaComparator {
+
+  public static boolean equals(Schema a, Schema b, SchemaComparisonConfiguration config) {
+    validateConfig(config);
+    Set<SeenPair> seen = new HashSet<>(3);
+    return equals(a, b, config, seen);
+  }
+
+  private static void validateConfig(SchemaComparisonConfiguration config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config required");
+    }
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_7) && config.isCompareNonStringJsonProps()) {
+      //1.7 itself changes between < 1.7.3 and >= 1.7.3, so we leave that validation to later runtime :-(
+      throw new IllegalArgumentException("avro " + runtimeAvroVersion
+          + " does not preserve non-string props and so cannot compare them");
+    }
+  }
+
+  private static boolean equals(Schema a, Schema b,  SchemaComparisonConfiguration config, Set<SeenPair> seen) {
+    if (a == null && b == null) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    Schema.Type type = a.getType();
+    if (!Objects.equals(type, b.getType())) {
+      return false;
+    }
+
+    boolean considerJsonStringProps = config.isCompareStringJsonProps();
+    boolean considerJsonNonStringProps = config.isCompareNonStringJsonProps();
+    boolean considerAliases = config.isCompareAliases();
+
+    switch (type) {
+      //all of these have nothing more to compare by beyond their type (and we ignore props)
+      case NULL:
+        return true;
+      case BOOLEAN:
+        return true;
+      case INT:
+        return true;
+      case LONG:
+        return true;
+      case FLOAT:
+        return true;
+      case DOUBLE:
+        return true;
+      case STRING:
+        return true;
+      case BYTES:
+        return true;
+
+      //named types
+
+      case ENUM:
+        return a.getFullName().equals(b.getFullName())
+            && (!considerAliases || hasSameAliases(a, b))
+            && a.getEnumSymbols().equals(b.getEnumSymbols());
+      case FIXED:
+        return a.getFullName().equals(b.getFullName())
+            && (!considerAliases || hasSameAliases(a, b))
+            && a.getFixedSize() == b.getFixedSize();
+      case RECORD:
+        return recordSchemaEquals(a, b, config, seen);
+
+      //collections and union
+
+      case ARRAY:
+        return equals(a.getElementType(), b.getElementType(), config, seen);
+      case MAP:
+        return equals(a.getValueType(), b.getValueType(), config, seen);
+      case UNION:
+        List<Schema> aBranches = a.getTypes();
+        List<Schema> bBranches = b.getTypes();
+        if (aBranches.size() != bBranches.size()) {
+          return false;
+        }
+        for (int i = 0; i < aBranches.size(); i++) {
+          Schema aBranch = aBranches.get(i);
+          Schema bBranch = bBranches.get(i);
+          if (!equals(aBranch, bBranch, config, seen)) {
+            return false;
+          }
+        }
+        return true;
+      default:
+        throw new IllegalStateException("unhandled: " + type);
+    }
+  }
+
+  private static boolean recordSchemaEquals(Schema a, Schema b, SchemaComparisonConfiguration config, Set<SeenPair> seen) {
+    if (!a.getFullName().equals(b.getFullName())) {
+      return false;
+    }
+    //loop protection for self-referencing schemas
+    SeenPair pair = new SeenPair(a, b);
+    if (seen.contains(pair)) {
+      return true;
+    }
+    seen.add(pair);
+
+    boolean considerJsonStringProps = config.isCompareStringJsonProps();
+    boolean considerJsonNonStringProps = config.isCompareNonStringJsonProps();
+    boolean considerAliases = config.isCompareAliases();
+    boolean considerJsonProps = considerJsonStringProps || considerJsonNonStringProps;
+    boolean compareIntToFLoatDefaults = config.isCompareIntToFloatDefaults();
+
+    try {
+      if (considerAliases && !hasSameAliases(a, b)) {
+        return false;
+      }
+
+      if (considerJsonProps && !hasSameObjectProps(a, b, considerJsonStringProps, considerJsonNonStringProps)) {
+        return false;
+      }
+
+      List<Schema.Field> aFields = a.getFields();
+      List<Schema.Field> bFields = b.getFields();
+      if (aFields.size() != bFields.size()) {
+        return false;
+      }
+      for (int i = 0; i < aFields.size(); i++) {
+        Schema.Field aField = aFields.get(i);
+        Schema.Field bField = bFields.get(i);
+
+        if (!aField.name().equals(bField.name())) {
+          return false;
+        }
+        if (!equals(aField.schema(), bField.schema(), config, seen)) {
+          return false;
+        }
+        if (AvroCompatibilityHelper.fieldHasDefault(aField) && AvroCompatibilityHelper.fieldHasDefault(bField)) {
+          boolean defaultsEqual = AvroCompatibilityHelper.defaultValuesEqual(aField, bField, compareIntToFLoatDefaults);
+          if (!defaultsEqual) {
+            return false;
+          }
+        } else if (AvroCompatibilityHelper.fieldHasDefault(aField) || AvroCompatibilityHelper.fieldHasDefault(bField)) {
+          //means one field has a default value and the other does not
+          return false;
+        }
+
+        if (!Objects.equals(aField.order(), bField.order())) {
+          return false;
+        }
+
+        if (considerJsonProps && !hasSameObjectProps(aField, bField, considerJsonStringProps, considerJsonNonStringProps)) {
+          return false;
+        }
+      }
+      return true;
+    } finally {
+      seen.remove(pair);
+    }
+  }
+
+  private static boolean hasSameAliases(Schema a, Schema b) {
+    return a.getAliases().equals(b.getAliases());
+  }
+
+  private static boolean hasSameObjectProps(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    return AvroCompatibilityHelper.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+  }
+
+  private static boolean hasSameObjectProps(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    return AvroCompatibilityHelper.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+  }
+
+  private static class SeenPair {
+    private final Schema s1;
+    private final Schema s2;
+
+    public SeenPair(Schema s1, Schema s2) {
+      this.s1 = s1;
+      this.s2 = s2;
+    }
+
+    public boolean equals(Object o) {
+      if (!(o instanceof SeenPair)) {
+        return false;
+      }
+      return this.s1 == ((SeenPair) o).s1 && this.s2 == ((SeenPair) o).s2;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(s1) + System.identityHashCode(s2);
+    }
+  }
+}

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
@@ -76,6 +76,7 @@ public class ConfigurableSchemaComparator {
       case ENUM:
         return a.getFullName().equals(b.getFullName())
             && (!considerAliases || hasSameAliases(a, b))
+            //list comparison is sensitive to order
             && a.getEnumSymbols().equals(b.getEnumSymbols());
       case FIXED:
         return a.getFullName().equals(b.getFullName())
@@ -159,12 +160,13 @@ public class ConfigurableSchemaComparator {
           //means one field has a default value and the other does not
           return false;
         }
-
         if (!Objects.equals(aField.order(), bField.order())) {
           return false;
         }
-
         if (considerJsonProps && !hasSameObjectProps(aField, bField, considerJsonStringProps, considerJsonNonStringProps)) {
+          return false;
+        }
+        if (considerAliases && !hasSameAliases(aField, bField)) {
           return false;
         }
       }
@@ -175,7 +177,13 @@ public class ConfigurableSchemaComparator {
   }
 
   private static boolean hasSameAliases(Schema a, Schema b) {
-    return a.getAliases().equals(b.getAliases());
+    return Objects.equals(a.getAliases(), b.getAliases());
+  }
+
+  private static boolean hasSameAliases(Schema.Field a, Schema.Field b) {
+    Set<String> aAliases = AvroCompatibilityHelper.getFieldAliases(a);
+    Set<String> bAliases = AvroCompatibilityHelper.getFieldAliases(b);
+    return Objects.equals(aAliases, bAliases);
   }
 
   private static boolean hasSameObjectProps(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -70,6 +70,72 @@ public class SchemaComparisonConfiguration {
   public boolean isCompareFieldLogicalTypes() {
     return compareFieldLogicalTypes;
   }
+
+  public SchemaComparisonConfiguration compareStringJsonProps(boolean compare) {
+    return new SchemaComparisonConfiguration(
+        compare,
+        compareNonStringJsonProps,
+        compareAliases,
+        compareIntToFloatDefaults,
+        compareFieldOrder,
+        compareFieldLogicalTypes
+    );
+  }
+
+  public SchemaComparisonConfiguration compareNonStringJsonProps(boolean compare) {
+    return new SchemaComparisonConfiguration(
+        compareStringJsonProps,
+        compare,
+        compareAliases,
+        compareIntToFloatDefaults,
+        compareFieldOrder,
+        compareFieldLogicalTypes
+    );
+  }
+
+  public SchemaComparisonConfiguration compareAliases(boolean compare) {
+    return new SchemaComparisonConfiguration(
+        compareStringJsonProps,
+        compareNonStringJsonProps,
+        compare,
+        compareIntToFloatDefaults,
+        compareFieldOrder,
+        compareFieldLogicalTypes
+    );
+  }
+
+  public SchemaComparisonConfiguration compareIntToFloatDefaults(boolean compare) {
+    return new SchemaComparisonConfiguration(
+        compareStringJsonProps,
+        compareNonStringJsonProps,
+        compareAliases,
+        compare,
+        compareFieldOrder,
+        compareFieldLogicalTypes
+    );
+  }
+
+  public SchemaComparisonConfiguration compareFieldOrder(boolean compare) {
+    return new SchemaComparisonConfiguration(
+        compareStringJsonProps,
+        compareNonStringJsonProps,
+        compareAliases,
+        compareIntToFloatDefaults,
+        compare,
+        compareFieldLogicalTypes
+    );
+  }
+
+  public SchemaComparisonConfiguration compareFieldLogicalTypes(boolean compare) {
+    return new SchemaComparisonConfiguration(
+        compareStringJsonProps,
+        compareNonStringJsonProps,
+        compareAliases,
+        compareIntToFloatDefaults,
+        compareFieldOrder,
+        compare
+    );
+  }
 }
 
 

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+
+public class SchemaComparisonConfiguration {
+  /**
+   * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
+   */
+  public static final SchemaComparisonConfiguration PRE_1_7_3 = new SchemaComparisonConfiguration(
+      true, false, false, false, true, false
+  );
+  /**
+   * same as {@link #STRICT} but allows int default values to match (round) float default values
+   */
+  public static final SchemaComparisonConfiguration LOOSE_NUMERICS = new SchemaComparisonConfiguration(
+      true, true, true, true, true, true
+  );
+  public static final SchemaComparisonConfiguration STRICT = new SchemaComparisonConfiguration(
+      true, true, true, false, true, true
+  );
+
+  private final boolean compareStringJsonProps;
+  private final boolean compareNonStringJsonProps;
+  private final boolean compareAliases;
+  private final boolean compareIntToFloatDefaults;
+  private final boolean compareFieldOrder;
+  private final boolean compareFieldLogicalTypes;
+
+  public SchemaComparisonConfiguration(
+      boolean compareStringJsonProps,
+      boolean compareNonStringJsonProps,
+      boolean compareAliases,
+      boolean compareIntToFloatDefaults,
+      boolean compareFieldOrder,
+      boolean compareFieldLogicalTypes
+  ) {
+    this.compareStringJsonProps = compareStringJsonProps;
+    this.compareNonStringJsonProps = compareNonStringJsonProps;
+    this.compareAliases = compareAliases;
+    this.compareIntToFloatDefaults = compareIntToFloatDefaults;
+    this.compareFieldOrder = compareFieldOrder;
+    this.compareFieldLogicalTypes = compareFieldLogicalTypes;
+  }
+
+  public boolean isCompareStringJsonProps() {
+    return compareStringJsonProps;
+  }
+
+  public boolean isCompareNonStringJsonProps() {
+    return compareNonStringJsonProps;
+  }
+
+  public boolean isCompareAliases() {
+    return compareAliases;
+  }
+
+  public boolean isCompareIntToFloatDefaults() {
+    return compareIntToFloatDefaults;
+  }
+
+  public boolean isCompareFieldOrder() {
+    return compareFieldOrder;
+  }
+
+  public boolean isCompareFieldLogicalTypes() {
+    return compareFieldLogicalTypes;
+  }
+}
+
+

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -308,10 +308,10 @@ public class Avro110Adapter implements AvroAdapter {
     }
 
     @Override
-    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
         JsonNode aVal = Accessor.defaultValue(a);
         JsonNode bVal = Accessor.defaultValue(b);
-        return Jackson2Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+        return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
     }
 
     @Override

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -30,6 +30,7 @@ import com.linkedin.avroutil1.compatibility.avro110.codec.CompatibleJsonDecoder;
 import com.linkedin.avroutil1.compatibility.avro110.codec.CompatibleJsonEncoder;
 import com.linkedin.avroutil1.compatibility.backports.ObjectInputToInputStreamAdapter;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
@@ -67,6 +68,7 @@ import java.util.Set;
 
 public class Avro110Adapter implements AvroAdapter {
 
+    private final Field jsonPropertiesPropsField;
     private boolean compilerSupported;
     private Throwable compilerSupportIssue;
     private String compilerSupportMessage;
@@ -83,6 +85,12 @@ public class Avro110Adapter implements AvroAdapter {
     private Method setStringTypeMethod;
 
     public Avro110Adapter() {
+        try {
+            jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
+            jsonPropertiesPropsField.setAccessible(true);
+        } catch (Exception e) {
+            throw new IllegalStateException("error initializing adapter", e);
+        }
         tryInitializeCompilerFields();
     }
 
@@ -300,6 +308,13 @@ public class Avro110Adapter implements AvroAdapter {
     }
 
     @Override
+    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+        JsonNode aVal = Accessor.defaultValue(a);
+        JsonNode bVal = Accessor.defaultValue(b);
+        return Jackson2Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    }
+
+    @Override
     public Set<String> getFieldAliases(Schema.Field field) {
         return field.aliases();
     }
@@ -329,6 +344,24 @@ public class Avro110Adapter implements AvroAdapter {
     }
 
     @Override
+    public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+        if (a == null || b == null) {
+            return false;
+        }
+        Map<String, JsonNode> propsA;
+        Map<String, JsonNode> propsB;
+        try {
+            //noinspection unchecked
+            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+            //noinspection unchecked
+            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+        } catch (Exception e) {
+            throw new IllegalStateException("unable to access JsonProperties.props", e);
+        }
+        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+    }
+
+    @Override
     public String getSchemaPropAsJsonString(Schema schema, String name) {
         // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
         JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
@@ -340,6 +373,24 @@ public class Avro110Adapter implements AvroAdapter {
         // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
         JsonNode node = Jackson2Utils.toJsonNode(value, strict);
         schema.addProp(name, JacksonUtils.toObject(node));
+    }
+
+    @Override
+    public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+        if (a == null || b == null) {
+            return false;
+        }
+        Map<String, JsonNode> propsA;
+        Map<String, JsonNode> propsB;
+        try {
+            //noinspection unchecked
+            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+            //noinspection unchecked
+            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+        } catch (Exception e) {
+            throw new IllegalStateException("unable to access JsonProperties.props", e);
+        }
+        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
     }
 
     @Override

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -30,6 +30,7 @@ import com.linkedin.avroutil1.compatibility.avro111.codec.CompatibleJsonDecoder;
 import com.linkedin.avroutil1.compatibility.avro111.codec.CompatibleJsonEncoder;
 import com.linkedin.avroutil1.compatibility.backports.ObjectInputToInputStreamAdapter;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
@@ -67,6 +68,7 @@ import java.util.Set;
 
 public class Avro111Adapter implements AvroAdapter {
 
+    private final Field jsonPropertiesPropsField;
     private boolean compilerSupported;
     private Throwable compilerSupportIssue;
     private String compilerSupportMessage;
@@ -83,6 +85,12 @@ public class Avro111Adapter implements AvroAdapter {
     private Method setStringTypeMethod;
 
     public Avro111Adapter() {
+        try {
+            jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
+            jsonPropertiesPropsField.setAccessible(true);
+        } catch (Exception e) {
+            throw new IllegalStateException("error initializing adapter", e);
+        }
         tryInitializeCompilerFields();
     }
 
@@ -299,6 +307,13 @@ public class Avro111Adapter implements AvroAdapter {
     }
 
     @Override
+    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+        JsonNode aVal = Accessor.defaultValue(a);
+        JsonNode bVal = Accessor.defaultValue(b);
+        return Jackson2Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    }
+
+    @Override
     public Set<String> getFieldAliases(Schema.Field field) {
         return field.aliases();
     }
@@ -328,6 +343,24 @@ public class Avro111Adapter implements AvroAdapter {
     }
 
     @Override
+    public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+        if (a == null || b == null) {
+            return false;
+        }
+        Map<String, JsonNode> propsA;
+        Map<String, JsonNode> propsB;
+        try {
+            //noinspection unchecked
+            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+            //noinspection unchecked
+            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+        } catch (Exception e) {
+            throw new IllegalStateException("unable to access JsonProperties.props", e);
+        }
+        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+    }
+
+    @Override
     public String getSchemaPropAsJsonString(Schema schema, String name) {
         // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
         JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
@@ -339,6 +372,24 @@ public class Avro111Adapter implements AvroAdapter {
         // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
         JsonNode node = Jackson2Utils.toJsonNode(value, strict);
         schema.addProp(name, JacksonUtils.toObject(node));
+    }
+
+    @Override
+    public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+        if (a == null || b == null) {
+            return false;
+        }
+        Map<String, JsonNode> propsA;
+        Map<String, JsonNode> propsB;
+        try {
+            //noinspection unchecked
+            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+            //noinspection unchecked
+            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+        } catch (Exception e) {
+            throw new IllegalStateException("unable to access JsonProperties.props", e);
+        }
+        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
     }
 
     @Override

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -307,10 +307,10 @@ public class Avro111Adapter implements AvroAdapter {
     }
 
     @Override
-    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
         JsonNode aVal = Accessor.defaultValue(a);
         JsonNode bVal = Accessor.defaultValue(b);
-        return Jackson2Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+        return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
     }
 
     @Override

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -275,10 +275,10 @@ public class Avro14Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
     JsonNode aVal = a.defaultValue();
     JsonNode bVal = b.defaultValue();
-    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -299,10 +299,10 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
     JsonNode aVal = a.defaultValue();
     JsonNode bVal = b.defaultValue();
-    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -16,6 +16,7 @@ import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaBuilder;
 import com.linkedin.avroutil1.compatibility.SchemaNormalization;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
@@ -31,6 +32,7 @@ import com.linkedin.avroutil1.compatibility.avro15.codec.CompatibleJsonDecoder;
 import com.linkedin.avroutil1.compatibility.avro15.codec.CompatibleJsonEncoder;
 import com.linkedin.avroutil1.compatibility.backports.ObjectInputToInputStreamAdapter;
 import com.linkedin.avroutil1.compatibility.backports.ObjectOutputToOutputStreamAdapter;
+import java.util.Objects;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -74,6 +76,8 @@ public class Avro15Adapter implements AvroAdapter {
   private final static Logger LOG = LoggerFactory.getLogger(Avro15Adapter.class);
 
   private final Field fieldAliasesField;
+  private final Field fieldPropsField;
+  private final Field schemaPropsField;
   private boolean compilerSupported;
   private Throwable compilerSupportIssue;
   private String compilerSupportMessage;
@@ -87,6 +91,10 @@ public class Avro15Adapter implements AvroAdapter {
     try {
       fieldAliasesField = Schema.Field.class.getDeclaredField("aliases");
       fieldAliasesField.setAccessible(true);
+      fieldPropsField = Schema.Field.class.getDeclaredField("props");
+      fieldPropsField.setAccessible(true);
+      schemaPropsField = Schema.class.getDeclaredField("props");
+      schemaPropsField.setAccessible(true);
     } catch (Exception e) {
       throw new IllegalStateException("error initializing adapter", e);
     }
@@ -291,6 +299,13 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    JsonNode aVal = a.defaultValue();
+    JsonNode bVal = b.defaultValue();
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+  }
+
+  @Override
   public Set<String> getFieldAliases(Schema.Field field) {
     try {
       @SuppressWarnings("unchecked")
@@ -325,6 +340,31 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (compareNonStringProps) {
+      throw new IllegalArgumentException("avro " + supportedMajorVersion()
+          + " does not preserve non-string props and so cannot compare them");
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    if (!compareStringProps) {
+      return true;
+    }
+    Map<String, String> aProps;
+    Map<String, String> bProps;
+    try {
+      //noinspection unchecked
+      aProps = (Map<String, String>) fieldPropsField.get(a);
+      //noinspection unchecked
+      bProps = (Map<String, String>) fieldPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access Schema.Field.props", e);
+    }
+    return Objects.equals(aProps, bProps);
+  }
+
+  @Override
   public String getSchemaPropAsJsonString(Schema schema, String name) {
     return StringPropertyUtils.getSchemaPropAsJsonString(schema, name);
   }
@@ -332,6 +372,31 @@ public class Avro15Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (compareNonStringProps) {
+      throw new IllegalArgumentException("avro " + supportedMajorVersion()
+          + " does not preserve non-string props and so cannot compare them");
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    if (!compareStringProps) {
+      return true;
+    }
+    Map<String, String> aProps;
+    Map<String, String> bProps;
+    try {
+      //noinspection unchecked
+      aProps = (Map<String, String>) schemaPropsField.get(a);
+      //noinspection unchecked
+      bProps = (Map<String, String>) schemaPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access Schema.props", e);
+    }
+    return Objects.equals(aProps, bProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -298,10 +298,10 @@ public class Avro16Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
     JsonNode aVal = a.defaultValue();
     JsonNode bVal = b.defaultValue();
-    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
   }
 
   @Override

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -15,6 +15,7 @@ import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaBuilder;
 import com.linkedin.avroutil1.compatibility.SchemaNormalization;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
@@ -30,6 +31,7 @@ import com.linkedin.avroutil1.compatibility.avro16.codec.CompatibleJsonDecoder;
 import com.linkedin.avroutil1.compatibility.avro16.codec.CompatibleJsonEncoder;
 import com.linkedin.avroutil1.compatibility.backports.ObjectInputToInputStreamAdapter;
 import com.linkedin.avroutil1.compatibility.backports.ObjectOutputToOutputStreamAdapter;
+import java.util.Objects;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -296,6 +298,13 @@ public class Avro16Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    JsonNode aVal = a.defaultValue();
+    JsonNode bVal = b.defaultValue();
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+  }
+
+  @Override
   public Set<String> getFieldAliases(Schema.Field field) {
     return field.aliases();
   }
@@ -321,6 +330,23 @@ public class Avro16Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (compareNonStringProps) {
+      throw new IllegalArgumentException("avro " + supportedMajorVersion()
+          + " does not preserve non-string props and so cannot compare them");
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    if (!compareStringProps) {
+      return true;
+    }
+    Map<String, String> aProps = a.props();
+    Map<String, String> bProps = b.props();
+    return Objects.equals(aProps, bProps);
+  }
+
+  @Override
   public String getSchemaPropAsJsonString(Schema schema, String name) {
     return StringPropertyUtils.getSchemaPropAsJsonString(schema, name);
   }
@@ -328,6 +354,23 @@ public class Avro16Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (compareNonStringProps) {
+      throw new IllegalArgumentException("avro " + supportedMajorVersion()
+          + " does not preserve non-string props and so cannot compare them");
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    if (!compareStringProps) {
+      return true;
+    }
+    Map<String, String> aProps = a.getProps();
+    Map<String, String> bProps = b.getProps();
+    return Objects.equals(aProps, bProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -15,6 +15,7 @@ import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeTransformations;
 import com.linkedin.avroutil1.compatibility.ExceptionUtils;
 import com.linkedin.avroutil1.compatibility.FieldBuilder;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.SchemaBuilder;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import com.linkedin.avroutil1.compatibility.SchemaParseResult;
@@ -343,6 +344,13 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    JsonNode aVal = a.defaultValue();
+    JsonNode bVal = b.defaultValue();
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+  }
+
+  @Override
   public Set<String> getFieldAliases(Schema.Field field) {
     return field.aliases();
   }
@@ -368,6 +376,11 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
   public String getSchemaPropAsJsonString(Schema schema, String name) {
     return Avro17Utils.getJsonProp(schema, name);
   }
@@ -375,6 +388,11 @@ public class Avro17Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     Avro17Utils.setJsonProp(schema, name, value, strict);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -344,10 +344,10 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
     JsonNode aVal = a.defaultValue();
     JsonNode bVal = b.defaultValue();
-    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
   }
 
   @Override

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -295,10 +295,10 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
     JsonNode aVal = a.defaultValue();
     JsonNode bVal = b.defaultValue();
-    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
   }
 
   @Override

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -295,6 +295,13 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    JsonNode aVal = a.defaultValue();
+    JsonNode bVal = b.defaultValue();
+    return Jackson1Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+  }
+
+  @Override
   public Set<String> getFieldAliases(Schema.Field field) {
     return field.aliases();
   }
@@ -324,6 +331,16 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA = a.getJsonProps();
+    Map<String, JsonNode> propsB = b.getJsonProps();
+    return Jackson1Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
   public String getSchemaPropAsJsonString(Schema schema, String name) {
     @SuppressWarnings("deprecation") //this is faster
     JsonNode node = schema.getJsonProp(name);
@@ -335,6 +352,16 @@ public class Avro18Adapter implements AvroAdapter {
     JsonNode node = Jackson1Utils.toJsonNode(value, strict);
     //noinspection deprecation this is faster
     schema.addProp(name, node);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA = a.getJsonProps();
+    Map<String, JsonNode> propsB = b.getJsonProps();
+    return Jackson1Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -30,6 +30,7 @@ import com.linkedin.avroutil1.compatibility.avro19.codec.CompatibleJsonDecoder;
 import com.linkedin.avroutil1.compatibility.avro19.codec.CompatibleJsonEncoder;
 import com.linkedin.avroutil1.compatibility.backports.ObjectInputToInputStreamAdapter;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaNormalization;
 import org.apache.avro.generic.GenericData;
@@ -71,6 +72,7 @@ import java.util.Set;
 public class Avro19Adapter implements AvroAdapter {
   private final static Logger LOG = LoggerFactory.getLogger(Avro19Adapter.class);
 
+  private final Field jsonPropertiesPropsField;
   private boolean compilerSupported;
   private Throwable compilerSupportIssue;
   private String compilerSupportMessage;
@@ -87,6 +89,12 @@ public class Avro19Adapter implements AvroAdapter {
   private Method setStringTypeMethod;
 
   public Avro19Adapter() {
+    try {
+      jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
+      jsonPropertiesPropsField.setAccessible(true);
+    } catch (Exception e) {
+      throw new IllegalStateException("error initializing adapter", e);
+    }
     tryInitializeCompilerFields();
   }
 
@@ -297,6 +305,13 @@ public class Avro19Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+    JsonNode aVal = Accessor.defaultValue(a);
+    JsonNode bVal = Accessor.defaultValue(b);
+    return Jackson2Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+  }
+
+  @Override
   public Set<String> getFieldAliases(Schema.Field field) {
     return field.aliases();
   }
@@ -326,6 +341,24 @@ public class Avro19Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA;
+    Map<String, JsonNode> propsB;
+    try {
+      //noinspection unchecked
+      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
   public String getSchemaPropAsJsonString(Schema schema, String name) {
     // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
     JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
@@ -337,6 +370,24 @@ public class Avro19Adapter implements AvroAdapter {
     // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
     JsonNode node = Jackson2Utils.toJsonNode(value, strict);
     schema.addProp(name, JacksonUtils.toObject(node));
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA;
+    Map<String, JsonNode> propsB;
+    try {
+      //noinspection unchecked
+      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -305,10 +305,10 @@ public class Avro19Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean looseNumerics) {
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
     JsonNode aVal = Accessor.defaultValue(a);
     JsonNode bVal = Accessor.defaultValue(b);
-    return Jackson2Utils.JsonNodesEqual(aVal, bVal, looseNumerics);
+    return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
   }
 
   @Override

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import org.apache.avro.Schema;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+
+public class ConfigurableSchemaComparatorTest {
+
+  @Test
+  public void showOldAvroCantCompareNonStrings() throws Exception {
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    String avscA = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaIntProp\": 1,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"fieldIntProp\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    String avscB = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaIntProp\": 3,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"fieldIntProp\": 4\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    Schema a = Schema.parse(avscA);
+    Schema b = Schema.parse(avscB);
+    switch (runtimeAvroVersion) {
+      case AVRO_1_4:
+      case AVRO_1_5:
+      case AVRO_1_6:
+        Assert.assertEquals(a, b);
+        break;
+      case AVRO_1_7: //capability is added in 1.7.3, so in the "middle" of 1.7
+        break;
+      default:
+        Assert.assertNotEquals(a, b); //int props kick in
+    }
+  }
+
+  @Test
+  public void testExceptionOnTryingToCompareNonStringsUnderOldAvro() throws Exception {
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    String avscA = "\"string\"";
+    String avscB = "\"int\"";
+    Schema a = Schema.parse(avscA);
+    Schema b = Schema.parse(avscB);
+    SchemaComparisonConfiguration config = new SchemaComparisonConfiguration(
+        false,
+        true, //boom
+        false,
+        true,
+        true,
+        true
+    );
+    switch (runtimeAvroVersion) {
+      case AVRO_1_4:
+      case AVRO_1_5:
+      case AVRO_1_6:
+        try {
+          ConfigurableSchemaComparator.equals(a, b, config);
+          Assert.fail("expected to throw for " + runtimeAvroVersion);
+        } catch (IllegalArgumentException expected) {
+          //expected
+        }
+        break;
+      case AVRO_1_7: //capability is added in 1.7.3, so in the "middle" of 1.7
+        break;
+      default:
+        Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, config));
+    }
+  }
+
+  @Test
+  public void testCompareOnlyStringProps() throws Exception {
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    String avscA = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaStrProp\": \"val1\",\n"
+        + "  \"schemaIntProp\": 1,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"fieldStrProp\": \"val2\",\n"
+        + "      \"fieldIntProp\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    String avscB = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaStrProp\": \"val1\",\n"
+        + "  \"schemaIntProp\": 3,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"fieldStrProp\": \"val2\",\n"
+        + "      \"fieldIntProp\": 4\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    Schema a = Schema.parse(avscA);
+    Schema b = Schema.parse(avscB);
+    Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.PRE_1_7_3));
+    if (runtimeAvroVersion.laterThan(AvroVersion.AVRO_1_7)) {
+      //complex props are only supported by avro >= 1.7.3
+      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT));
+    }
+  }
+
+  @Test
+  public void testLooseNumericDefaults() throws Exception {
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8)) {
+      throw new SkipException("strict parsing doesnt work under " + runtimeAvroVersion);
+    }
+    String avscA = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f1\",\n"
+        + "      \"type\": \"int\",\n"
+        + "      \"default\": 1.0\n"
+        + "    },\n"
+        + "    {\n"
+        + "      \"name\": \"f2\",\n"
+        + "      \"type\": \"double\",\n"
+        + "      \"default\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    String avscB = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f1\",\n"
+        + "      \"type\": \"int\",\n"
+        + "      \"default\": 1\n"
+        + "    },\n"
+        + "    {\n"
+        + "      \"name\": \"f2\",\n"
+        + "      \"type\": \"double\",\n"
+        + "      \"default\": 2.0\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    Schema a = AvroCompatibilityHelper.parse(avscA, SchemaParseConfiguration.LOOSE_NUMERICS, null).getMainSchema();
+    Schema b = AvroCompatibilityHelper.parse(avscB, SchemaParseConfiguration.LOOSE_NUMERICS, null).getMainSchema();
+    Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.LOOSE_NUMERICS));
+    Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT));
+  }
+}


### PR DESCRIPTION
its generally impossible to write "portable" (across avro versions) code that relies on the behavior of Schema.equals(), for the following reasons:

1. avro 1.4 discards non-string properties on types and fields, yet props are part of equals(). this means that schemas that are equals() under 1.4 are not so under more modern avro
2. modern versions of avro do not allow floating point default values for integer fields and vice versa. older avro did not complain about those and it is sometimes required to support "loose" comparison of those for legacy reasons
3. avro Schema.equals() does not take aliases into account yet there are situations where differences in aliases are important
4. similarly to above, we want to be able to compare logical types and java string types

class ConfigurableSchemaComparator is meant to allow solving all these issues and providing a consistent equals() implementation across all supported avro versions