### PR TITLE
adds support for importable source to avro-util's codegen/builder

### DIFF
--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -45,7 +45,7 @@ public class SchemaBuilder {
     OptionSpec<String> inputOpt = parser.accepts("input", "Schema or directory of schemas to compile [REQUIRED]")
         .withRequiredArg().required()
         .describedAs("file");
-    OptionSpec<String> includesOpt = parser.accepts("include", "Common schemas")
+    OptionSpec<String> nonImportableSourceOpt = parser.accepts("non-importable-source", "source schemas that cannot be used as imports by other schemas")
         .withOptionalArg()
         .describedAs("file")
         .withValuesSeparatedBy(File.pathSeparatorChar);
@@ -103,9 +103,9 @@ public class SchemaBuilder {
 
     List<File> inputs = AvroSchemaBuilderUtils.toFiles(options.valuesOf(inputOpt));
 
-    List<File> includes = null;
-    if (options.has(includesOpt)) {
-      includes = AvroSchemaBuilderUtils.toFiles(options.valuesOf(includesOpt));
+    List<File> nonImportableSources = null;
+    if (options.has(nonImportableSourceOpt)) {
+      nonImportableSources = AvroSchemaBuilderUtils.toFiles(options.valuesOf(nonImportableSourceOpt));
     }
 
     boolean includeFromClasspath = false;
@@ -186,7 +186,7 @@ public class SchemaBuilder {
 
     CodeGenOpConfig opConfig = new CodeGenOpConfig(
         inputs,
-        includes,
+        nonImportableSources,
         includeFromClasspath,
         outputDir,
         expandedSchemasDir,

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/CodeGenOpConfig.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/CodeGenOpConfig.java
@@ -25,7 +25,7 @@ public class CodeGenOpConfig {
   //inputs
 
   List<File> inputRoots;
-  List<File> includeRoots;
+  List<File> nonImportableSourceRoots;
   boolean includeClasspath;
 
   //outputs
@@ -45,7 +45,7 @@ public class CodeGenOpConfig {
 
   public CodeGenOpConfig(
       List<File> inputRoots,
-      List<File> includeRoots,
+      List<File> nonImportableSourceRoots,
       boolean includeClasspath,
       File outputSpecificRecordClassesRoot,
       File outputExpandedSchemasRoot,
@@ -57,7 +57,7 @@ public class CodeGenOpConfig {
       boolean avro702Handling
   ) {
     this.inputRoots = inputRoots;
-    this.includeRoots = includeRoots;
+    this.nonImportableSourceRoots = nonImportableSourceRoots;
     this.includeClasspath = includeClasspath;
     this.outputSpecificRecordClassesRoot = outputSpecificRecordClassesRoot;
     this.outputExpandedSchemasRoot = outputExpandedSchemasRoot;
@@ -80,12 +80,12 @@ public class CodeGenOpConfig {
     validateInput(inputRoots, "input");
     List<File> inputsAndIncludes = new ArrayList<>(inputRoots);
 
-    if (includeRoots != null) {
-      if (includeRoots.isEmpty()) {
-        includeRoots = null;
+    if (nonImportableSourceRoots != null) {
+      if (nonImportableSourceRoots.isEmpty()) {
+        nonImportableSourceRoots = null;
       } else {
-        validateInput(includeRoots, "include");
-        inputsAndIncludes.addAll(includeRoots);
+        validateInput(nonImportableSourceRoots, "non-importable-source");
+        inputsAndIncludes.addAll(nonImportableSourceRoots);
       }
     }
 
@@ -125,8 +125,8 @@ public class CodeGenOpConfig {
     return inputRoots;
   }
 
-  public List<File> getIncludeRoots() {
-    return includeRoots;
+  public List<File> getNonImportableSourceRoots() {
+    return nonImportableSourceRoots;
   }
 
   public boolean isIncludeClasspath() {

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -21,8 +21,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -59,7 +57,6 @@ public class AvroUtilCodeGenOp implements Operation {
     Set<File> avscFiles = new HashSet<>();
     Set<File> importableFiles = new HashSet<>();
     String[] extensions = new String[]{BuilderConsts.AVSC_EXTENSION};
-
 
     for (File inputRoot : config.getInputRoots()) {
       avscFiles.addAll(FileUtils.listFiles(inputRoot, extensions, true));

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -55,33 +55,30 @@ public class AvroUtilCodeGenOp implements Operation {
     }
 
     Set<File> avscFiles = new HashSet<>();
-    Set<File> importableFiles = new HashSet<>();
+    Set<File> nonImportableFiles = new HashSet<>();
     String[] extensions = new String[]{BuilderConsts.AVSC_EXTENSION};
 
     for (File inputRoot : config.getInputRoots()) {
       avscFiles.addAll(FileUtils.listFiles(inputRoot, extensions, true));
     }
 
-    if (config.getIncludeRoots() != null) {
-      for (File includeRoot : config.getIncludeRoots()) {
-        importableFiles.addAll(FileUtils.listFiles(includeRoot, extensions, true));
+    if (config.getNonImportableSourceRoots() != null) {
+      for (File nonImportableRoot : config.getNonImportableSourceRoots()) {
+        nonImportableFiles.addAll(FileUtils.listFiles(nonImportableRoot, extensions, true));
       }
     }
 
-    // If there are no importable files, then all of avscFiles should be marked as importable.
-    boolean areAvscFilesImportable = importableFiles.isEmpty();
-
-    if (avscFiles.isEmpty() && importableFiles.isEmpty()) {
+    if (avscFiles.isEmpty() && nonImportableFiles.isEmpty()) {
       LOGGER.warn("no input schema files were found under roots " + config.getInputRoots());
       return;
     }
-    LOGGER.info("found " + (avscFiles.size() + importableFiles.size()) + " avsc schema files");
+    LOGGER.info("found " + (avscFiles.size() + nonImportableFiles.size()) + " avsc schema files");
 
     AvroParseContext context = new AvroParseContext();
     List<AvscParseResult> parsedFiles = new ArrayList<>();
 
-    parseAvscFiles(importableFiles, true, context, parsedFiles);
-    parseAvscFiles(avscFiles, areAvscFilesImportable, context, parsedFiles);
+    parseAvscFiles(avscFiles, true, context, parsedFiles);
+    parseAvscFiles(nonImportableFiles, false, context, parsedFiles);
 
     //resolve any references across files that are part of this op (anything left would be external)
     context.resolveReferences();

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
@@ -71,7 +71,7 @@ public class VanillaProcessedCodeGenOp implements Operation {
 
     FileSystemSchemaSetProvider provider = new FileSystemSchemaSetProvider(
         config.getInputRoots(),
-        config.getIncludeRoots(),
+        config.getNonImportableSourceRoots(),
         FileSystemSchemaSetProvider.DEFAULT_SCHEMA_SUFFIX,
         cpLookup
     );
@@ -90,8 +90,8 @@ public class VanillaProcessedCodeGenOp implements Operation {
 
     Set<File> avroFiles = new HashSet<>();
     String[] extensions = new String[]{BuilderConsts.AVSC_EXTENSION};
-    if (config.getIncludeRoots() != null) {
-      for (File include : config.getIncludeRoots()) {
+    if (config.getNonImportableSourceRoots() != null) {
+      for (File include : config.getNonImportableSourceRoots()) {
         avroFiles.addAll(FileUtils.listFiles(include, extensions, true));
       }
     }

--- a/avro-builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -58,7 +58,6 @@ public class SchemaBuilderTest {
     Assert.assertEquals(txtFiles.size(), 1);
   }
 
-  //TODO - complete this
   @Test
   public void testSimpleProjectUsingOwnCodegen() throws Exception {
     File simpleProjectRoot = new File(locateTestProjectsRoot(), "simple-project");
@@ -78,6 +77,47 @@ public class SchemaBuilderTest {
         (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
     ).collect(Collectors.toList());
     Assert.assertEquals(javaFiles.size(), 1);
+  }
+
+  @Test
+  public void testImportableSchemasUsingOwnCodegen() throws Exception {
+    File simpleProjectRoot = new File(locateTestProjectsRoot(), "test-includes-option");
+    File inputFolder = new File(simpleProjectRoot, "input");
+    File includesFolder = new File(simpleProjectRoot, "common");
+    File outputFolder = new File(simpleProjectRoot, "output");
+    if (outputFolder.exists()) { //clear output
+      FileUtils.deleteDirectory(outputFolder);
+    }
+    //run the builder
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--include", includesFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath(),
+        "--generator", CodeGenerator.AVRO_UTIL.name()
+    });
+    //see output was generated
+    List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
+        (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
+    ).collect(Collectors.toList());
+    Assert.assertEquals(javaFiles.size(), 2);
+  }
+
+  @Test(expectedExceptions = java.lang.UnsupportedOperationException.class, expectedExceptionsMessageRegExp = ".*unresolved referenced.*")
+  public void testImportableSchemasWithBadImport() throws Exception {
+    File simpleProjectRoot = new File(locateTestProjectsRoot(), "bad-import");
+    File inputFolder = new File(simpleProjectRoot, "input");
+    File includesFolder = new File(simpleProjectRoot, "common");
+    File outputFolder = new File(simpleProjectRoot, "output");
+    if (outputFolder.exists()) { //clear output
+      FileUtils.deleteDirectory(outputFolder);
+    }
+    //run the builder
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--include", includesFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath(),
+        "--generator", CodeGenerator.AVRO_UTIL.name()
+    });
   }
 
   private File locateTestProjectsRoot() {

--- a/avro-builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -90,8 +90,8 @@ public class SchemaBuilderTest {
     }
     //run the builder
     SchemaBuilder.main(new String[] {
-        "--input", inputFolder.getAbsolutePath(),
-        "--include", includesFolder.getAbsolutePath(),
+        "--input", includesFolder.getAbsolutePath(),
+        "--non-importable-source", inputFolder.getAbsolutePath(),
         "--output", outputFolder.getAbsolutePath(),
         "--generator", CodeGenerator.AVRO_UTIL.name()
     });

--- a/avro-builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -102,24 +102,6 @@ public class SchemaBuilderTest {
     Assert.assertEquals(javaFiles.size(), 2);
   }
 
-  @Test(expectedExceptions = java.lang.UnsupportedOperationException.class, expectedExceptionsMessageRegExp = ".*unresolved referenced.*")
-  public void testImportableSchemasWithBadImport() throws Exception {
-    File simpleProjectRoot = new File(locateTestProjectsRoot(), "bad-import");
-    File inputFolder = new File(simpleProjectRoot, "input");
-    File includesFolder = new File(simpleProjectRoot, "common");
-    File outputFolder = new File(simpleProjectRoot, "output");
-    if (outputFolder.exists()) { //clear output
-      FileUtils.deleteDirectory(outputFolder);
-    }
-    //run the builder
-    SchemaBuilder.main(new String[] {
-        "--input", inputFolder.getAbsolutePath(),
-        "--include", includesFolder.getAbsolutePath(),
-        "--output", outputFolder.getAbsolutePath(),
-        "--generator", CodeGenerator.AVRO_UTIL.name()
-    });
-  }
-
   private File locateTestProjectsRoot() {
     //the current working directory for test execution varies across gradle and IDEs.
     //as such, we need to get creative to locate the folder

--- a/avro-builder/src/test/resources/test-projects/test-includes-option/common/ImportableSchema.avsc
+++ b/avro-builder/src/test/resources/test-projects/test-includes-option/common/ImportableSchema.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "testincludesoption.common",
+  "name": "ImportableSchema",
+  "fields": [
+    {"name": "f", "type": "int"}
+  ]
+}

--- a/avro-builder/src/test/resources/test-projects/test-includes-option/input/SimpleRecord.avsc
+++ b/avro-builder/src/test/resources/test-projects/test-includes-option/input/SimpleRecord.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "namespace": "testincludesoption",
+  "name": "SimpleRecord",
+  "fields": [
+    {
+      "name": "f",
+      "type": "int"
+    },
+    {
+      "name": "importedField",
+      "type": "testincludesoption.common.ImportableSchema"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for the `--include` statement that `VanillaProcessedCodeGenOp` already implements.

One detail of note: if there are no `--include` schemas, all `--input` schemas are allowed to import from each other. Is this the functionality we want? 