### PR TITLE
[builder] separate plugin context from operation context

### DIFF
--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -10,7 +10,7 @@ import com.linkedin.avroutil1.builder.operations.codegen.CodeGenerator;
 import com.linkedin.avroutil1.builder.operations.codegen.own.AvroUtilCodeGenOp;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
 import com.linkedin.avroutil1.builder.operations.Operation;
-import com.linkedin.avroutil1.builder.operations.OperationContext;
+import com.linkedin.avroutil1.builder.operations.BuilderPluginContext;
 import com.linkedin.avroutil1.builder.operations.codegen.vanilla.VanillaProcessedCodeGenOp;
 import com.linkedin.avroutil1.builder.plugins.BuilderPlugin;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
@@ -182,7 +182,7 @@ public class SchemaBuilder {
       plugin.parseAndValidateOptions(options);
     }
 
-    OperationContext context = new OperationContext();
+    BuilderPluginContext context = new BuilderPluginContext();
 
     CodeGenOpConfig opConfig = new CodeGenOpConfig(
         inputs,

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/AvroSchemaUtils.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/AvroSchemaUtils.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
 package com.linkedin.avroutil1.builder.operations;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/AvroSchemaUtils.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/AvroSchemaUtils.java
@@ -1,0 +1,23 @@
+package com.linkedin.avroutil1.builder.operations;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.model.AvroSchema;
+import com.linkedin.avroutil1.parser.avsc.AvscParser;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.avro.Schema;
+
+
+public class AvroSchemaUtils {
+  public static Set<AvroSchema> schemasToAvroSchemas(Set<Schema> schemas) {
+    HashSet<AvroSchema> avroSchemas = new HashSet();
+    AvscParser avscParser = new AvscParser();
+    for (Schema schema : schemas) {
+      // TODO: Is this the  correct AvscGenerationConfig to use?
+      String avscText = AvroCompatibilityHelper.toAvsc(schema, AvscGenerationConfig.VANILLA_PRETTY);
+      avroSchemas.add(avscParser.parse(avscText).getTopLevelSchema());
+    }
+    return avroSchemas;
+  }
+}

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/BuilderPluginContext.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/BuilderPluginContext.java
@@ -6,16 +6,18 @@
 
 package com.linkedin.avroutil1.builder.operations;
 
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContext;
 import java.util.ArrayList;
 import java.util.List;
 
 
 /**
- * common context to all {@link Operation}s run during an execution
+ * context for running a set of {@link  com.linkedin.avroutil1.builder.plugins.BuilderPlugin}s
  */
-public class OperationContext {
+public class BuilderPluginContext {
 
   private List<Operation> operations = new ArrayList<>(1);
+  private OperationContext _operationContext = new OperationContext();
   private volatile boolean sealed = false;
 
   public void add(Operation op) {
@@ -29,11 +31,15 @@ public class OperationContext {
   }
 
   public void run() throws Exception {
+    if (sealed) {
+      throw new IllegalStateException("run() has already been invoked");
+    }
+
     //"seal" any internal state to prevent plugins from trying to do weird things during execution
     sealed = true;
 
     for (Operation op : operations) {
-      op.run(this);
+      op.run(_operationContext);
     }
   }
 }

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/Operation.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/Operation.java
@@ -6,6 +6,9 @@
 
 package com.linkedin.avroutil1.builder.operations;
 
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContext;
+
+
 public interface Operation {
   void run(OperationContext opContext) throws Exception;
 }

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContext.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContext.java
@@ -6,35 +6,60 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen;
 
+import com.linkedin.avroutil1.builder.operations.AvroSchemaUtils;
+import com.linkedin.avroutil1.model.AvroSchema;
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Set;
+import org.apache.avro.Schema;
 
 
 /**
  * common context to all {@link com.linkedin.avroutil1.builder.operations.Operation}s run during an execution
  */
 public class OperationContext {
-  private Set<File> avroFiles;
   private final HashMap<String, Object> context;
+  private Set<File> avroFiles;
+  private Set<AvroSchema> avroSchemas;
 
   public OperationContext() {
     this.context = new HashMap<>();
   }
 
-  public void setAvroFiles(Set<File> avroFiles) {
-    if (this.avroFiles != null) {
+  public void addParsedSchemas(Set<AvroSchema> avroSchemas, Set<File> avroFiles) {
+    if (this.avroFiles != null || this.avroSchemas != null) {
       throw new IllegalStateException("Cannot initialize avro files twice");
     }
-    this.avroFiles = avroFiles;
+
+    this.avroFiles = Collections.unmodifiableSet(avroFiles);
+    this.avroSchemas = Collections.unmodifiableSet(avroSchemas);
   }
 
+  public void addVanillaSchemas(Set<Schema> schemas, Set<File> avroFiles) {
+    addParsedSchemas(AvroSchemaUtils.schemasToAvroSchemas(schemas), avroFiles);
+  }
+
+  /**
+   * Returns an unmodifiable set of all input avro files.
+   */
   public Set<File> getAvroFiles() {
-    if (avroFiles == null) {
-      throw new IllegalStateException("Avro files are undefined");
+    if (this.avroFiles == null) {
+      throw new IllegalStateException("Avro files haven't been added yet.");
+    }
+    return this.avroFiles;
+  }
+
+  /**
+   * Returns an unmodifiable set of all parsed avro schemas.
+   */
+  public Set<AvroSchema> getAvroSchemas() {
+    if (this.avroSchemas == null) {
+      throw new IllegalStateException("Avro schemas haven't been added yet.");
     }
 
-    return this.avroFiles;
+    return this.avroSchemas;
   }
 
   public void setConfigValue(String key, Object value) {

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContext.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.builder.operations.codegen;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Set;
+
+
+/**
+ * common context to all {@link com.linkedin.avroutil1.builder.operations.Operation}s run during an execution
+ */
+public class OperationContext {
+  private Set<File> avroFiles;
+  private final HashMap<String, Object> context;
+
+  public OperationContext() {
+    this.context = new HashMap<>();
+  }
+
+  public void setAvroFiles(Set<File> avroFiles) {
+    if (this.avroFiles != null) {
+      throw new IllegalStateException("Cannot initialize avro files twice");
+    }
+    this.avroFiles = avroFiles;
+  }
+
+  public Set<File> getAvroFiles() {
+    if (avroFiles == null) {
+      throw new IllegalStateException("Avro files are undefined");
+    }
+
+    return this.avroFiles;
+  }
+
+  public void setConfigValue(String key, Object value) {
+    if (this.context.containsKey(key)) {
+      throw new IllegalStateException("Cannot initialize an already-initialized config key.");
+    }
+    this.context.put(key, value);
+  }
+
+  public Object getConfigValue(String key) {
+    if (!this.context.containsKey(key)) {
+      throw new IllegalStateException("No value for key " + key);
+    }
+    return this.context.get(key);
+  }
+}

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContext.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContext.java
@@ -11,7 +11,6 @@ import com.linkedin.avroutil1.model.AvroSchema;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.avro.Schema;
 

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -13,6 +13,7 @@ import com.linkedin.avroutil1.builder.operations.codegen.OperationContext;
 import com.linkedin.avroutil1.codegen.SpecificRecordClassGenerator;
 import com.linkedin.avroutil1.codegen.SpecificRecordGenerationConfig;
 import com.linkedin.avroutil1.model.AvroNamedSchema;
+import com.linkedin.avroutil1.model.AvroSchema;
 import com.linkedin.avroutil1.parser.avsc.AvroParseContext;
 import com.linkedin.avroutil1.parser.avsc.AvscParseResult;
 import com.linkedin.avroutil1.parser.avsc.AvscParser;
@@ -26,6 +27,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.management.remote.rmi._RMIConnection_Stub;
 import javax.tools.JavaFileObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -91,7 +93,9 @@ public class AvroUtilCodeGenOp implements Operation {
 
     SpecificRecordClassGenerator generator = new SpecificRecordClassGenerator();
     List<JavaFileObject> specificRecords = new ArrayList<>();
+    Set<AvroSchema> avroSchemas = new HashSet<>();
     for (AvscParseResult parsedFile : parsedFiles) {
+      avroSchemas.add(parsedFile.getTopLevelSchema());
       JavaFileObject javaFileObject =
           generator.generateSpecificRecordClass((AvroNamedSchema) parsedFile.getTopLevelSchema(),
               SpecificRecordGenerationConfig.BROAD_COMPATIBILITY);
@@ -102,7 +106,7 @@ public class AvroUtilCodeGenOp implements Operation {
 
     Set<File> allAvroFiles = new HashSet<>(avscFiles);
     allAvroFiles.addAll(nonImportableFiles);
-    opContext.setAvroFiles(allAvroFiles);
+    opContext.addParsedSchemas(avroSchemas, allAvroFiles);
 
     // TODO - look for dups
 

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -27,7 +27,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.management.remote.rmi._RMIConnection_Stub;
 import javax.tools.JavaFileObject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -8,8 +8,8 @@ package com.linkedin.avroutil1.builder.operations.codegen.own;
 
 import com.linkedin.avroutil1.builder.BuilderConsts;
 import com.linkedin.avroutil1.builder.operations.Operation;
-import com.linkedin.avroutil1.builder.operations.OperationContext;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContext;
 import com.linkedin.avroutil1.codegen.SpecificRecordClassGenerator;
 import com.linkedin.avroutil1.codegen.SpecificRecordGenerationConfig;
 import com.linkedin.avroutil1.model.AvroNamedSchema;
@@ -99,6 +99,10 @@ public class AvroUtilCodeGenOp implements Operation {
     }
 
     writeJavaFilesToDisk(specificRecords, config.getOutputSpecificRecordClassesRoot());
+
+    Set<File> allAvroFiles = new HashSet<>(avscFiles);
+    allAvroFiles.addAll(nonImportableFiles);
+    opContext.setAvroFiles(allAvroFiles);
 
     // TODO - look for dups
 

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
@@ -9,7 +9,7 @@ package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 import com.linkedin.avroutil1.builder.BuilderConsts;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
 import com.linkedin.avroutil1.builder.operations.Operation;
-import com.linkedin.avroutil1.builder.operations.OperationContext;
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContext;
 import com.linkedin.avroutil1.compatibility.Avro702Checker;
 import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.CodeGenerationConfig;
@@ -177,6 +177,8 @@ public class VanillaProcessedCodeGenOp implements Operation {
         );
       }
     }
+
+    opContext.setAvroFiles(avroFiles);
 
     LOGGER.info("Compilation complete.");
   }

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
@@ -178,7 +178,7 @@ public class VanillaProcessedCodeGenOp implements Operation {
       }
     }
 
-    opContext.setAvroFiles(avroFiles);
+    opContext.addVanillaSchemas(new HashSet<>(schemas), avroFiles);
 
     LOGGER.info("Compilation complete.");
   }

--- a/avro-builder/src/main/java/com/linkedin/avroutil1/builder/plugins/BuilderPlugin.java
+++ b/avro-builder/src/main/java/com/linkedin/avroutil1/builder/plugins/BuilderPlugin.java
@@ -6,7 +6,7 @@
 
 package com.linkedin.avroutil1.builder.plugins;
 
-import com.linkedin.avroutil1.builder.operations.OperationContext;
+import com.linkedin.avroutil1.builder.operations.BuilderPluginContext;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 
@@ -50,7 +50,7 @@ public interface BuilderPlugin {
     //nop
   }
 
-  default void createOperations(OperationContext context) {
+  default void createOperations(BuilderPluginContext context) {
     //nop
   }
 }

--- a/avro-builder/src/test/java/com/linkedin/avroutil1/builder/plugins/TestBuilderPlugin.java
+++ b/avro-builder/src/test/java/com/linkedin/avroutil1/builder/plugins/TestBuilderPlugin.java
@@ -7,7 +7,8 @@
 package com.linkedin.avroutil1.builder.plugins;
 
 import com.linkedin.avroutil1.builder.operations.Operation;
-import com.linkedin.avroutil1.builder.operations.OperationContext;
+import com.linkedin.avroutil1.builder.operations.BuilderPluginContext;
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContext;
 import java.io.File;
 import java.io.FileWriter;
 import java.util.Collections;
@@ -53,7 +54,7 @@ public class TestBuilderPlugin implements BuilderPlugin {
   }
 
   @Override
-  public void createOperations(OperationContext context) {
+  public void createOperations(BuilderPluginContext context) {
     if (extraFile != null) {
       context.add(new CreateDummyFileOperation(extraFile));
     }


### PR DESCRIPTION
* separates operation context from plugin context
* Adds `Set<File> avroFiles` to operation context
* Not sure if we should add `Set<AvroSchema> avroSchemas` since they won't necessarily be generated if we use vanilla codegen