### PR TITLE
Enforces using Avro 702 Handling & adds min avro version config

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -81,7 +81,7 @@ public class SchemaBuilder {
             "enableAvro702Handling",
             "enable handling of avro702 when generating classes (will have correct AVSC with aliases to the impacted fullnames)")
         .withOptionalArg()
-        .defaultsTo("false")
+        .defaultsTo("true")
         .describedAs("true/false");
 
     //allow plugins to add CLI options
@@ -171,7 +171,7 @@ public class SchemaBuilder {
       }
     }
 
-    boolean handleAvro702 = false;
+    boolean handleAvro702 = true;
     if (options.has(enableAvro702Handling)) {
       String value = options.valueOf(enableAvro702Handling);
       handleAvro702 = Boolean.TRUE.equals(Boolean.parseBoolean(value));

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -59,7 +59,7 @@ public class AvroUtilCodeGenOp implements Operation {
     }
 
     if (!config.isAvro702Handling()) {
-      throw new IllegalArgumentException("--enableAvro702Handling should never be disabled");
+      LOGGER.warn("Avro-702 handling was disabled, however Avro-702 handling cannot be  disabled in AvroUtilCodeGenOp.");
     }
 
     Set<File> avscFiles = new HashSet<>();

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -58,6 +58,10 @@ public class AvroUtilCodeGenOp implements Operation {
           "unable to create destination folder " + config.getOutputSpecificRecordClassesRoot());
     }
 
+    if (!config.isAvro702Handling()) {
+      throw new IllegalArgumentException("--enableAvro702Handling should never be disabled");
+    }
+
     Set<File> avscFiles = new HashSet<>();
     Set<File> nonImportableFiles = new HashSet<>();
     String[] extensions = new String[]{BuilderConsts.AVSC_EXTENSION};
@@ -164,10 +168,9 @@ public class AvroUtilCodeGenOp implements Operation {
       AvroNamedSchema namedSchema = fileParseResult.getDefinedSchema(fullname);
 
       try {
-        JavaFileObject javaFileObject = generator.generateSpecificClass(
-            namedSchema,
-            SpecificRecordGenerationConfig.BROAD_COMPATIBILITY
-        );
+        JavaFileObject javaFileObject = generator.generateSpecificClass(namedSchema,
+            SpecificRecordGenerationConfig.getBroadCompatibilitySpecificRecordGenerationConfig(
+                config.getMinAvroVersion()));
         specificRecords.add(javaFileObject);
       } catch (Exception e) {
         errorCount++;

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
@@ -58,9 +58,9 @@ public class VanillaProcessedCodeGenOp implements Operation {
       }
     }
 
-    AvscGenerationConfig avscConfig = AvscGenerationConfig.VANILLA_ONELINE;
-    if (config.isAvro702Handling()) {
-      avscConfig = AvscGenerationConfig.CORRECT_MITIGATED_ONELINE;
+    AvscGenerationConfig avscConfig = AvscGenerationConfig.CORRECT_MITIGATED_ONELINE;
+    if (!config.isAvro702Handling()) {
+      throw new IllegalArgumentException("--enableAvro702Handling should never be disabled");
     }
 
     //build a classpath SchemaSet if classpath (cp) lookup is turned on
@@ -193,7 +193,7 @@ public class VanillaProcessedCodeGenOp implements Operation {
       throw new IllegalArgumentException("no \"name\" property in schema " + schemaJson);
     }
     String name = schemaJson.getString("name");
-    String fqcn ;
+    String fqcn;
     if (name.contains(".") || namespace == null) {
       fqcn = name; //avro spec says ignore namespace if name is a "full name"
     } else {

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
@@ -60,7 +60,7 @@ public class VanillaProcessedCodeGenOp implements Operation {
 
     AvscGenerationConfig avscConfig = AvscGenerationConfig.CORRECT_MITIGATED_ONELINE;
     if (!config.isAvro702Handling()) {
-      throw new IllegalArgumentException("--enableAvro702Handling should never be disabled");
+      LOGGER.warn("Avro-702 handling was disabled. It is HIGHLY recommended that you enable Avro-702 handling.");
     }
 
     //build a classpath SchemaSet if classpath (cp) lookup is turned on

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordGenerationConfig.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordGenerationConfig.java
@@ -25,6 +25,20 @@ public class SpecificRecordGenerationConfig {
       AvroVersion.AVRO_1_4
   );
 
+  public final static SpecificRecordGenerationConfig getBroadCompatibilitySpecificRecordGenerationConfig(
+      AvroVersion minimumSupportedAvroVersion) {
+    return new SpecificRecordGenerationConfig(
+        BROAD_COMPATIBILITY.publicFields,
+        BROAD_COMPATIBILITY.getters,
+        BROAD_COMPATIBILITY.setters,
+        BROAD_COMPATIBILITY.builders,
+        BROAD_COMPATIBILITY.honorStringTypeHints,
+        BROAD_COMPATIBILITY.defaultFieldStringRepresentation,
+        BROAD_COMPATIBILITY.defaultMethodStringRepresentation,
+        minimumSupportedAvroVersion
+    );
+  }
+
   /**
    * true to make generated fields public
    */


### PR DESCRIPTION
Enforces using Avro 702 Handling in 2 ways
1. Changes the `--enableAvro702Handling` default value from `false` -> `true`
2. Logs a warning if the user attempts to set the value to `true`

Eventually, we will deprecate this field, but for now we can track who still tries to disable 702 handling.

This PR also adds handling of the `--minAvroVersion` to avro-util's custom codegen.