### PR TITLE
Handle literal sign in JavaPoet during codegen

### DIFF
--- a/avro-builder/tests/codegen-14/src/main/avro/vs14/DollarSignInDoc.avsc
+++ b/avro-builder/tests/codegen-14/src/main/avro/vs14/DollarSignInDoc.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "namespace": "vs14",
+  "name": "DollarSignInDoc",
+  "doc": "$ sign in doc with Schema$ in Vari$able",
+  "fields": [
+    {
+      "name": "arOfRec",
+      "type": {
+        "type":"array",
+        "items": "string"
+      }
+    }
+  ]
+}

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/DollarSignInAvroTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/DollarSignInAvroTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.builder;
+
+import com.linkedin.avroutil1.compatibility.AvroCodecUtil;
+import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
+import com.linkedin.avroutil1.compatibility.RecordGenerationConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DollarSignInAvroTest {
+
+  @Test
+  public void testRoundTripSerialization() throws Exception {
+    RandomRecordGenerator generator = new RandomRecordGenerator();
+    vs14.DollarSignInDoc instance =
+        generator.randomSpecific(vs14.DollarSignInDoc.class, RecordGenerationConfig.newConfig().withAvoidNulls(true));
+
+    byte[] serialized = AvroCodecUtil.serializeBinary(instance);
+    vs14.DollarSignInDoc deserialized =
+        AvroCodecUtil.deserializeAsSpecific(serialized, vs14.DollarSignInDoc.getClassSchema(), vs14.DollarSignInDoc.class);
+
+    Assert.assertNotSame(deserialized, instance);
+    Assert.assertEquals(deserialized, instance);
+  }
+}

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -286,6 +286,9 @@ public class SpecificRecordClassGenerator {
     //file-level (top of file) comment is added to the file object later
     String doc = recordSchema.getDoc();
     if (doc != null && !doc.isEmpty()) {
+      if(doc.contains("$")) {
+        doc = doc.replaceAll("\\$", "\\$\\$");
+      }
       classBuilder.addJavadoc(doc);
     }
 

--- a/avro-codegen/src/test/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGeneratorTest.java
+++ b/avro-codegen/src/test/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGeneratorTest.java
@@ -6,13 +6,13 @@
 
 package com.linkedin.avroutil1.codegen;
 
-import com.linkedin.avroutil1.testutil.CompilerHelper;
 import com.linkedin.avroutil1.model.AvroEnumSchema;
 import com.linkedin.avroutil1.model.AvroFixedSchema;
 import com.linkedin.avroutil1.model.AvroRecordSchema;
 import com.linkedin.avroutil1.parser.avsc.AvscParseResult;
 import com.linkedin.avroutil1.parser.avsc.AvscParser;
 import com.linkedin.avroutil1.testcommon.TestUtil;
+import com.linkedin.avroutil1.testutil.CompilerHelper;
 import java.util.List;
 import javax.tools.JavaFileObject;
 import org.testng.Assert;
@@ -116,6 +116,20 @@ public class SpecificRecordClassGeneratorTest {
     AvroRecordSchema recordSchema = (AvroRecordSchema) result.getTopLevelSchema();
     Assert.assertNotNull(recordSchema);
     List<JavaFileObject> javaSourceFile = generator.generateSpecificClassWithInternalTypes(recordSchema, SpecificRecordGenerationConfig.BROAD_COMPATIBILITY);
+  }
+
+  @Test
+  public void testSpecificWith$InDoc() throws Exception {
+    String avsc = TestUtil.load("schemas/DollarSignInDoc.avsc");
+    SpecificRecordClassGenerator generator = new SpecificRecordClassGenerator();
+    AvscParser parser = new AvscParser();
+    AvscParseResult result = parser.parse(avsc);
+    Assert.assertNull(result.getParseError());
+    AvroRecordSchema recordSchema = (AvroRecordSchema) result.getTopLevelSchema();
+    Assert.assertNotNull(recordSchema);
+    JavaFileObject javaFileObject =
+        generator.generateSpecificClass(recordSchema, SpecificRecordGenerationConfig.BROAD_COMPATIBILITY);
+    CompilerHelper.assertCompiles(javaFileObject);
   }
 
 }

--- a/avro-codegen/src/test/resources/schemas/DollarSignInDoc.avsc
+++ b/avro-codegen/src/test/resources/schemas/DollarSignInDoc.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "namespace": "com.linkedin.test",
+  "name": "DollarSignInDoc",
+  "doc": "$ sign in doc with Schema$ in Vari$able",
+  "fields": [
+    {
+      "name": "arOfRec",
+      "type": {
+        "type":"array",
+        "items": "string"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
JavaPoet treats $ as a string literal. Replacing with $$ to handle it. This will result in a single $ sign after build.