### PR TITLE
move CP import logic to the end of parsing

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -110,10 +110,8 @@ public class AvroUtilCodeGenOp implements Operation {
         AvscParser parser = new AvscParser();
         String ref = externalReference.getRef();
         String inheritedRef = externalReference.getInheritedName();
-        boolean avroParseContextContainsRef = ref != null && !ref.isEmpty() && context.getAllNamedSchemas().containsKey(ref);
-        boolean avroParseContextContainsInheritedRef =
-            inheritedRef != null && !inheritedRef.isEmpty() && context.getAllNamedSchemas().containsKey(inheritedRef);
-        if (!avroParseContextContainsRef && !avroParseContextContainsInheritedRef && cpLookup != null) {
+        if (!context.getAllNamedSchemas().containsKey(inheritedRef) && !context.getAllNamedSchemas().containsKey(ref)
+            && cpLookup != null) {
           Schema referencedSchema = cpLookup.getByName(ref);
           if (referencedSchema != null) {
             AvscParseResult referencedParseResult =

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -96,14 +96,40 @@ public class AvroUtilCodeGenOp implements Operation {
     AvroParseContext context = new AvroParseContext();
     Set<AvscParseResult> parsedFiles = new HashSet<>();
 
-    HashSet<String> visitedSchemas = new HashSet<>();
     //build a classpath SchemaSet if classpath (cp) lookup is turned on
     ClasspathSchemaSet cpLookup = null;
     if (config.isIncludeClasspath()) {
       cpLookup = new ClasspathSchemaSet();
     }
-    parsedFiles.addAll(parseAvscFiles(avscFiles, true, context, cpLookup, visitedSchemas));
-    parsedFiles.addAll(parseAvscFiles(nonImportableFiles, false, context, cpLookup, visitedSchemas));
+    parsedFiles.addAll(parseAvscFiles(avscFiles, true, context));
+    parsedFiles.addAll(parseAvscFiles(nonImportableFiles, false, context));
+
+    // Lookup unresolved schemas in classpath
+    for (AvscParseResult parsedFile : parsedFiles) {
+      for (SchemaOrRef externalReference : parsedFile.getExternalReferences()) {
+        AvscParser parser = new AvscParser();
+        String ref = externalReference.getRef();
+        String inheritedRef = externalReference.getInheritedName();
+        boolean avroParseContextContainsRef = ref != null && !ref.isEmpty() && context.getAllNamedSchemas().containsKey(ref);
+        boolean avroParseContextContainsInheritedRef =
+            inheritedRef != null && !inheritedRef.isEmpty() && context.getAllNamedSchemas().containsKey(inheritedRef);
+        if (!avroParseContextContainsRef && !avroParseContextContainsInheritedRef && cpLookup != null) {
+          Schema referencedSchema = cpLookup.getByName(ref);
+          if (referencedSchema != null) {
+            AvscParseResult referencedParseResult =
+                parser.parse(AvroCompatibilityHelper.toAvsc(referencedSchema, AvscGenerationConfig.CORRECT_PRETTY));
+            context.add(referencedParseResult, true);
+          } else {
+            Schema inheritedReferencedSchema = cpLookup.getByName(inheritedRef);
+            if (inheritedReferencedSchema != null) {
+              AvscParseResult referencedParseResult = parser.parse(
+                  AvroCompatibilityHelper.toAvsc(inheritedReferencedSchema, AvscGenerationConfig.CORRECT_PRETTY));
+              context.add(referencedParseResult, true);
+            }
+          }
+        }
+      }
+    }
 
     //resolve any references across files that are part of this op (anything left would be external)
     context.resolveReferences();
@@ -228,12 +254,9 @@ public class AvroUtilCodeGenOp implements Operation {
    * @param avscFiles Avsc files to parse
    * @param areFilesImportable whether to allow other avsc files to import from this avsc file
    * @param context the full parsing context for this "run".
-   * @param cpLookup
-   * @param visitedSchemas
    * @return a set of all the parsed file results (a Set of AvscParseResult)
    */
-  private Set<AvscParseResult> parseAvscFiles(Set<File> avscFiles, boolean areFilesImportable, AvroParseContext context,
-      ClasspathSchemaSet cpLookup, HashSet<String> visitedSchemas) {
+  private Set<AvscParseResult> parseAvscFiles(Set<File> avscFiles, boolean areFilesImportable, AvroParseContext context) {
     AvscParser parser = new AvscParser();
     HashSet<AvscParseResult> parsedFiles = new HashSet<>();
     for (File p : avscFiles) {
@@ -242,32 +265,7 @@ public class AvroUtilCodeGenOp implements Operation {
       if (parseError != null) {
         throw new IllegalArgumentException("failed to parse file " + p.getAbsolutePath(), parseError);
       }
-      if (fileParseResult.getTopLevelSchema() instanceof AvroNamedSchema) {
-        String fullname = ((AvroNamedSchema) fileParseResult.getTopLevelSchema()).getFullName();
-        visitedSchemas.add(fullname);
-      }
-      // Lookup unresolved schemas in classpath
-      for (SchemaOrRef externalReference : fileParseResult.getExternalReferences()) {
-        String ref = externalReference.getRef();
-        String inheritedRef = externalReference.getInheritedName();
-        if (ref != null && !ref.isEmpty() && !visitedSchemas.contains(ref)) {
-          Schema referencedSchema = cpLookup.getByName(ref);
-          if (referencedSchema != null) {
-            AvscParseResult referencedParseResult =
-                parser.parse(AvroCompatibilityHelper.toAvsc(referencedSchema, AvscGenerationConfig.CORRECT_PRETTY));
-            context.add(referencedParseResult);
-            visitedSchemas.add(ref);
-          }
-        } else if (inheritedRef != null && !inheritedRef.isEmpty() && !visitedSchemas.contains(inheritedRef)) {
-          Schema referencedSchema = cpLookup.getByName(inheritedRef);
-          if (referencedSchema != null) {
-            AvscParseResult referencedParseResult =
-                parser.parse(AvroCompatibilityHelper.toAvsc(referencedSchema, AvscGenerationConfig.CORRECT_PRETTY));
-            context.add(referencedParseResult);
-            visitedSchemas.add(ref);
-          }
-        }
-      }
+
       context.add(fileParseResult, areFilesImportable);
       // We skipp adding the referenced parse results to `parsedFiles`
       parsedFiles.add(fileParseResult);

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -128,6 +128,7 @@ public class AvroUtilCodeGenOp implements Operation {
         }
       }
     }
+    // TODO: check and throw if schemas defined in the filesystem (parsedFiles) have duplicates on the classpath.
 
     //resolve any references across files that are part of this op (anything left would be external)
     context.resolveReferences();

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -9,6 +9,7 @@ package com.linkedin.avroutil1.builder;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenerator;
 import java.io.File;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -118,6 +119,30 @@ public class SchemaBuilderTest {
     Assert.assertEquals(javaFiles.size(), 1);
   }
 
+  @Test
+  public void testWithImportsOnBothClasspathAndInFile() throws Exception {
+    File simpleProjectRoot = new File(locateTestProjectsRoot(), "classpath-dup-project");
+    File inputFolder = new File(simpleProjectRoot, "input");
+    File outputFolder = new File(simpleProjectRoot, "output");
+    if (outputFolder.exists()) { //clear output
+      FileUtils.deleteDirectory(outputFolder);
+    }
+    //run the builder
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath(),
+        "--generator", CodeGenerator.AVRO_UTIL.name(),
+        "--includeClasspath", Boolean.toString(true)
+    });
+    //see output was generated
+    List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
+        (path, basicFileAttributes) -> path.getFileName().toString().endsWith("SchemaWithClasspathImport.java")
+    ).collect(Collectors.toList());
+    Assert.assertEquals(javaFiles.size(), 1);
+    String fileContents = new String(Files.readAllBytes(javaFiles.get(0)), StandardCharsets.UTF_8);
+    // This field name exists in the schema that's in the filesystem and does not exist in the schema on the classpath.
+    Assert.assertTrue(fileContents.contains("lookAtMe"));
+  }
 
   @Test
   public void testImportableSchemasUsingOwnCodegen() throws Exception {

--- a/avro-builder/builder/src/test/resources/test-projects/classpath-dup-project/input/SchemaWithDupImport.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/classpath-dup-project/input/SchemaWithDupImport.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "SchemaWithClasspathImport",
+  "namespace": "com.linkedin.test",
+  "doc": "This is a test schema with a reference to a schema that is both on the classpath and in a file",
+  "fields": [
+    {
+      "name": "date",
+      "type": "build.generated.SimpleRecord"
+    }
+  ]
+}

--- a/avro-builder/builder/src/test/resources/test-projects/classpath-dup-project/input/SimpleRecord.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/classpath-dup-project/input/SimpleRecord.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "SimpleRecord",
+  "namespace": "build.generated",
+  "doc": "This is a test schema with a reference to a schema that is both on the classpath and in a file",
+  "fields": [
+    {
+      "name": "lookAtMe",
+      "type": "string"
+    }
+  ]
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvroParseContext.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvroParseContext.java
@@ -37,16 +37,16 @@ public class AvroParseContext {
     /**
      * all named (record, enum, fixed) schemas defined in any importable source file
      */
-    private Map<String, AvscParseResult> importableNamedSchemas = null;
+    private Map<String, AvscParseResult> importableNamedSchemas = new HashMap<>(1);
     /**
      * all named (record, enum, fixed) schemas defined in any source file
      */
-    private Map<String, AvscParseResult> allNamedSchemas = null;
+    private Map<String, AvscParseResult> allNamedSchemas = new HashMap<>(1);
     /**
      * these are the top-level (outermost) schemas defined, one per file
      */
-    private Set<AvroSchema> topLevelSchemas = null;
-    private Map<String, List<AvscParseResult>> duplicates = null;
+    private Set<AvroSchema> topLevelSchemas = new HashSet<>(1);
+    private Map<String, List<AvscParseResult>> duplicates = new HashMap<>(1);
     /**
      * remaining unresolved references after all references across files that
      * are part of this context have been handled.
@@ -70,54 +70,46 @@ public class AvroParseContext {
         }
         assertMutable();
         individualResults.add(new AvscStandaloneResult(singleResult, isImportable));
+
+        //add to an index of FQCNs (also find dups)
+        Throwable error = singleResult.getParseError();
+        if (error != null) {
+            //don't touch files with outright failures
+            //TODO - add an issue here
+            return;
+        }
+        Map<String, AvroNamedSchema> namedInFile = singleResult.getDefinedNamedSchemas();
+        namedInFile.forEach((fqcn, schema) -> {
+            AvscParseResult prior = allNamedSchemas.putIfAbsent(fqcn, singleResult);
+            if (prior != null) {
+                //TODO - find dups in aliases as well ?
+                //this is a dup
+                duplicates.compute(fqcn, (k, dups) -> {
+                    if (dups == null) {
+                        dups = new ArrayList<>(2);
+                        dups.add(prior);
+                    }
+                    dups.add(singleResult);
+                    return dups;
+                });
+                //TODO - add context-level issues for dups
+            }
+            if (isImportable) {
+                //dont care about return value since we handled dups above
+                importableNamedSchemas.putIfAbsent(fqcn, singleResult);
+            }
+        });
+        topLevelSchemas.add(singleResult.getTopLevelSchema());
     }
 
     /**
      * expected to be called once after all individual file parsing results have been added.
-     * this method resolves any cross-file references in schemas and populates
-     * the index datastructures.
+     * this method resolves any cross-file references in schemas.
      * no file parsing results can be added to this context once this method is called.
      */
     public void resolveReferences() {
         assertMutable();
         sealed = true;
-
-        //build up an index of FQCNs (also find dups)
-        importableNamedSchemas = new HashMap<>(individualResults.size());
-        allNamedSchemas = new HashMap<>(individualResults.size());
-        topLevelSchemas = new HashSet<>(individualResults.size());
-        duplicates = new HashMap<>(1);
-        for (AvscStandaloneResult fileResult : individualResults) {
-            AvscParseResult parseResult = fileResult.parseResult;
-            Throwable error = parseResult.getParseError();
-            if (error != null) {
-                //don't touch files with outright failures
-                //TODO - add an issue here
-                continue;
-            }
-            Map<String, AvroNamedSchema> namedInFile = parseResult.getDefinedNamedSchemas();
-            namedInFile.forEach((fqcn, schema) -> {
-                AvscParseResult prior = allNamedSchemas.putIfAbsent(fqcn, parseResult);
-                if (prior != null) {
-                    //TODO - find dups in aliases as well ?
-                    //this is a dup
-                    duplicates.compute(fqcn, (k, dups) -> {
-                        if (dups == null) {
-                            dups = new ArrayList<>(2);
-                            dups.add(prior);
-                        }
-                        dups.add(parseResult);
-                        return dups;
-                    });
-                }
-                if (fileResult.isImportable) {
-                    //dont care about return value since we handled dups above
-                    importableNamedSchemas.putIfAbsent(fqcn, parseResult);
-                }
-            });
-            topLevelSchemas.add(parseResult.getTopLevelSchema());
-        }
-        //TODO - add context-level issues for dups
 
         //resolve any unresolved references in individual file results from other files
         externalReferences = new ArrayList<>();
@@ -139,8 +131,9 @@ public class AvroParseContext {
                 if (inheritedNameResolution != null) {
                     ref.setResolvedTo(inheritedNameResolution.getDefinedNamedSchemas().get(inheritedName));
                     if (simpleNameResolution != null) {
-                        String msg = "ERROR: Two different schemas found for reference " + simpleName
-                            + " with inherited name " + inheritedName + ". Only one should exist.";
+                        String msg =
+                            "ERROR: Two different schemas found for reference " + simpleName + " with inherited name "
+                                + inheritedName + ". Only one should exist.";
                         singleFile.parseResult.addIssue(new AvscIssue(ref.getCodeLocation(), IssueSeverity.WARNING, msg,
                             new IllegalStateException(msg)));
                     }


### PR DESCRIPTION
This PR moves the logic for crawling the classpath for schema imports until after parsing all input files completes. As part of the change, the building of `AvroParseContext`'s indices was moved from `resolveReferences()` (at the very end of parsing) to being updated as each file is `add()`ed to the context. This allows external callers to access these indices instead of needing to reproduce these indices themselves.