### PR TITLE
Add AvroCompatibilityHelper.getAllPropNames() API to return all prop names.

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -162,6 +162,9 @@ public interface AvroAdapter {
    */
   boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps);
 
+  List<String> getAllPropNames(Schema schema);
+  List<String> getAllPropNames(Schema.Field field);
+
   String getEnumDefault(Schema s);
 
   default Schema newEnumSchema(String name, String doc, String namespace, List<String> values, String enumDefault) {

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -1140,6 +1140,16 @@ public class AvroCompatibilityHelper {
     return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
   }
 
+  public static List<String> getAllPropNames(Schema schema) {
+    assertAvroAvailable();
+    return ADAPTER.getAllPropNames(schema);
+  }
+
+  public static List<String> getAllPropNames(Schema.Field field) {
+    assertAvroAvailable();
+    return ADAPTER.getAllPropNames(field);
+  }
+
   /**
    * returns the enum default value.
    * returns null if schema has no such property.

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -405,6 +405,16 @@ public class Avro110Adapter implements AvroAdapter {
     }
 
     @Override
+    public List<String> getAllPropNames(Schema schema) {
+        return new ArrayList<>(schema.getObjectProps().keySet());
+    }
+
+    @Override
+    public List<String> getAllPropNames(Schema.Field field) {
+        return new ArrayList<>(field.getObjectProps().keySet());
+    }
+
+    @Override
     public String getEnumDefault(Schema s) {
         return s.getEnumDefault();
     }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -403,6 +403,16 @@ public class Avro111Adapter implements AvroAdapter {
     }
 
     @Override
+    public List<String> getAllPropNames(Schema schema) {
+      return new ArrayList<>(schema.getObjectProps().keySet());
+    }
+
+    @Override
+    public List<String> getAllPropNames(Schema.Field field) {
+        return new ArrayList<>(field.getObjectProps().keySet());
+    }
+
+    @Override
     public String getEnumDefault(Schema s) {
         return s.getEnumDefault();
     }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -404,7 +404,7 @@ public class Avro111Adapter implements AvroAdapter {
 
     @Override
     public List<String> getAllPropNames(Schema schema) {
-      return new ArrayList<>(schema.getObjectProps().keySet());
+        return new ArrayList<>(schema.getObjectProps().keySet());
     }
 
     @Override

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -318,6 +318,24 @@ public class Avro14Adapter implements AvroAdapter {
     StringPropertyUtils.setFieldPropFromJsonString(field, name, value, strict);
   }
 
+  private Map<String, String> getPropsMap(Schema schema) {
+    try {
+      //noinspection unchecked
+      return (Map<String, String>) schemaPropsField.get(schema);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access Schema.Field.props", e);
+    }
+  }
+
+  private Map<String, String> getPropsMap(Schema.Field field) {
+    try {
+      //noinspection unchecked
+      return (Map<String, String>) fieldPropsField.get(field);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access Schema.Field.props", e);
+    }
+  }
+
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
     if (compareNonStringProps) {
@@ -330,16 +348,8 @@ public class Avro14Adapter implements AvroAdapter {
     if (!compareStringProps) {
       return true;
     }
-    Map<String, String> aProps;
-    Map<String, String> bProps;
-    try {
-      //noinspection unchecked
-      aProps = (Map<String, String>) fieldPropsField.get(a);
-      //noinspection unchecked
-      bProps = (Map<String, String>) fieldPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access Schema.Field.props", e);
-    }
+    Map<String, String> aProps = getPropsMap(a);
+    Map<String, String> bProps = getPropsMap(b);
     return Objects.equals(aProps, bProps);
   }
 
@@ -365,17 +375,19 @@ public class Avro14Adapter implements AvroAdapter {
     if (!compareStringProps) {
       return true;
     }
-    Map<String, String> aProps;
-    Map<String, String> bProps;
-    try {
-      //noinspection unchecked
-      aProps = (Map<String, String>) schemaPropsField.get(a);
-      //noinspection unchecked
-      bProps = (Map<String, String>) schemaPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access Schema.props", e);
-    }
+    Map<String, String> aProps = getPropsMap(a);
+    Map<String, String> bProps = getPropsMap(b);
     return Objects.equals(aProps, bProps);
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(getPropsMap(schema).keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(getPropsMap(field).keySet());
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -349,6 +349,24 @@ public class Avro15Adapter implements AvroAdapter {
     StringPropertyUtils.setFieldPropFromJsonString(field, name, value, strict);
   }
 
+  private Map<String, String> getPropsMap(Schema schema) {
+    try {
+      //noinspection unchecked
+      return (Map<String, String>) schemaPropsField.get(schema);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access Schema.Field.props", e);
+    }
+  }
+
+  private Map<String, String> getPropsMap(Schema.Field field) {
+    try {
+      //noinspection unchecked
+      return (Map<String, String>) fieldPropsField.get(field);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access Schema.Field.props", e);
+    }
+  }
+
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
     if (compareNonStringProps) {
@@ -361,16 +379,8 @@ public class Avro15Adapter implements AvroAdapter {
     if (!compareStringProps) {
       return true;
     }
-    Map<String, String> aProps;
-    Map<String, String> bProps;
-    try {
-      //noinspection unchecked
-      aProps = (Map<String, String>) fieldPropsField.get(a);
-      //noinspection unchecked
-      bProps = (Map<String, String>) fieldPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access Schema.Field.props", e);
-    }
+    Map<String, String> aProps = getPropsMap(a);
+    Map<String, String> bProps = getPropsMap(b);
     return Objects.equals(aProps, bProps);
   }
 
@@ -396,17 +406,19 @@ public class Avro15Adapter implements AvroAdapter {
     if (!compareStringProps) {
       return true;
     }
-    Map<String, String> aProps;
-    Map<String, String> bProps;
-    try {
-      //noinspection unchecked
-      aProps = (Map<String, String>) schemaPropsField.get(a);
-      //noinspection unchecked
-      bProps = (Map<String, String>) schemaPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access Schema.props", e);
-    }
+    Map<String, String> aProps = getPropsMap(a);
+    Map<String, String> bProps = getPropsMap(b);
     return Objects.equals(aProps, bProps);
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(getPropsMap(schema).keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(getPropsMap(field).keySet());
   }
 
   @Override

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -384,6 +384,16 @@ public class Avro16Adapter implements AvroAdapter {
   }
 
   @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(schema.getProps().keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(field.props().keySet());
+  }
+
+  @Override
   public String getEnumDefault(Schema s) {
     return s.getProp("default");
   }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -406,6 +406,16 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(schema.getJsonProps().keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(field.getJsonProps().keySet());
+  }
+
+  @Override
   public String getEnumDefault(Schema s) {
     return s.getProp("default");
   }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -376,6 +376,16 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(schema.getObjectProps().keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(field.getObjectProps().keySet());
+  }
+
+  @Override
   public String getEnumDefault(Schema s) {
     return s.getProp("default");
   }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -401,6 +401,16 @@ public class Avro19Adapter implements AvroAdapter {
   }
 
   @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(schema.getObjectProps().keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(field.getObjectProps().keySet());
+  }
+
+  @Override
   public String getEnumDefault(Schema s) {
     return s.getEnumDefault();
   }

--- a/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/AvroCompatibilityHelperProps111Test.java
+++ b/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/AvroCompatibilityHelperProps111Test.java
@@ -30,17 +30,17 @@ public class AvroCompatibilityHelperProps111Test {
   public void testValidNonStrings() throws Exception {
     Schema schema = Schema.parse(TestUtil.load("PerfectlyNormalRecord.avsc"));
     for (int i = 0; i < JsonLiterals.NON_STRING_LITERALS.length; ++i) {
-    String name = "schema/" + i;
-    String literal = JsonLiterals.NON_STRING_LITERALS[i];
-    String value = JsonLiterals.NON_STRING_VALUES[i];
+      String name = "schema/" + i;
+      String literal = JsonLiterals.NON_STRING_LITERALS[i];
+      String value = JsonLiterals.NON_STRING_VALUES[i];
 
-    AvroCompatibilityHelper.setSchemaPropFromJsonString(schema, name, literal, true);
-    JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
-    Assert.assertFalse(node.isTextual(), name);
-    Assert.assertEquals(node.toString(), value, name);
+      AvroCompatibilityHelper.setSchemaPropFromJsonString(schema, name, literal, true);
+      JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
+      Assert.assertFalse(node.isTextual(), name);
+      Assert.assertEquals(node.toString(), value, name);
 
-    String got = AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, name, false, false);
-    Assert.assertEquals(got, value, name);
+      String got = AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, name, false, false);
+      Assert.assertEquals(got, value, name);
     }
 
     // ----------------------------------------------------------------------------------------------
@@ -48,17 +48,17 @@ public class AvroCompatibilityHelperProps111Test {
 
     Schema.Field field = schema.getField("stringField");
     for (int i = 0; i < JsonLiterals.NON_STRING_LITERALS.length; ++i) {
-    String name = "field/" + i;
-    String literal = JsonLiterals.NON_STRING_LITERALS[i];
-    String value = JsonLiterals.NON_STRING_VALUES[i];
+      String name = "field/" + i;
+      String literal = JsonLiterals.NON_STRING_LITERALS[i];
+      String value = JsonLiterals.NON_STRING_VALUES[i];
 
-    AvroCompatibilityHelper.setFieldPropFromJsonString(field, name, literal, true);
-    JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
-    Assert.assertFalse(node.isTextual(), name);
-    Assert.assertEquals(node.toString(), value, name);
+      AvroCompatibilityHelper.setFieldPropFromJsonString(field, name, literal, true);
+      JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
+      Assert.assertFalse(node.isTextual(), name);
+      Assert.assertEquals(node.toString(), value, name);
 
-    String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
-    Assert.assertEquals(got, value, name);
+      String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
+      Assert.assertEquals(got, value, name);
     }
   }
 
@@ -66,13 +66,13 @@ public class AvroCompatibilityHelperProps111Test {
   public void testSchemaPropNames() throws Exception {
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     List<String> want = Arrays.asList(new String[]{
-    "schemaBoolProp",
-    "schemaFloatProp",
-    "schemaIntProp",
-    "schemaNestedJsonProp",
-    "schemaNullProp",
-    "schemaObjectProp",
-    "schemaStringProp",
+      "schemaBoolProp",
+      "schemaFloatProp",
+      "schemaIntProp",
+      "schemaNestedJsonProp",
+      "schemaNullProp",
+      "schemaObjectProp",
+      "schemaStringProp",
     });
     List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
     Collections.sort(got);
@@ -83,13 +83,13 @@ public class AvroCompatibilityHelperProps111Test {
   public void testFieldPropNames() throws Exception {
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     List<String> want = Arrays.asList(new String[]{
-    "boolProp",
-    "floatProp",
-    "intProp",
-    "nestedJsonProp",
-    "nullProp",
-    "objectProp",
-    "stringProp",
+      "boolProp",
+      "floatProp",
+      "intProp",
+      "nestedJsonProp",
+      "nullProp",
+      "objectProp",
+      "stringProp",
     });
     List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
     Collections.sort(got);

--- a/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/AvroCompatibilityHelperProps111Test.java
+++ b/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/AvroCompatibilityHelperProps111Test.java
@@ -4,7 +4,7 @@
  * See License in the project root for license information.
  */
 
-package com.linkedin.avroutil1.compatibility.avro110;
+package com.linkedin.avroutil1.compatibility.avro111;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
@@ -24,24 +24,23 @@ import org.testng.annotations.Test;
 /**
  * tests props-related methods on the {@link AvroCompatibilityHelper} class
  */
-
-public class AvroCompatibilityHelperProps110Test {
+public class AvroCompatibilityHelperProps111Test {
 
   @Test
   public void testValidNonStrings() throws Exception {
     Schema schema = Schema.parse(TestUtil.load("PerfectlyNormalRecord.avsc"));
     for (int i = 0; i < JsonLiterals.NON_STRING_LITERALS.length; ++i) {
-      String name = "schema/" + i;
-      String literal = JsonLiterals.NON_STRING_LITERALS[i];
-      String value = JsonLiterals.NON_STRING_VALUES[i];
+    String name = "schema/" + i;
+    String literal = JsonLiterals.NON_STRING_LITERALS[i];
+    String value = JsonLiterals.NON_STRING_VALUES[i];
 
-      AvroCompatibilityHelper.setSchemaPropFromJsonString(schema, name, literal, true);
-      JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
-      Assert.assertFalse(node.isTextual(), name);
-      Assert.assertEquals(node.toString(), value, name);
+    AvroCompatibilityHelper.setSchemaPropFromJsonString(schema, name, literal, true);
+    JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
+    Assert.assertFalse(node.isTextual(), name);
+    Assert.assertEquals(node.toString(), value, name);
 
-      String got = AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, name, false, false);
-      Assert.assertEquals(got, value, name);
+    String got = AvroCompatibilityHelper.getSchemaPropAsJsonString(schema, name, false, false);
+    Assert.assertEquals(got, value, name);
     }
 
     // ----------------------------------------------------------------------------------------------
@@ -49,17 +48,17 @@ public class AvroCompatibilityHelperProps110Test {
 
     Schema.Field field = schema.getField("stringField");
     for (int i = 0; i < JsonLiterals.NON_STRING_LITERALS.length; ++i) {
-      String name = "field/" + i;
-      String literal = JsonLiterals.NON_STRING_LITERALS[i];
-      String value = JsonLiterals.NON_STRING_VALUES[i];
+    String name = "field/" + i;
+    String literal = JsonLiterals.NON_STRING_LITERALS[i];
+    String value = JsonLiterals.NON_STRING_VALUES[i];
 
-      AvroCompatibilityHelper.setFieldPropFromJsonString(field, name, literal, true);
-      JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
-      Assert.assertFalse(node.isTextual(), name);
-      Assert.assertEquals(node.toString(), value, name);
+    AvroCompatibilityHelper.setFieldPropFromJsonString(field, name, literal, true);
+    JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
+    Assert.assertFalse(node.isTextual(), name);
+    Assert.assertEquals(node.toString(), value, name);
 
-      String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
-      Assert.assertEquals(got, value, name);
+    String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
+    Assert.assertEquals(got, value, name);
     }
   }
 
@@ -67,13 +66,13 @@ public class AvroCompatibilityHelperProps110Test {
   public void testSchemaPropNames() throws Exception {
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     List<String> want = Arrays.asList(new String[]{
-      "schemaBoolProp",
-      "schemaFloatProp",
-      "schemaIntProp",
-      "schemaNestedJsonProp",
-      "schemaNullProp",
-      "schemaObjectProp",
-      "schemaStringProp",
+    "schemaBoolProp",
+    "schemaFloatProp",
+    "schemaIntProp",
+    "schemaNestedJsonProp",
+    "schemaNullProp",
+    "schemaObjectProp",
+    "schemaStringProp",
     });
     List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
     Collections.sort(got);
@@ -84,13 +83,13 @@ public class AvroCompatibilityHelperProps110Test {
   public void testFieldPropNames() throws Exception {
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     List<String> want = Arrays.asList(new String[]{
-      "boolProp",
-      "floatProp",
-      "intProp",
-      "nestedJsonProp",
-      "nullProp",
-      "objectProp",
-      "stringProp",
+    "boolProp",
+    "floatProp",
+    "intProp",
+    "nestedJsonProp",
+    "nullProp",
+    "objectProp",
+    "stringProp",
     });
     List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
     Collections.sort(got);

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/AvroCompatibilityHelperProps14Test.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/AvroCompatibilityHelperProps14Test.java
@@ -9,6 +9,11 @@ package com.linkedin.avroutil1.compatibility.avro14;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.testcommon.JsonLiterals;
 import com.linkedin.avroutil1.testcommon.TestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -57,5 +62,29 @@ public class AvroCompatibilityHelperProps14Test {
       String got = field.getProp(name);
       Assert.assertEquals(got, value, name);
     }
+  }
+
+  @Test
+  public void testSchemaPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "schemaNestedJsonProp",
+      "schemaStringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
+  }
+
+  @Test
+  public void testFieldPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "nestedJsonProp",
+      "stringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
   }
 }

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/AvroCompatibilityHelperProps16Test.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/AvroCompatibilityHelperProps16Test.java
@@ -9,6 +9,11 @@ package com.linkedin.avroutil1.compatibility.avro16;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.testcommon.JsonLiterals;
 import com.linkedin.avroutil1.testcommon.TestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -57,5 +62,29 @@ public class AvroCompatibilityHelperProps16Test {
       String got = field.getProp(name);
       Assert.assertEquals(got, value, name);
     }
+  }
+
+  @Test
+  public void testSchemaPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "schemaNestedJsonProp",
+      "schemaStringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
+  }
+
+  @Test
+  public void testFieldPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "nestedJsonProp",
+      "stringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
   }
 }

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperProps17Test.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/AvroCompatibilityHelperProps17Test.java
@@ -9,6 +9,11 @@ package com.linkedin.avroutil1.compatibility.avro17;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.testcommon.JsonLiterals;
 import com.linkedin.avroutil1.testcommon.TestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonNode;
 import org.testng.Assert;
