### PR TITLE
fix record field json properties not being emitted

### DIFF
--- a/parser/src/main/java/com/linkedin/avroutil1/writer/avsc/AvscSchemaWriter.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/writer/avsc/AvscSchemaWriter.java
@@ -319,6 +319,9 @@ public class AvscSchemaWriter implements AvroSchemaWriter {
       }
       AvroSchema fieldSchema = field.getSchema();
       fieldBuilder.add("type", writeSchema(fieldSchema, context, config));
+
+      emitJsonProperties(field.getAllProps(), context, config, fieldBuilder);
+
       if (field.hasDefaultValue()) {
         AvroLiteral defaultValue = field.getDefaultValue();
         JsonValue defaultValueLiteral = writeDefaultValue(fieldSchema, defaultValue);

--- a/parser/src/test/java/com/linkedin/avroutil1/writer/avsc/AvscSchemaWriterTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/writer/avsc/AvscSchemaWriterTest.java
@@ -88,6 +88,11 @@ public class AvscSchemaWriterTest {
     testParsingCycle(avsc);
   }
 
+  @Test void testIfFieldPropsAreWritten() throws IOException {
+    String avsc = TestUtil.load("schemas/RecordFieldWithProps.avsc");
+    testParsingCycle(avsc);
+  }
+
   /**
    * given an avsc, parses and re-prints it using our code
    * and compares the result to vanilla avro.

--- a/parser/src/test/resources/schemas/RecordFieldWithProps.avsc
+++ b/parser/src/test/resources/schemas/RecordFieldWithProps.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "record",
+  "name": "RecordFieldWithProps",
+  "doc": "The record's fields contain props",
+  "fields": [
+    {
+      "name": "hostname",
+      "type": "string",
+      "extra": "prop"
+    },
+    {
+      "name": "logNumberj",
+      "type": "long",
+      "extra": {
+        "blob": "ofProps"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Record field json properties were not being written in AvscSchemaWriter. This PR fixes that bug