### PR TITLE
Removed unnecessary libs during fast-class compilation

### DIFF
--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
@@ -158,24 +158,10 @@ public final class FastSerdeCache {
           } else if (classPath != null) {
             _INSTANCE = new FastSerdeCache(classPath);
           } else {
-            // Infer class path if no classpath specified.
-            classPath = System.getProperty("java.class.path");
-            String avroSchemaClassName = "org.apache.avro.Schema";
-            try {
-              Class avroSchemaClass = Class.forName(avroSchemaClassName);
-              String avroLibLocation = avroSchemaClass.getProtectionDomain().getCodeSource().getLocation().getFile();
-              // find all other libs
-              File avroLibFile = new File(avroLibLocation).getParentFile();
-              for (File lib : avroLibFile.listFiles()) {
-                if (lib.getName().endsWith(".jar")) {
-                  classPath += ":" + lib.getAbsolutePath();
-                }
-              }
-              LOGGER.debug("Inferred class path: {}", classPath);
-            } catch (ClassNotFoundException e) {
-              throw new RuntimeException("Failed to find class: " + avroSchemaClassName);
-            }
-            _INSTANCE = new FastSerdeCache(classPath);
+            /**
+             * The fast-class generator will figure out the compile dependencies during fast-class generation.
+             */
+            _INSTANCE = new FastSerdeCache("");
           }
         }
       }


### PR DESCRIPTION
Previously, fast-avro would put all the libs in the same folder of avro jar
in the compilation classpath of generated fast classes, which sometimes
triggers some weird issues since some unnecessary libs might be corrupted,
this code change removes the unnecessary libs by inferring all the compilation
dependencies while generating the fast classes.