@@ -54,5 +59,39 @@ public class AvroCompatibilityHelperProps17Test {
       String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
       Assert.assertEquals(got, value, name);
     }
+  }
+
+  @Test
+  public void testSchemaPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "schemaBoolProp",
+      "schemaFloatProp",
+      "schemaIntProp",
+      "schemaNestedJsonProp",
+      "schemaNullProp",
+      "schemaObjectProp",
+      "schemaStringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
+  }
+
+  @Test
+  public void testFieldPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "boolProp",
+      "floatProp",
+      "intProp",
+      "nestedJsonProp",
+      "nullProp",
+      "objectProp",
+      "stringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
   }
 }

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/AvroCompatibilityHelperProps18Test.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/AvroCompatibilityHelperProps18Test.java
@@ -9,6 +9,11 @@ package com.linkedin.avroutil1.compatibility.avro18;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.testcommon.JsonLiterals;
 import com.linkedin.avroutil1.testcommon.TestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonNode;
 import org.testng.Assert;
@@ -54,5 +59,39 @@ public class AvroCompatibilityHelperProps18Test {
       String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
       Assert.assertEquals(got, value, name);
     }
+  }
+
+  @Test
+  public void testSchemaPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "schemaBoolProp",
+      "schemaFloatProp",
+      "schemaIntProp",
+      "schemaNestedJsonProp",
+      "schemaNullProp",
+      "schemaObjectProp",
+      "schemaStringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
+  }
+
+  @Test
+  public void testFieldPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "boolProp",
+      "floatProp",
+      "intProp",
+      "nestedJsonProp",
+      "nullProp",
+      "objectProp",
+      "stringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
   }
 }

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/AvroCompatibilityHelperProps19Test.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/AvroCompatibilityHelperProps19Test.java
@@ -10,6 +10,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.testcommon.JsonLiterals;
 import com.linkedin.avroutil1.testcommon.TestUtil;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.apache.avro.util.internal.JacksonUtils;
 import org.testng.Assert;
@@ -55,5 +60,39 @@ public class AvroCompatibilityHelperProps19Test {
       String got = AvroCompatibilityHelper.getFieldPropAsJsonString(field, name, false, false);
       Assert.assertEquals(got, value, name);
     }
+  }
+
+  @Test
+  public void testSchemaPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "schemaBoolProp",
+      "schemaFloatProp",
+      "schemaIntProp",
+      "schemaNestedJsonProp",
+      "schemaNullProp",
+      "schemaObjectProp",
+      "schemaStringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema);
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
+  }
+
+  @Test
+  public void testFieldPropNames() throws Exception {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    List<String> want = Arrays.asList(new String[]{
+      "boolProp",
+      "floatProp",
+      "intProp",
+      "nestedJsonProp",
+      "nullProp",
+      "objectProp",
+      "stringProp",
+    });
+    List<String> got = AvroCompatibilityHelper.getAllPropNames(schema.getField("stringField"));
+    Collections.sort(got);
+    Assert.assertEquals(got, want);
   }
 }


### PR DESCRIPTION
Fixes #389.
