### PR TITLE
Fix fast-serdese bug with enums inside of record unions

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133.java
@@ -1,0 +1,75 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+
+public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133
+    implements FastDeserializer<com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField>
+{
+
+    private final Schema readerSchema;
+
+    public UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_5893918162876115133_5893918162876115133(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+        throws IOException
+    {
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
+        if ((reuse)!= null) {
+            UnionOfRecordsWithSameNameEnumField = ((com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField)(reuse));
+        } else {
+            UnionOfRecordsWithSameNameEnumField = new com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+        } else {
+            if (unionIndex0 == 1) {
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
+            }
+        }
+        return UnionOfRecordsWithSameNameEnumField;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
+        if ((reuse)!= null) {
+            MyRecordV1 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV1)(reuse));
+        } else {
+            MyRecordV1 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV1();
+        }
+        MyRecordV1 .put(0, MyEnumV1 .values()[(decoder.readEnum())]);
+        return MyRecordV1;
+    }
+
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+        throws IOException
+    {
+        com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;
+        if ((reuse)!= null) {
+            MyRecordV2 = ((com.linkedin.avro.fastserde.generated.avro.MyRecordV2)(reuse));
+        } else {
+            MyRecordV2 = new com.linkedin.avro.fastserde.generated.avro.MyRecordV2();
+        }
+        MyRecordV2 .put(0, MyEnumV2 .values()[(decoder.readEnum())]);
+        return MyRecordV2;
+    }
+
+}

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/backport/ResolvingGrammarGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/backport/ResolvingGrammarGenerator.java
@@ -452,7 +452,11 @@ public class ResolvingGrammarGenerator extends ValidatingGrammarGenerator {
   }
 
   private static Symbol mkEnumAdjustWithDefault(Schema writer, Schema reader) {
-    Avro19Resolver.EnumAdjust e = (Avro19Resolver.EnumAdjust) Avro19Resolver.EnumAdjust.resolve(writer, reader, GenericData.get());
+    Avro19Resolver.Action a = Avro19Resolver.EnumAdjust.resolve(writer, reader, GenericData.get());
+    if (a instanceof Avro19Resolver.ErrorAction) {
+      return Symbol.error(a.toString());
+    }
+    Avro19Resolver.EnumAdjust e = (Avro19Resolver.EnumAdjust) a;
     Object[] adjs = new Object[e.adjustments.length];
     for (int i = 0; i < adjs.length; i++) {
       adjs[i] = (0 <= e.adjustments[i] ? new Integer(e.adjustments[i])

--- a/avro-fastserde/src/test/avro/unionOfRecordsWithSameNameEnumField.avsc
+++ b/avro-fastserde/src/test/avro/unionOfRecordsWithSameNameEnumField.avsc
@@ -1,0 +1,46 @@
+{
+  "type": "record",
+  "name": "UnionOfRecordsWithSameNameEnumField",
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "fields": [
+    {
+      "name": "unionField",
+      "type": [
+        {
+          "type": "record",
+          "name": "MyRecordV1",
+          "fields": [
+            {
+              "name": "enumField",
+              "type": {
+                "type": "enum",
+                "name": "MyEnumV1",
+                "symbols": [
+                  "VAL1",
+                  "VAL2"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "MyRecordV2",
+          "fields": [
+            {
+              "name": "enumField",
+              "type": {
+                "type": "enum",
+                "name": "MyEnumV2",
+                "symbols": [
+                  "VAL1",
+                  "VAL3"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGeneratorTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGeneratorTest.java
@@ -2,6 +2,8 @@ package com.linkedin.avro.fastserde;
 
 import com.linkedin.avro.fastserde.generated.avro.FullRecord;
 import com.linkedin.avro.fastserde.generated.avro.IntRecord;
+import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
+import com.linkedin.avro.fastserde.generated.avro.MyRecordV2;
 import com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord;
 import com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1;
 import com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2;
@@ -10,6 +12,7 @@ import com.linkedin.avro.fastserde.generated.avro.SubRecord;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avro.fastserde.generated.avro.TestRecord;
+import com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.io.File;
 import java.io.IOException;
@@ -800,6 +803,25 @@ public class FastSpecificDeserializerGeneratorTest {
       Assert.assertEquals(getField(((List<FullRecord>) getField(splitRecordTest1, "record3")).get(0), "field1"), new Utf8("test3"));
       Assert.assertEquals(getField(((List<FullRecord>) getField(splitRecordTest1, "record3")).get(0), "field2"), 3);
     }
+  }
+
+  @Test(groups = {"deserializationTest"}, dataProvider = "SlowFastDeserializer")
+  public void shouldReadUnionOfRecordFieldsWithSameEnumFieldName(Boolean whetherUseFastDeserializer) {
+    Schema writerSchema = UnionOfRecordsWithSameNameEnumField.SCHEMA$;
+
+    UnionOfRecordsWithSameNameEnumField testRecord = new UnionOfRecordsWithSameNameEnumField();
+    MyRecordV2 myRecord = new MyRecordV2();
+    setField(myRecord, "enumField", MyEnumV2.VAL3);
+    setField(testRecord, "unionField", myRecord);
+
+    UnionOfRecordsWithSameNameEnumField deserRecord = null;
+    if (whetherUseFastDeserializer) {
+      deserRecord = decodeRecordFast(writerSchema, writerSchema, specificDataAsDecoder(testRecord));
+    } else {
+      deserRecord = decodeRecordSlow(writerSchema, writerSchema, specificDataAsDecoder(testRecord));
+    }
+
+    Assert.assertEquals(getField((MyRecordV2) getField(deserRecord, "unionField"), "enumField"), MyEnumV2.VAL3);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
After upgrading our avro version to 1.9 from 1.4, we discovered that FastDeser generation started failing. I was able to recreate this failure with a simple unit test involving a union of two records that have the same field name, but different enum types. The exception we see is:

```
Caused by: java.lang.ClassCastException: class com.linkedin.avro.fastserde.backport.Avro19Resolver$ErrorAction cannot be cast to class com.linkedin.avro.fastserde.backport.Avro19Resolver$EnumAdjust (com.linkedin.avro.fastserde.backport.Avro19Resolver$ErrorAction and com.linkedin.avro.fastserde.backport.Avro19Resolver$EnumAdjust are in unnamed module of loader 'app')
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.mkEnumAdjustWithDefault(ResolvingGrammarGenerator.java:455)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.generate(ResolvingGrammarGenerator.java:102)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.resolveRecords(ResolvingGrammarGenerator.java:280)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.bestBranch(ResolvingGrammarGenerator.java:504)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.generate(ResolvingGrammarGenerator.java:173)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.resolveUnion(ResolvingGrammarGenerator.java:209)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.generate(ResolvingGrammarGenerator.java:124)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.resolveRecords(ResolvingGrammarGenerator.java:280)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.generate(ResolvingGrammarGenerator.java:122)
	at com.linkedin.avro.fastserde.backport.ResolvingGrammarGenerator.generate(ResolvingGrammarGenerator.java:52)
	at com.linkedin.avro.fastserde.FastDeserializerGenerator.generateDeserializer(FastDeserializerGenerator.java:100)
	... 52 more
```
Looking at the code, the `mkEnumAdjustWithDefault` function doesn't correctly ignore mismatched schema. And because the field names are the same, `bestBranch` incorrectly returns the first union type which then errors out when it tries to resolve the mismatched enum types. Instead, we should propagate the error Symbol so that `bestMatch` moves onto the next union type.

For testing, this PR include a unit test which fails before the changes in ResolvingGrammarGenerator and passes after.