### PR TITLE
Proper handling of asymmetric union reads

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionArrayElemSchema0;
+
+    public Array_of_record_GenericDeserializer_8211777093653381542_4260305944593863397(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                List<IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                if ((reuse) instanceof List) {
+                    unionOption0 = ((List)(reuse));
+                    unionOption0 .clear();
+                } else {
+                    unionOption0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), readerSchema);
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object unionOptionArrayElementReuseVar0 = null;
+                        if ((reuse) instanceof GenericArray) {
+                            unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                        }
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701.java
@@ -1,0 +1,77 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema unionOptionMapValueSchema0;
+
+    public Map_of_record_GenericDeserializer_4807922374121811220_3052180383482420701(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.unionOptionMapValueSchema0 = readerSchema.getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":{\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, IndexedRecord> unionOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
+                    if ((reuse) instanceof Map) {
+                        unionOptionReuse0 = ((Map)(reuse));
+                    }
+                    if (unionOptionReuse0 != (null)) {
+                        unionOptionReuse0 .clear();
+                        unionOption0 = unionOptionReuse0;
+                    } else {
+                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                }
+                return unionOption0;
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == unionOptionMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(unionOptionMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UNION_GenericDeserializer_3052180383482420701_4807922374121811220.java
@@ -1,0 +1,69 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class UNION_GenericDeserializer_3052180383482420701_4807922374121811220
+    implements FastDeserializer<Map<Utf8, IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema mapMapSchema0;
+    private final Schema mapMapValueSchema0;
+
+    public UNION_GenericDeserializer_3052180383482420701_4807922374121811220(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.mapMapSchema0 = readerSchema.getTypes().get(1);
+        this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
+    }
+
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        Map<Utf8, IndexedRecord> map0 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, IndexedRecord> mapReuse0 = null;
+            if ((reuse) instanceof Map) {
+                mapReuse0 = ((Map)(reuse));
+            }
+            if (mapReuse0 != (null)) {
+                mapReuse0 .clear();
+                map0 = mapReuse0;
+            } else {
+                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            map0 = new HashMap<Utf8, IndexedRecord>(0);
+        }
+        return map0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == mapMapValueSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(mapMapValueSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UNION_GenericDeserializer_4260305944593863397_8211777093653381542.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_4260305944593863397_8211777093653381542
+    implements FastDeserializer<List<IndexedRecord>>
+{
+
+    private final Schema readerSchema;
+    private final Schema arrayArraySchema0;
+    private final Schema arrayArrayElemSchema0;
+
+    public UNION_GenericDeserializer_4260305944593863397_8211777093653381542(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.arrayArraySchema0 = readerSchema.getTypes().get(1);
+        this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
+    }
+
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+        throws IOException
+    {
+        List<IndexedRecord> array0 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        if ((reuse) instanceof List) {
+            array0 = ((List)(reuse));
+            array0 .clear();
+        } else {
+            array0 = new org.apache.avro.generic.GenericData.Array<IndexedRecord>(((int) chunkLen0), arrayArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                Object arrayArrayElementReuseVar0 = null;
+                if ((reuse) instanceof GenericArray) {
+                    arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
+                }
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        return array0;
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == arrayArrayElemSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(arrayArrayElemSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UNION_GenericDeserializer_5876384051379941598_7537588945112528029.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class UNION_GenericDeserializer_5876384051379941598_7537588945112528029
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema recordRecordSchema0;
+
+    public UNION_GenericDeserializer_5876384051379941598_7537588945112528029(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.recordRecordSchema0 = readerSchema.getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == recordRecordSchema0)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(recordRecordSchema0);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_189121143970461908_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_189121143970461908_6318304989806183720.java
@@ -1,0 +1,68 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_189121143970461908_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_189121143970461908_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        someIntsOption0 .addPrimitive((decoder.readInt()));
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_3011431218838630619_7563779026522497792.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3011431218838630619_7563779026522497792
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3011431218838630619_7563779026522497792(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            if (unionIndex0 == 1) {
+                throw new AvroTypeException("Found \"string\", expecting \"int\"");
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someField': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_3503986355731546549_5876384051379941598.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3503986355731546549_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_3503986355731546549_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            record.put(0, (decoder.readInt()));
+        } else {
+            throw new RuntimeException(("Illegal union index for 'someInt': "+ unionIndex0));
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_3607335147694341100_6604037637742608849.java
@@ -1,0 +1,71 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_3607335147694341100_6604037637742608849
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+
+    public record_GenericDeserializer_3607335147694341100_6604037637742608849(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecord0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_4891996123930737799_6318304989806183720.java
@@ -1,0 +1,82 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_4891996123930737799_6318304989806183720
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_4891996123930737799_6318304989806183720(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"array\",\"items\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                PrimitiveIntList someIntsOption0 = null;
+                long chunkLen0 = (decoder.readArrayStart());
+                Object oldArray0 = record.get(0);
+                if (oldArray0 instanceof PrimitiveIntList) {
+                    someIntsOption0 = ((PrimitiveIntList) oldArray0);
+                    someIntsOption0 .clear();
+                } else {
+                    someIntsOption0 = new PrimitiveIntArrayList(((int) chunkLen0));
+                }
+                while (chunkLen0 > 0) {
+                    for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                        Object someIntsOptionArrayElementReuseVar0 = null;
+                        if (oldArray0 instanceof GenericArray) {
+                            someIntsOptionArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
+                        }
+                        int unionIndex1 = (decoder.readIndex());
+                        if (unionIndex1 == 0) {
+                            someIntsOption0 .addPrimitive((decoder.readInt()));
+                        } else {
+                            if (unionIndex1 == 1) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                throw new RuntimeException(("Illegal union index for 'someIntsOptionElem': "+ unionIndex1));
+                            }
+                        }
+                    }
+                    chunkLen0 = (decoder.arrayNext());
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_5876384051379941598_3503986355731546549.java
@@ -1,0 +1,41 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_5876384051379941598_3503986355731546549
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInt0;
+
+    public record_GenericDeserializer_5876384051379941598_3503986355731546549(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInt0 = readerSchema.getField("someInt").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_5919039771168630173_6705804244729881900.java
@@ -1,0 +1,72 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_6705804244729881900
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+    private final Schema someIntsMapValueSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_6705804244729881900(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+        this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_5919039771168630173_7006761166437777067.java
@@ -1,0 +1,70 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_5919039771168630173_7006761166437777067
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsMapSchema0;
+
+    public record_GenericDeserializer_5919039771168630173_7006761166437777067(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        Map<Utf8, Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readMapStart());
+        if (chunkLen0 > 0) {
+            Map<Utf8, Integer> someIntsReuse0 = null;
+            Object oldMap0 = record.get(0);
+            if (oldMap0 instanceof Map) {
+                someIntsReuse0 = ((Map) oldMap0);
+            }
+            if (someIntsReuse0 != (null)) {
+                someIntsReuse0 .clear();
+                someInts1 = someIntsReuse0;
+            } else {
+                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+            }
+            do {
+                for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                    Utf8 key0 = (decoder.readString(null));
+                    someInts1 .put(key0, (decoder.readInt()));
+                }
+                chunkLen0 = (decoder.mapNext());
+            } while (chunkLen0 > 0);
+        } else {
+            someInts1 = new HashMap<Utf8, Integer>(0);
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6318304989806183720_189121143970461908.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6318304989806183720_189121143970461908.java
@@ -1,0 +1,60 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.api.PrimitiveIntList;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_189121143970461908
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+
+    public record_GenericDeserializer_6318304989806183720_189121143970461908(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        PrimitiveIntList someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof PrimitiveIntList) {
+            someInts1 = ((PrimitiveIntList) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new PrimitiveIntArrayList(((int) chunkLen0));
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .addPrimitive((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6318304989806183720_4891996123930737799.java
@@ -1,0 +1,61 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6318304989806183720_4891996123930737799
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+    private final Schema someIntsArraySchema0;
+    private final Schema someIntsArrayElemSchema0;
+
+    public record_GenericDeserializer_6318304989806183720_4891996123930737799(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+        this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
+        this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        List<Integer> someInts1 = null;
+        long chunkLen0 = (decoder.readArrayStart());
+        Object oldArray0 = record.get(0);
+        if (oldArray0 instanceof List) {
+            someInts1 = ((List) oldArray0);
+            someInts1 .clear();
+        } else {
+            someInts1 = new org.apache.avro.generic.GenericData.Array<Integer>(((int) chunkLen0), someIntsArraySchema0);
+        }
+        while (chunkLen0 > 0) {
+            for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                someInts1 .add((decoder.readInt()));
+            }
+            chunkLen0 = (decoder.arrayNext());
+        }
+        record.put(0, someInts1);
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6604037637742608849_3607335147694341100.java
@@ -1,0 +1,63 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_6604037637742608849_3607335147694341100
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema subRecord0;
+    private final Schema subRecordRecordSchema0;
+
+    public record_GenericDeserializer_6604037637742608849_3607335147694341100(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.subRecord0 = readerSchema.getField("subRecord").schema();
+        this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        return record;
+    }
+
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord subRecord;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == subRecordRecordSchema0)) {
+            subRecord = ((IndexedRecord)(reuse));
+        } else {
+            subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
+        }
+        subRecord.put(0, (decoder.readInt()));
+        populate_subRecord0((subRecord), (decoder));
+        return subRecord;
+    }
+
+    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+        throws IOException
+    {
+        subRecord.put(1, (decoder.readInt()));
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_6705804244729881900_5919039771168630173.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_6705804244729881900_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_6705804244729881900_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            int unionIndex1 = (decoder.readIndex());
+                            if (unionIndex1 == 0) {
+                                throw new AvroTypeException("Found \"null\", expecting \"int\"");
+                            } else {
+                                if (unionIndex1 == 1) {
+                                    someIntsOption0 .put(key0, (decoder.readInt()));
+                                } else {
+                                    throw new RuntimeException(("Illegal union index for 'someIntsOptionValue': "+ unionIndex1));
+                                }
+                            }
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_7006761166437777067_5919039771168630173.java
@@ -1,0 +1,78 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class record_GenericDeserializer_7006761166437777067_5919039771168630173
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema someInts0;
+
+    public record_GenericDeserializer_7006761166437777067_5919039771168630173(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.someInts0 = readerSchema.getField("someInts").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializerecord0((reuse), (decoder));
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"map\",\"values\":\"int\"}");
+        } else {
+            if (unionIndex0 == 1) {
+                Map<Utf8, Integer> someIntsOption0 = null;
+                long chunkLen0 = (decoder.readMapStart());
+                if (chunkLen0 > 0) {
+                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
+                    Object oldMap0 = record.get(0);
+                    if (oldMap0 instanceof Map) {
+                        someIntsOptionReuse0 = ((Map) oldMap0);
+                    }
+                    if (someIntsOptionReuse0 != (null)) {
+                        someIntsOptionReuse0 .clear();
+                        someIntsOption0 = someIntsOptionReuse0;
+                    } else {
+                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
+                    }
+                    do {
+                        for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
+                            Utf8 key0 = (decoder.readString(null));
+                            someIntsOption0 .put(key0, (decoder.readInt()));
+                        }
+                        chunkLen0 = (decoder.mapNext());
+                    } while (chunkLen0 > 0);
+                } else {
+                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                }
+                record.put(0, someIntsOption0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'someInts': "+ unionIndex0));
+            }
+        }
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/record_GenericDeserializer_7537588945112528029_5876384051379941598.java
@@ -1,0 +1,49 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import org.apache.avro.AvroTypeException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+
+public class record_GenericDeserializer_7537588945112528029_5876384051379941598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+
+    public record_GenericDeserializer_7537588945112528029_5876384051379941598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.adpilot.utils.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
+        } else {
+            if (unionIndex0 == 1) {
+                return deserializerecord0((reuse), (decoder));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
+            }
+        }
+    }
+
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        IndexedRecord record;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            record = ((IndexedRecord)(reuse));
+        } else {
+            record = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        record.put(0, (decoder.readInt()));
+        return record;
+    }
+
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -482,4 +482,22 @@ public class SchemaAssistant {
       return JExpr._new(defaultStringType()).arg(stringExpr);
     }
   }
+
+  // TODO: this code should support primitive type promotions
+  public int compatibleUnionSchemaIndex(Schema schema, Schema unionSchema) {
+    for (int i = 0; i < unionSchema.getTypes().size(); i++) {
+      Schema potentialCompatibleSchema = unionSchema.getTypes().get(i);
+      if (potentialCompatibleSchema.getType().equals(schema.getType()) &&
+              (!isNamedType(potentialCompatibleSchema) ||
+                      AvroCompatibilityHelper.getSchemaFullName(potentialCompatibleSchema).equals(AvroCompatibilityHelper.getSchemaFullName(schema)) ||
+                      potentialCompatibleSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(schema)))) {
+        return i;
+      }
+    }
+    throw new SchemaAssistantException("No compatible schema found");
+  }
+
+  public Schema compatibleUnionSchema(Schema schema, Schema unionSchema) {
+    return unionSchema.getTypes().get(compatibleUnionSchemaIndex(schema, unionSchema));
+  }
 }


### PR DESCRIPTION
Hi

Asymmetric union read operations are not working properly in current avro-fastserde implementation. Such operations are rarely used, but they are clearly defined within Avro [documentation](https://avro.apache.org/docs/current/spec.html#Schema+Resolution) :

**If reader's is a union, but writer's is not**

- The first schema in the reader's union that matches the writer's schema is recursively resolved against it. If none match, an error is signalled.


**if writer's is a union, but reader's is not**

- If the reader's schema matches the selected writer's schema, it is recursively resolved against it. If they do not match, an error is signalled.

The current implementation fails with `FastDeserializerGeneratorException` thrown during deserializer generation every time it encounters asymmetric union reads.  This PR contains fixes to align the behaviour with the one specified in documentation.

Apart from that, the current implementation also can't handle the union as a top level type. This PR also fixes that.

The first commit 33b1b2ee158ddfb275badb143f1fd5f385b5b622 is a bunch of test cases where the current implementation fails.
The second commit 8a9dbd2f4314330e51217cdea1e458e8b57f04cf contains the actual fix.
The third commit 19e0cf2e933c80a3bfb7a18945b891f0a4ae3291 contains the codegen for the fixed test cases.