### PR TITLE
Fix cached builder instance generation.

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
@@ -904,8 +904,14 @@ public class CodeTransformations {
     // of the cached instance may try to look up those fields.
     int insertPosition = code.indexOf(MODEL_DECL_REPLACEMENT);
     if (insertPosition < 0) {
-      // This must be because the max targeted Avro version is <= 1.8, which doesn't use MODEL$. Use SCHEMA$ instead.
-      insertPosition = findEndOfSchemaDeclaration(code);
+      // Perhaps the MODEL$ definition was NOT transformed, for whatever reason. Look for the original definition.
+      Matcher modelMatcher = MODEL_DECL_PATTERN.matcher(code);
+      if (modelMatcher.find()) {
+        insertPosition = modelMatcher.end();
+      } else {
+        // This must be because the max targeted Avro version is <= 1.8, which doesn't use MODEL$. Use SCHEMA$ instead.
+        insertPosition = findEndOfSchemaDeclaration(code);
+      }
     } else {
       insertPosition += MODEL_DECL_REPLACEMENT.length();
     }

--- a/helper/tests/codegen-110/build.gradle
+++ b/helper/tests/codegen-110/build.gradle
@@ -26,6 +26,7 @@ sourceSets {
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -85,6 +86,25 @@ task runCompatAvroCodegenWithBuilders {
   }
 }
 
+task runCompatAvroCodegenWithBuildersMinAvro18 {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main",
+                "-min", "AVRO_1_8"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -109,8 +129,9 @@ jar {
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
 runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuildersMinAvro18.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, copyCompatAvroCodeToResources
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, runCompatAvroCodegenWithBuildersMinAvro18, copyCompatAvroCodeToResources
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-110/src/main/compat-avro-w-builders-min-avro18/under110wbuildersmin18/NormalRecordWithoutReferences.avsc
+++ b/helper/tests/codegen-110/src/main/compat-avro-w-builders-min-avro18/under110wbuildersmin18/NormalRecordWithoutReferences.avsc
@@ -1,0 +1,81 @@
+{
+  "type": "record",
+  "namespace": "under110wbuildersmin18",
+  "name": "NormalRecordWithoutReferences",
+  "fields": [
+    {
+      "name": "nullWithoutDefault",
+      "type": "null"
+    },
+    {
+      "name": "nullField",
+      "type": "null",
+      "default": null
+    },
+    {
+      "name": "boolWithoutDefault",
+      "type": "boolean"
+    },
+    {
+      "name": "boolField",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "intField",
+      "type": "int",
+      "default": 1
+    },
+    {
+      "name": "doubleField",
+      "type": "double",
+      "default": 4.0
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "default"
+    },
+    {
+      "name": "strWithoutDefault",
+      "type": "string"
+    },
+    {
+      "name": "arrayField",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": [
+        "bla", "bla"
+      ]
+    },
+    {
+      "name": "mapField",
+      "type": {
+        "type": "map",
+        "values": "float"
+      },
+      "default": {
+      }
+    },
+    {
+      "name": "unionWithNullDefault",
+      "type": ["null", "double"],
+      "default": null
+    },
+    {
+      "name": "unionWithNullNoDefault",
+      "type": ["null", "double"]
+    },
+    {
+      "name": "unionWithDoubleDefault",
+      "type": ["double", "null"],
+      "default": 2.6
+    },
+    {
+      "name": "unionWithDoubleNoDefault",
+      "type": ["double", "null"]
+    }
+  ]
+}

--- a/helper/tests/codegen-111/build.gradle
+++ b/helper/tests/codegen-111/build.gradle
@@ -26,6 +26,7 @@ sourceSets {
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -85,6 +86,25 @@ task runCompatAvroCodegenWithBuilders {
   }
 }
 
+task runCompatAvroCodegenWithBuildersMinAvro18 {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main",
+                "-min", "AVRO_1_8"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -109,8 +129,9 @@ jar {
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
 runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuildersMinAvro18.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, copyCompatAvroCodeToResources
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, runCompatAvroCodegenWithBuildersMinAvro18, copyCompatAvroCodeToResources
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-111/src/main/compat-avro-w-builders-min-avro18/under111wbuildersmin18/NormalRecordWithoutReferences.avsc
+++ b/helper/tests/codegen-111/src/main/compat-avro-w-builders-min-avro18/under111wbuildersmin18/NormalRecordWithoutReferences.avsc
@@ -1,0 +1,81 @@
+{
+  "type": "record",
+  "namespace": "under111wbuildersmin18",
+  "name": "NormalRecordWithoutReferences",
+  "fields": [
+    {
+      "name": "nullWithoutDefault",
+      "type": "null"
+    },
+    {
+      "name": "nullField",
+      "type": "null",
+      "default": null
+    },
+    {
+      "name": "boolWithoutDefault",
+      "type": "boolean"
+    },
+    {
+      "name": "boolField",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "intField",
+      "type": "int",
+      "default": 1
+    },
+    {
+      "name": "doubleField",
+      "type": "double",
+      "default": 4.0
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "default"
+    },
+    {
+      "name": "strWithoutDefault",
+      "type": "string"
+    },
+    {
+      "name": "arrayField",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": [
+        "bla", "bla"
+      ]
+    },
+    {
+      "name": "mapField",
+      "type": {
+        "type": "map",
+        "values": "float"
+      },
+      "default": {
+      }
+    },
+    {
+      "name": "unionWithNullDefault",
+      "type": ["null", "double"],
+      "default": null
+    },
+    {
+      "name": "unionWithNullNoDefault",
+      "type": ["null", "double"]
+    },
+    {
+      "name": "unionWithDoubleDefault",
+      "type": ["double", "null"],
+      "default": 2.6
+    },
+    {
+      "name": "unionWithDoubleNoDefault",
+      "type": ["double", "null"]
+    }
+  ]
+}

--- a/helper/tests/codegen-18/build.gradle
+++ b/helper/tests/codegen-18/build.gradle
@@ -26,6 +26,7 @@ sourceSets {
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -84,6 +85,25 @@ task runCompatAvroCodegenWithBuilders {
   }
 }
 
+task runCompatAvroCodegenWithBuildersMinAvro18 {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main",
+                "-min", "AVRO_1_8"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -108,8 +128,9 @@ jar {
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
 runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuildersMinAvro18.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, runCompatAvroCodegenWithBuildersMinAvro18
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-18/src/main/compat-avro-w-builders-min-avro18/under18wbuildersmin18/NormalRecordWithoutReferences.avsc
+++ b/helper/tests/codegen-18/src/main/compat-avro-w-builders-min-avro18/under18wbuildersmin18/NormalRecordWithoutReferences.avsc
@@ -1,0 +1,81 @@
+{
+  "type": "record",
+  "namespace": "under18wbuildersmin18",
+  "name": "NormalRecordWithoutReferences",
+  "fields": [
+    {
+      "name": "nullWithoutDefault",
+      "type": "null"
+    },
+    {
+      "name": "nullField",
+      "type": "null",
+      "default": null
+    },
+    {
+      "name": "boolWithoutDefault",
+      "type": "boolean"
+    },
+    {
+      "name": "boolField",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "intField",
+      "type": "int",
+      "default": 1
+    },
+    {
+      "name": "doubleField",
+      "type": "double",
+      "default": 4.0
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "default"
+    },
+    {
+      "name": "strWithoutDefault",
+      "type": "string"
+    },
+    {
+      "name": "arrayField",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": [
+        "bla", "bla"
+      ]
+    },
+    {
+      "name": "mapField",
+      "type": {
+        "type": "map",
+        "values": "float"
+      },
+      "default": {
+      }
+    },
+    {
+      "name": "unionWithNullDefault",
+      "type": ["null", "double"],
+      "default": null
+    },
+    {
+      "name": "unionWithNullNoDefault",
+      "type": ["null", "double"]
+    },
+    {
+      "name": "unionWithDoubleDefault",
+      "type": ["double", "null"],
+      "default": 2.6
+    },
+    {
+      "name": "unionWithDoubleNoDefault",
+      "type": ["double", "null"]
+    }
+  ]
+}

--- a/helper/tests/codegen-19/build.gradle
+++ b/helper/tests/codegen-19/build.gradle
@@ -26,6 +26,7 @@ sourceSets {
       srcDir "$buildDir/generated/sources/raw-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro/java/main"
       srcDir "$buildDir/generated/sources/compat-avro-w-builders/java/main"
+      srcDir "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main"
     }
     resources {
       srcDirs = ["src/main/raw-avro", "src/main/compat-avro", "$buildDir/generated/resources"]
@@ -84,6 +85,25 @@ task runCompatAvroCodegenWithBuilders {
   }
 }
 
+task runCompatAvroCodegenWithBuildersMinAvro18 {
+  description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+  outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+  fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
+    doLast {
+      javaexec {
+        classpath configurations.codegen
+        main = 'com.linkedin.avroutil1.TestTool'
+        args = [
+                "-op", "compile",
+                "-in", file.getAbsolutePath(),
+                "-out", "$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main",
+                "-min", "AVRO_1_8"
+        ]
+      }
+    }
+  }
+}
+
 //copy output generated compatible code into resources so downstream modules can use it
 task copyCompatAvroCodeToResources(type: Copy) {
   from "$buildDir/generated/sources/compat-avro/java/main"
@@ -108,8 +128,9 @@ jar {
 //TODO - figure out why this must be done manually
 runCompatAvroCodegen.dependsOn ":helper:tests:helper-tests-common:jar"
 runCompatAvroCodegenWithBuilders.dependsOn ":helper:tests:helper-tests-common:jar"
+runCompatAvroCodegenWithBuildersMinAvro18.dependsOn ":helper:tests:helper-tests-common:jar"
 copyCompatAvroCodeToResources.dependsOn runCompatAvroCodegen
-compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, copyCompatAvroCodeToResources
+compileJava.dependsOn runVanillaAvroCodegen, runCompatAvroCodegen, runCompatAvroCodegenWithBuilders, runCompatAvroCodegenWithBuildersMinAvro18, copyCompatAvroCodeToResources
 jar.dependsOn runResourceGeneration
 
 dependencies {

--- a/helper/tests/codegen-19/src/main/compat-avro-w-builders-min-avro18/under19wbuildersmin18/NormalRecordWithoutReferences.avsc
+++ b/helper/tests/codegen-19/src/main/compat-avro-w-builders-min-avro18/under19wbuildersmin18/NormalRecordWithoutReferences.avsc
@@ -1,0 +1,81 @@
+{
+  "type": "record",
+  "namespace": "under19wbuildersmin18",
+  "name": "NormalRecordWithoutReferences",
+  "fields": [
+    {
+      "name": "nullWithoutDefault",
+      "type": "null"
+    },
+    {
+      "name": "nullField",
+      "type": "null",
+      "default": null
+    },
+    {
+      "name": "boolWithoutDefault",
+      "type": "boolean"
+    },
+    {
+      "name": "boolField",
+      "type": "boolean",
+      "default": true
+    },
+    {
+      "name": "intField",
+      "type": "int",
+      "default": 1
+    },
+    {
+      "name": "doubleField",
+      "type": "double",
+      "default": 4.0
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "default"
+    },
+    {
+      "name": "strWithoutDefault",
+      "type": "string"
+    },
+    {
+      "name": "arrayField",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "default": [
+        "bla", "bla"
+      ]
+    },
+    {
+      "name": "mapField",
+      "type": {
+        "type": "map",
+        "values": "float"
+      },
+      "default": {
+      }
+    },
+    {
+      "name": "unionWithNullDefault",
+      "type": ["null", "double"],
+      "default": null
+    },
+    {
+      "name": "unionWithNullNoDefault",
+      "type": ["null", "double"]
+    },
+    {
+      "name": "unionWithDoubleDefault",
+      "type": ["double", "null"],
+      "default": 2.6
+    },
+    {
+      "name": "unionWithDoubleNoDefault",
+      "type": ["double", "null"]
+    }
+  ]
+}

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CodeTransformationsAvro110Test.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CodeTransformationsAvro110Test.java
@@ -25,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.regex.Matcher;
 
+import under110wbuildersmin18.NormalRecordWithoutReferences;
+
 
 public class CodeTransformationsAvro110Test {
 
@@ -149,6 +151,11 @@ public class CodeTransformationsAvro110Test {
     Method customDecodeMethod = fixedClass.getMethod("customDecode", ResolvingDecoder.class);
     Assert.assertNotNull(customDecodeMethod);
     Assert.assertEquals(customDecodeMethod.getDeclaringClass().getName(), "org.apache.avro.specific.SpecificRecordBase"); //inherited default impl
+  }
+
+  @Test
+  public void testBuilders() throws Exception {
+    Assert.assertNotNull(NormalRecordWithoutReferences.newBuilder());
   }
 
   private String runNativeCodegen(Schema schema) throws Exception {

--- a/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/CodeTransformationsAvro111Test.java
+++ b/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/CodeTransformationsAvro111Test.java
@@ -25,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.regex.Matcher;
 
+import under111wbuildersmin18.NormalRecordWithoutReferences;
+
 
 public class CodeTransformationsAvro111Test {
 
@@ -76,6 +78,11 @@ public class CodeTransformationsAvro111Test {
     Method customDecodeMethod = fixedClass.getMethod("customDecode", ResolvingDecoder.class);
     Assert.assertNotNull(customDecodeMethod);
     Assert.assertEquals(customDecodeMethod.getDeclaringClass().getName(), "org.apache.avro.specific.SpecificRecordBase"); //inherited default impl
+  }
+
+  @Test
+  public void testBuilders() throws Exception {
+    Assert.assertNotNull(NormalRecordWithoutReferences.newBuilder());
   }
 
   private String runNativeCodegen(Schema schema) throws Exception {

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/CodeTransformationsAvro18Test.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/CodeTransformationsAvro18Test.java
@@ -23,6 +23,8 @@ import org.apache.commons.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import under18wbuildersmin18.NormalRecordWithoutReferences;
+
 
 public class CodeTransformationsAvro18Test {
 
@@ -49,6 +51,11 @@ public class CodeTransformationsAvro18Test {
 
     Class<?> transformedClass = CompilerUtils.CACHED_COMPILER.loadFromJava(schema.getFullName(), transformedCode);
     Assert.assertNotNull(transformedClass);
+  }
+
+  @Test
+  public void testBuilders() throws Exception {
+    Assert.assertNotNull(NormalRecordWithoutReferences.newBuilder());
   }
 
   private String runNativeCodegen(Schema schema) throws Exception {

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/CodeTransformationsAvro19Test.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/CodeTransformationsAvro19Test.java
@@ -25,6 +25,8 @@ import org.apache.commons.io.IOUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import under19wbuildersmin18.NormalRecordWithoutReferences;
+
 
 public class CodeTransformationsAvro19Test {
 
@@ -137,6 +139,11 @@ public class CodeTransformationsAvro19Test {
     Method customDecodeMethod = fixedClass.getMethod("customDecode", ResolvingDecoder.class);
     Assert.assertNotNull(customDecodeMethod);
     Assert.assertEquals(customDecodeMethod.getDeclaringClass().getName(), "org.apache.avro.specific.SpecificRecordBase"); //inherited default impl
+  }
+
+  @Test
+  public void testBuilders() throws Exception {
+    Assert.assertNotNull(NormalRecordWithoutReferences.newBuilder());
   }
 
   private String runNativeCodegen(Schema schema) throws Exception {


### PR DESCRIPTION
When performing CodeTransformations, we must ensure that we insert the cached
builder instance _after_ the MODEL$ definition. Fix one case where this wasn't
being done properly, viz., codegen with minAvroVer >= 1.8.

Without this fix, on susceptible cases, calling `new Builder()` is enough to
cause an NPE. Example:
```
java.lang.NullPointerException
	at under19wbuildersmin18.NormalRecordWithoutReferences$Builder.<init>(NormalRecordWithoutReferences.java:432)
	at under19wbuildersmin18.NormalRecordWithoutReferences$Builder.<init>(NormalRecordWithoutReferences.java:422)
	at under19wbuildersmin18.NormalRecordWithoutReferences$Builder.<init>(NormalRecordWithoutReferences.java:401)
	at under19wbuildersmin18.NormalRecordWithoutReferences.newBuilder(NormalRecordWithoutReferences.java:368)
	at com.linkedin.avroutil1.compatibility.avro19.CodeTransformationsAvro19Test.testBuilders(CodeTransformationsAvro19Test.java:146)
        ...
```

A couple of notes on the tests:
* Trying to test `newBuilder()` via reflection doesn't cause an NPE (not sure
  why). This is why the tests refer to the generated class directly by name, and
  don't follow the style of the existing tests in CodeTransformationsAvroNTest.
* Avro 1.8 runtime doesn't crash even without the fix. This is expected. The fix
  is a no-op in this case.
