### PR TITLE
add validation to Helper.parse() for contents after the end of an avsc (see AVRO-3560)

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaParseConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaParseConfiguration.java
@@ -14,13 +14,13 @@ import java.util.Objects;
  */
 public class SchemaParseConfiguration {
   public final static SchemaParseConfiguration STRICT = new SchemaParseConfiguration(
-      true, true, true
+      true, true, true, true
   );
   public final static SchemaParseConfiguration LOOSE_NUMERICS = new SchemaParseConfiguration(
-      true, true, false
+      true, true, false, true
   );
   public final static SchemaParseConfiguration LOOSE = new SchemaParseConfiguration(
-      false, false, false
+      false, false, false, false
   );
 
   /**
@@ -43,11 +43,17 @@ public class SchemaParseConfiguration {
    * no version of avro currently natively supports this validation.
    */
   private final boolean validateNumericDefaultValueTypes;
+  /**
+   * validates no dangling contents in the avsc string past the end of the schema.
+   * see https://issues.apache.org/jira/browse/AVRO-3560
+   */
+  private final boolean validateNoDanglingContent;
 
   public SchemaParseConfiguration(
       boolean validateNames,
       boolean validateDefaultValues,
-      boolean validateNumericDefaultValueTypes
+      boolean validateNumericDefaultValueTypes,
+      boolean validateNoDanglingContent
   ) {
     if (validateNumericDefaultValueTypes && !validateDefaultValues) {
       throw new IllegalArgumentException("validateNumericDefaultValueTypes requires validateDefaultValues");
@@ -55,6 +61,15 @@ public class SchemaParseConfiguration {
     this.validateNames = validateNames;
     this.validateDefaultValues = validateDefaultValues;
     this.validateNumericDefaultValueTypes = validateNumericDefaultValueTypes;
+    this.validateNoDanglingContent = validateNoDanglingContent;
+  }
+
+  @Deprecated
+  public SchemaParseConfiguration(
+      boolean validateNames,
+      boolean validateDefaultValues,
+      boolean validateNumericDefaultValueTypes) {
+    this(validateNames, validateDefaultValues, validateNumericDefaultValueTypes, true);
   }
 
   @Deprecated
@@ -74,6 +89,10 @@ public class SchemaParseConfiguration {
     return validateNumericDefaultValueTypes;
   }
 
+  public boolean validateNoDanglingContent() {
+    return validateNoDanglingContent;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -84,11 +103,12 @@ public class SchemaParseConfiguration {
     }
     SchemaParseConfiguration that = (SchemaParseConfiguration) o;
     return validateNames == that.validateNames && validateDefaultValues == that.validateDefaultValues
-        && validateNumericDefaultValueTypes == that.validateNumericDefaultValueTypes;
+        && validateNumericDefaultValueTypes == that.validateNumericDefaultValueTypes
+        && validateNoDanglingContent == that.validateNoDanglingContent;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(validateNames, validateDefaultValues, validateNumericDefaultValueTypes);
+    return Objects.hash(validateNames, validateDefaultValues, validateNumericDefaultValueTypes, validateNoDanglingContent);
   }
 }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -225,11 +225,19 @@ public class Avro111Adapter implements AvroAdapter {
         boolean validateNames = true;
         boolean validateDefaults = true;
         boolean validateNumericDefaultValueTypes = false;
+        boolean validateNoDanglingContent = false;
         if (desiredConf != null) {
             validateNames = desiredConf.validateNames();
             validateDefaults = desiredConf.validateDefaultValues();
             validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
+            validateNoDanglingContent = desiredConf.validateNoDanglingContent();
         }
+        SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
+            validateNames,
+            validateDefaults,
+            validateNumericDefaultValueTypes,
+            validateNoDanglingContent
+        );
         parser.setValidate(validateNames);
         //avro 1.11 default validation also validates numeric types, so if we want to be
         //more nuanced we cant use avro's default value validation
@@ -247,11 +255,13 @@ public class Avro111Adapter implements AvroAdapter {
         }
         Schema mainSchema = parser.parse(schemaJson);
         Map<String, Schema> knownByFullName = parser.getTypes();
-        SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
         if (configUsed.validateDefaultValues()) {
             //dont trust avro, also run our own. also we might have told avro not to validate over numerics
             Avro111SchemaValidator validator = new Avro111SchemaValidator(configUsed, known);
             AvroSchemaUtil.traverseSchema(mainSchema, validator);
+        }
+        if (configUsed.validateNoDanglingContent()) {
+            Jackson2Utils.assertNoTrailingContent(schemaJson);
         }
         return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
     }

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -216,6 +216,9 @@ public class Avro14Adapter implements AvroAdapter {
       Schema schema = result.getMainSchema();
       Avro14SchemaValidator validator = new Avro14SchemaValidator(desiredConf, known);
       AvroSchemaUtil.traverseSchema(schema, validator); //will throw on issues
+      if (desiredConf.validateNoDanglingContent()) {
+        Jackson1Utils.assertNoTrailingContent(schemaJson);
+      }
       return new SchemaParseResult(result.getMainSchema(), result.getAllSchemas(), desiredConf);
     } else {
       return result;

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -224,12 +224,19 @@ public class Avro15Adapter implements AvroAdapter {
     boolean validateNames = true;
     boolean validateDefaults = false;
     boolean validateNumericDefaultValueTypes = false;
+    boolean validateNoDanglingContent = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
       validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
+      validateNoDanglingContent = desiredConf.validateNoDanglingContent();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
+        validateNames,
+        validateDefaults,
+        validateNumericDefaultValueTypes,
+        validateNoDanglingContent
+    );
 
     parser.setValidate(validateNames);
     if (known != null && !known.isEmpty()) {
@@ -245,6 +252,9 @@ public class Avro15Adapter implements AvroAdapter {
       //avro 1.5 doesnt properly validate default values, so we have to do it ourselves
       Avro15SchemaValidator validator = new Avro15SchemaValidator(configUsed, known);
       AvroSchemaUtil.traverseSchema(mainSchema, validator); //will throw on issues
+    }
+    if (configUsed.validateNoDanglingContent()) {
+      Jackson1Utils.assertNoTrailingContent(schemaJson);
     }
     return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
   }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -223,12 +223,19 @@ public class Avro16Adapter implements AvroAdapter {
     boolean validateNames = true;
     boolean validateDefaults = false;
     boolean validateNumericDefaultValueTypes = false;
+    boolean validateNoDanglingContent = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
       validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
+      validateNoDanglingContent = desiredConf.validateNoDanglingContent();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
+        validateNames,
+        validateDefaults,
+        validateNumericDefaultValueTypes,
+        validateNoDanglingContent
+    );
 
     parser.setValidate(validateNames);
     if (known != null && !known.isEmpty()) {
@@ -244,6 +251,9 @@ public class Avro16Adapter implements AvroAdapter {
       //avro 1.6 doesnt properly validate default values, so we have to do it ourselves
       Avro16SchemaValidator validator = new Avro16SchemaValidator(configUsed, known);
       AvroSchemaUtil.traverseSchema(mainSchema, validator); //will throw on issues
+    }
+    if (configUsed.validateNoDanglingContent()) {
+      Jackson1Utils.assertNoTrailingContent(schemaJson);
     }
     return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
   }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -257,12 +257,19 @@ public class Avro17Adapter implements AvroAdapter {
     boolean validateNames = true;
     boolean validateDefaults = true;
     boolean validateNumericDefaultValueTypes = false;
+    boolean validateNoDanglingContent = false;
     if (desiredConf != null) {
       validateNames = desiredConf.validateNames();
       validateDefaults = desiredConf.validateDefaultValues();
       validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
+      validateNoDanglingContent = desiredConf.validateNoDanglingContent();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes);
+    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
+        validateNames,
+        validateDefaults,
+        validateNumericDefaultValueTypes,
+        validateNoDanglingContent
+    );
 
     parser.setValidate(validateNames);
 
@@ -284,6 +291,9 @@ public class Avro17Adapter implements AvroAdapter {
       //dont trust avro, also run our own
       Avro17SchemaValidator validator = new Avro17SchemaValidator(configUsed, known);
       AvroSchemaUtil.traverseSchema(mainSchema, validator);
+    }
+    if (configUsed.validateNoDanglingContent()) {
+      Jackson1Utils.assertNoTrailingContent(schemaJson);
     }
     return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
   }

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperParsingTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelperParsingTest.java
@@ -232,4 +232,27 @@ public class AvroCompatibilityHelperParsingTest {
       }
     }
   }
