### PR TITLE
[avro-util] fix large string chunk - remove escape chars

### DIFF
--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_4069749625437031485.java
@@ -46,7 +46,7 @@ public class RecordWithLargeUnionField_SpecificDeserializer_3405422059761328483_
                 RecordWithLargeUnionField.put(0, (decoder.readInt()));
             } else {
                 if (unionIndex0 == 2) {
-                    throw new AvroTypeException(new StringBuilder().append("\"Found\"").append("\" \"byt\"").append("\"es\", \"").append("\"expec\"").append("\"ting \"").append("\"[\"str\"").append("\"ing\",\"").append("\" \"int\"").append("\"\"]\"").toString());
+                    throw new AvroTypeException(new StringBuilder().append("Found").append(" \"byt").append("es\", ").append("expec").append("ting ").append("[\"str").append("ing\",").append(" \"int").append("\"]").toString());
                 } else {
                     throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
                 }

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -58,7 +58,9 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
   private static final String DECODER = "decoder";
   private static final String VAR_NAME_FOR_REUSE = "reuse";
   private static int FIELDS_PER_POPULATION_METHOD = 100;
-  static int MAX_LENGTH_OF_STRING_LITERAL = 65535;
+
+  // 65535 is the actual limit, 65K added for safety
+  static int MAX_LENGTH_OF_STRING_LITERAL = 65000;
 
   /**
    * This is sometimes passed into the reuse parameter,
@@ -1354,7 +1356,7 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
     JInvocation stringBuilder = JExpr._new(codeModel.ref(StringBuilder.class));
     for (int pos = 0; pos < input.length();) {
       int endIndex = Math.min(pos + MAX_LENGTH_OF_STRING_LITERAL, input.length());
-      String chunkedLiteral = "\"" + input.substring(pos, endIndex) + "\"";
+      String chunkedLiteral = input.substring(pos, endIndex);
       stringBuilder = stringBuilder.invoke("append").arg(chunkedLiteral);
       pos = endIndex;
     }


### PR DESCRIPTION
Bug fix
1. Remove redundant escape chars
2. 65000 limit instad of 65535