### PR TITLE
both string and charseq setters codegen for string field type

### DIFF
--- a/avro-codegen/src/test/resources/schemas/BuilderTester.avsc
+++ b/avro-codegen/src/test/resources/schemas/BuilderTester.avsc
@@ -99,6 +99,10 @@
         "items": "string"
       }
       ]
+    },
+    {
+      "name": "unionOfString",
+      "type": ["null", "string"]
     }
   ]
 }


### PR DESCRIPTION
- generate both string and charseq setters (overloaded) for string field types
- and for nullable unions ( null, type OR type,null )