### PR TITLE
Store utf8 runtime, String accessors

### DIFF
--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -222,5 +223,28 @@ public class SpecificRecordTest {
     Assert.assertEquals(builderTester.get(10), simpleUnion);
     Assert.assertEquals(builderTester.get(11), fixedType);
     Assert.assertEquals(builderTester.get(12), wierdUnion);
+  }
+
+  @Test
+  public void TestCharSeqAccessor() {
+    RandomRecordGenerator generator = new RandomRecordGenerator();
+    vs14.SimpleRecord instance14 = generator.randomSpecific(vs14.SimpleRecord.class, RecordGenerationConfig.newConfig().withAvoidNulls(true));
+    vs19.SimpleRecord instance19 = generator.randomSpecific(vs19.SimpleRecord.class, RecordGenerationConfig.newConfig().withAvoidNulls(true));
+    String string14 = "new_String_14";
+    String string19 = "new_String_19";
+
+    instance14.setStringField(string14);
+    instance19.setStringField(string19);
+
+    Assert.assertTrue(instance14.stringField instanceof Utf8);
+    Assert.assertEquals(instance14.stringField.toString(), string14);
+    Assert.assertTrue(instance14.getStringField() instanceof String);
+    Assert.assertEquals(instance14.stringField, new Utf8(instance14.getStringField()));
+
+    Assert.assertTrue(instance19.stringField instanceof Utf8);
+    Assert.assertEquals(instance19.stringField.toString(), string19);
+    Assert.assertTrue(instance19.getStringField() instanceof String);
+    Assert.assertEquals(instance19.stringField, new Utf8(instance19.getStringField()));
+
   }
 }

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -233,7 +233,7 @@ public class SpecificRecordTest {
     String string14 = "new_String_14";
     String string19 = "new_String_19";
 
-    instance14.setStringField(string14);
+    instance14.put(0, string14);
     instance19.setStringField(string19);
 
     Assert.assertTrue(instance14.stringField instanceof Utf8);

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -1371,7 +1371,7 @@ public class SpecificRecordClassGenerator {
 
     if(field.getSchemaOrRef().getSchema() != null) {
       fieldType = field.getSchemaOrRef().getSchema().type();
-      Class<?> fieldClass = getFieldClass(field.getSchemaOrRef().getSchema().type(), config.getDefaultFieldStringRepresentation());
+      Class<?> fieldClass = getFieldClass(field.getSchemaOrRef().getSchema().type(), config.getDefaultMethodStringRepresentation());
       if (fieldClass != null) {
         methodSpecBuilder.addParameter(fieldClass, escapedFieldName)
             .addModifiers(Modifier.PUBLIC);

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/StringConverterUtil.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/StringConverterUtil.java
@@ -24,16 +24,25 @@ public class StringConverterUtil {
   }
 
   public static String getString(Object value) {
+    if (value == null) {
+      return null;
+    }
     validateArgs(value);
     return String.valueOf(value);
   }
 
   public static Utf8 getUtf8(Object value) {
+    if (value == null) {
+      return null;
+    }
     validateArgs(value);
     return new Utf8(String.valueOf(value));
   }
 
   public static CharSequence getCharSequence(Object value) {
+    if (value == null) {
+      return null;
+    }
     validateArgs(value);
     return String.valueOf(value);
   }


### PR DESCRIPTION
- public Charsequence fields store Utf8s during runtime to support 1.4 functionality.

- type String Accessors 

**Tests:**
- Updated test case to verify getter setter and public field
- tracking build successful with this snapshot