+
+  @Test
+  public void testParseTrailingContent() throws Exception {
+    String innocent = "{\"type\": \"string\"}";
+    Assert.assertNotNull(AvroCompatibilityHelper.parse(innocent, SchemaParseConfiguration.STRICT, null).getMainSchema());
+    Assert.assertNotNull(AvroCompatibilityHelper.parse(innocent + "  \n \t \r  ", SchemaParseConfiguration.STRICT, null).getMainSchema());
+    try {
+      AvroCompatibilityHelper.parse(innocent + "?", SchemaParseConfiguration.STRICT, null);
+      Assert.fail("expected to fail");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("?"));
+    }
+    Assert.assertNotNull(AvroCompatibilityHelper.parse(innocent + "?", SchemaParseConfiguration.LOOSE, null).getMainSchema());
+    try {
+      AvroCompatibilityHelper.parse(innocent + "; DROP TABLE STUDENTS", SchemaParseConfiguration.STRICT, null);
+      Assert.fail("expected to fail");
+    } catch (IllegalArgumentException expected) {
+      Assert.assertTrue(expected.getMessage().contains("DROP TABLE STUDENTS"));
+    }
+    Assert.assertNotNull(
+        AvroCompatibilityHelper.parse(innocent + "; DROP TABLE STUDENTS", SchemaParseConfiguration.LOOSE, null).getMainSchema()
+    );
+  }
 }


### PR DESCRIPTION
avro uses a buffered json parser and ignores anything left in the buffer after reading the schema out,
this means that trailing "junk content" after the end of the schema is tolerated.

this PR adds validation to Helper.parse() to look for such junk