### PR TITLE
adds import from classpath functionality to AvroUtilCodeGenOp

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -224,12 +223,11 @@ public class SchemaBuilder {
   private static List<BuilderPlugin> loadPlugins(@SuppressWarnings("SameParameterValue") int currentApiVersion) {
     List<BuilderPlugin> plugins = new ArrayList<>(1);
     ServiceLoader<BuilderPlugin> loader = ServiceLoader.load(BuilderPlugin.class);
-    Iterator<BuilderPlugin> iterator = loader.iterator();
-    while (iterator.hasNext()) {
-      BuilderPlugin plugin = iterator.next();
+    for (BuilderPlugin plugin : loader) {
       Set<Integer> pluginSupportedVersions = plugin.supportedApiVersions();
       if (!pluginSupportedVersions.contains(currentApiVersion)) {
-        System.err.println("plugin " + plugin.name() + " does not support current API version " + currentApiVersion + " and will not be loaded");
+        System.err.println("plugin " + plugin.name() + " does not support current API version " + currentApiVersion
+            + " and will not be loaded");
         continue;
       }
       plugins.add(plugin);

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -10,9 +10,13 @@ import com.linkedin.avroutil1.builder.BuilderConsts;
 import com.linkedin.avroutil1.builder.operations.Operation;
 import com.linkedin.avroutil1.builder.operations.OperationContext;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
+import com.linkedin.avroutil1.builder.operations.codegen.vanilla.ClasspathSchemaSet;
 import com.linkedin.avroutil1.codegen.SpecificRecordClassGenerator;
 import com.linkedin.avroutil1.codegen.SpecificRecordGenerationConfig;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.model.AvroNamedSchema;
+import com.linkedin.avroutil1.model.SchemaOrRef;
 import com.linkedin.avroutil1.parser.avsc.AvroParseContext;
 import com.linkedin.avroutil1.parser.avsc.AvscParseResult;
 import com.linkedin.avroutil1.parser.avsc.AvscParser;
@@ -31,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import javax.tools.JavaFileObject;
+import org.apache.avro.Schema;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -89,8 +94,14 @@ public class AvroUtilCodeGenOp implements Operation {
     AvroParseContext context = new AvroParseContext();
     Set<AvscParseResult> parsedFiles = new HashSet<>();
 
-    parsedFiles.addAll(parseAvscFiles(avscFiles, true, context));
-    parsedFiles.addAll(parseAvscFiles(nonImportableFiles, false, context));
+    HashSet<String> visitedSchemas = new HashSet<>();
+    //build a classpath SchemaSet if classpath (cp) lookup is turned on
+    ClasspathSchemaSet cpLookup = null;
+    if (config.isIncludeClasspath()) {
+      cpLookup = new ClasspathSchemaSet();
+    }
+    parsedFiles.addAll(parseAvscFiles(avscFiles, true, context, cpLookup, visitedSchemas));
+    parsedFiles.addAll(parseAvscFiles(nonImportableFiles, false, context, cpLookup, visitedSchemas));
 
     //resolve any references across files that are part of this op (anything left would be external)
     context.resolveReferences();
@@ -204,10 +215,12 @@ public class AvroUtilCodeGenOp implements Operation {
    * @param avscFiles Avsc files to parse
    * @param areFilesImportable whether to allow other avsc files to import from this avsc file
    * @param context the full parsing context for this "run".
+   * @param cpLookup
+   * @param visitedSchemas
    * @return a set of all the parsed file results (a Set of AvscParseResult)
    */
-  private Set<AvscParseResult> parseAvscFiles(Set<File> avscFiles, boolean areFilesImportable,
-      AvroParseContext context) {
+  private Set<AvscParseResult> parseAvscFiles(Set<File> avscFiles, boolean areFilesImportable, AvroParseContext context,
+      ClasspathSchemaSet cpLookup, HashSet<String> visitedSchemas) {
     AvscParser parser = new AvscParser();
     HashSet<AvscParseResult> parsedFiles = new HashSet<>();
     for (File p : avscFiles) {
@@ -215,6 +228,32 @@ public class AvroUtilCodeGenOp implements Operation {
       Throwable parseError = fileParseResult.getParseError();
       if (parseError != null) {
         throw new IllegalArgumentException("failed to parse file " + p.getAbsolutePath(), parseError);
+      }
+      if (fileParseResult.getTopLevelSchema() instanceof AvroNamedSchema) {
+        String fullname = ((AvroNamedSchema) fileParseResult.getTopLevelSchema()).getFullName();
+        visitedSchemas.add(fullname);
+      }
+      // Lookup unresolved schemas in classpath
+      for (SchemaOrRef externalReference : fileParseResult.getExternalReferences()) {
+        String ref = externalReference.getRef();
+        String inheritedRef = externalReference.getInheritedName();
+        if (ref != null && !ref.isEmpty() && !visitedSchemas.contains(ref)) {
+          Schema referencedSchema = cpLookup.getByName(ref);
+          if (referencedSchema != null) {
+            AvscParseResult referencedParseResult =
+                parser.parse(AvroCompatibilityHelper.toAvsc(referencedSchema, AvscGenerationConfig.CORRECT_PRETTY));
+            context.add(referencedParseResult);
+            visitedSchemas.add(ref);
+          }
+        } else if (inheritedRef != null && !inheritedRef.isEmpty() && !visitedSchemas.contains(inheritedRef)) {
+          Schema referencedSchema = cpLookup.getByName(inheritedRef);
+          if (referencedSchema != null) {
+            AvscParseResult referencedParseResult =
+                parser.parse(AvroCompatibilityHelper.toAvsc(referencedSchema, AvscGenerationConfig.CORRECT_PRETTY));
+            context.add(referencedParseResult);
+            visitedSchemas.add(ref);
+          }
+        }
       }
       context.add(fileParseResult, areFilesImportable);
       parsedFiles.add(fileParseResult);

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/ClasspathSchemaSet.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/ClasspathSchemaSet.java
@@ -30,7 +30,7 @@ public class ClasspathSchemaSet implements SchemaSet {
 
   /**
    * @param name FQCN of a schema (so "com.acme.Foo")
-   * @return the schema, if an vro-generated class of the given name was found on the classpath
+   * @return the schema, if an avro-generated class of the given name was found on the classpath
    */
   @Override
   public synchronized Schema getByName(String name) {

--- a/avro-builder/builder/src/test/java/build/generated/SimpleRecord.java
+++ b/avro-builder/builder/src/test/java/build/generated/SimpleRecord.java
@@ -1,3 +1,6 @@
+// Specific Record used in com.linkedin.avroutil1.builder.SchemaBuilderTest in order to
+// test classpath imports. See SchemaBuilderTest#testWithImportsFromClasspath()
+
 package build.generated;
 
 import org.apache.avro.generic.GenericArray;

--- a/avro-builder/builder/src/test/java/build/generated/SimpleRecord.java
+++ b/avro-builder/builder/src/test/java/build/generated/SimpleRecord.java
@@ -1,6 +1,8 @@
-package simpleproject;
+package build.generated;
 
+import org.apache.avro.generic.GenericArray;
 import org.apache.avro.specific.SpecificData;
+import org.apache.avro.util.Utf8;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 
 
@@ -9,8 +11,8 @@ import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 
 
 public class SimpleRecord extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
-  private static final long serialVersionUID = 982161213722345332L;
-  public static final org.apache.avro.Schema SCHEMA$ = AvroCompatibilityHelper.parse("{\"type\":\"record\",\"name\":\"SimpleRecord\",\"namespace\":\"simpleproject\",\"fields\":[{\"name\":\"f\",\"type\":\"int\"}]}");
+  private static final long serialVersionUID = -1889173190812654313L;
+  public static final org.apache.avro.Schema SCHEMA$ = AvroCompatibilityHelper.parse("{\"type\":\"record\",\"name\":\"SimpleRecord\",\"namespace\":\"build.generated\",\"fields\":[{\"name\":\"f\",\"type\":\"int\"}]}");
   public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
 
   private static final org.apache.avro.specific.SpecificData MODEL$ = SpecificData.get();

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -96,6 +96,28 @@ public class SchemaBuilderTest {
     });
   }
 
+  @Test
+  public void testWithImportsFromClasspath() throws Exception {
+    File simpleProjectRoot = new File(locateTestProjectsRoot(), "classpath-project");
+    File inputFolder = new File(simpleProjectRoot, "input");
+    File outputFolder = new File(simpleProjectRoot, "output");
+    if (outputFolder.exists()) { //clear output
+      FileUtils.deleteDirectory(outputFolder);
+    }
+    //run the builder
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath(),
+        "--generator", CodeGenerator.AVRO_UTIL.name(),
+        "--includeClasspath", Boolean.toString(true)
+    });
+    //see output was generated
+    List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
+        (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
+    ).collect(Collectors.toList());
+    Assert.assertEquals(javaFiles.size(), 1);
+  }
+
 
   @Test
   public void testImportableSchemasUsingOwnCodegen() throws Exception {

--- a/avro-builder/builder/src/test/java/simpleproject/SimpleRecord.java
+++ b/avro-builder/builder/src/test/java/simpleproject/SimpleRecord.java
@@ -1,0 +1,104 @@
+package simpleproject;
+
+import org.apache.avro.specific.SpecificData;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+
+
+
+
+
+
+public class SimpleRecord extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+  private static final long serialVersionUID = 982161213722345332L;
+  public static final org.apache.avro.Schema SCHEMA$ = AvroCompatibilityHelper.parse("{\"type\":\"record\",\"name\":\"SimpleRecord\",\"namespace\":\"simpleproject\",\"fields\":[{\"name\":\"f\",\"type\":\"int\"}]}");
+  public static org.apache.avro.Schema getClassSchema() { return SCHEMA$; }
+
+  private static final org.apache.avro.specific.SpecificData MODEL$ = SpecificData.get();
+
+
+
+  public int f;
+
+  /**
+   * Default constructor.  Note that this does not initialize fields
+   * to their default values from the schema.  If that is desired then
+   * one should use <code>newBuilder()</code>.
+   */
+  public SimpleRecord() {}
+
+  /**
+   * All-args constructor.
+   * @param f The new value for f
+   */
+  public SimpleRecord(java.lang.Integer f) {
+    this.f = f;
+  }
+
+  public org.apache.avro.specific.SpecificData getSpecificData() { return MODEL$; }
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
+  // Used by DatumWriter.  Applications should not call.
+  public java.lang.Object get(int field$) {
+    switch (field$) {
+      case 0: return f;
+      default: throw new org.apache.avro.AvroRuntimeException("Bad index");
+    }
+  }
+
+  // Used by DatumReader.  Applications should not call.
+  @SuppressWarnings(value="unchecked")
+  public void put(int field$, java.lang.Object value$) {
+    switch (field$) {
+      case 0: f = (java.lang.Integer)value$; break;
+      default: throw new org.apache.avro.AvroRuntimeException("Bad index");
+    }
+  }
+
+  /**
+   * Gets the value of the 'f' field.
+   * @return The value of the 'f' field.
+   */
+  public int getF() {
+    return f;
+  }
+
+
+  /**
+   * Sets the value of the 'f' field.
+   * @param value the value to set.
+   */
+  public void setF(int value) {
+    this.f = value;
+  }
+
+
+
+  @SuppressWarnings("unchecked")
+  private static final org.apache.avro.io.DatumWriter<SimpleRecord>
+      WRITER$ = new org.apache.avro.specific.SpecificDatumWriter<>(SCHEMA$);
+
+  public void writeExternal(java.io.ObjectOutput out)
+      throws java.io.IOException {
+    WRITER$.write(this, AvroCompatibilityHelper.newBinaryEncoder(out));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static final org.apache.avro.io.DatumReader<SimpleRecord>
+      READER$ = new org.apache.avro.specific.SpecificDatumReader<>(SCHEMA$);
+
+  public void readExternal(java.io.ObjectInput in)
+      throws java.io.IOException {
+    READER$.read(this, AvroCompatibilityHelper.newBinaryDecoder(in));
+  }
+
+
+}
+
+
+
+
+
+
+
+
+
+

--- a/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
@@ -6,7 +6,7 @@
   "fields": [
     {
       "name": "date",
-      "type": "simpleproject.SimpleRecord"
+      "type": "build.generated.SimpleRecord"
     }
   ]
 }

--- a/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "SchemaWithClasspathImport",
+  "namespace": "com.linkedin.test",
+  "doc": "This is a test schema with a reference to a schema on the classpath",
+  "fields": [
+    {
+      "name": "date",
+      "type": "com.linkedin.events.common.Date"
+    }
+  ]
+}

--- a/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
@@ -6,7 +6,7 @@
   "fields": [
     {
       "name": "date",
-      "type": "com.linkedin.events.common.Date"
+      "type": "simpleproject.SimpleRecord"
     }
   ]
 }


### PR DESCRIPTION
supports `--includeClasspath` flag. When resolving references, unresolved schemas will be searched for on the classpath. Some changes were needed to codegen setup in order to not generate `.java` specific records for classpath files.

One option, if deemed fit, would be to move the import from classpath functionality into `AvroParseContext`. However, since this functionality is not part of org.apache.avro, it is probably best to keep it separate.

unit tests added as well