### PR TITLE
Codegen deprecate public fields

### DIFF
--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.avro.AvroRuntimeException;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 import org.testng.Assert;

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -7,6 +7,7 @@
 package com.linkedin.avroutil1.builder;
 
 import com.linkedin.avroutil1.compatibility.AvroCodecUtil;
+import com.linkedin.avroutil1.compatibility.AvroRecordUtil;
 import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
 import com.linkedin.avroutil1.compatibility.RecordGenerationConfig;
 import com.linkedin.avroutil1.compatibility.StringConverterUtil;
@@ -1700,8 +1701,11 @@ public class SpecificRecordTest {
 
   @Test(dataProvider = "TestRoundTripSerializationProvider")
   public <T extends IndexedRecord> void testDeprecatedPublicFields(Class<T> clazz, org.apache.avro.Schema classSchema) {
-
-    List<String> fieldNames = classSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
+    List<String> fieldNames = classSchema.getFields()
+        .stream()
+        .map(field -> AvroRecordUtil.AVRO_RESERVED_FIELD_NAMES.contains(field.name()) ? field.name() + "$"
+            : field.name())
+        .collect(Collectors.toList());
     for(int i = 0; i < clazz.getFields().length; i++) {
       Field field  = clazz.getFields()[i];
       if(fieldNames.contains(field.getName())) {

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -11,6 +11,7 @@ import com.linkedin.avroutil1.compatibility.RandomRecordGenerator;
 import com.linkedin.avroutil1.compatibility.RecordGenerationConfig;
 import com.linkedin.avroutil1.compatibility.StringConverterUtil;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -1693,6 +1694,15 @@ public class SpecificRecordTest {
       for(Parameter param : constructor.getParameters()) {
         Assert.assertFalse(param.getType().isPrimitive());
       }
+    }
+  }
+
+  @Test(dataProvider = "TestRoundTripSerializationProvider")
+  public <T extends IndexedRecord> void testDeprecatedPublicFields(Class<T> clazz, org.apache.avro.Schema classSchema) {
+    // first public field is SCHEMA
+    for(int i = 1; i < clazz.getFields().length; i++) {
+      Field field  = clazz.getFields()[i];
+      Assert.assertEquals(field.getDeclaredAnnotations()[0].annotationType(), Deprecated.class);
     }
   }
 

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 import org.testng.Assert;
@@ -1699,10 +1700,13 @@ public class SpecificRecordTest {
 
   @Test(dataProvider = "TestRoundTripSerializationProvider")
   public <T extends IndexedRecord> void testDeprecatedPublicFields(Class<T> clazz, org.apache.avro.Schema classSchema) {
-    // first public field is SCHEMA
-    for(int i = 1; i < clazz.getFields().length; i++) {
+
+    List<String> fieldNames = classSchema.getFields().stream().map(Schema.Field::name).collect(Collectors.toList());
+    for(int i = 0; i < clazz.getFields().length; i++) {
       Field field  = clazz.getFields()[i];
-      Assert.assertEquals(field.getDeclaredAnnotations()[0].annotationType(), Deprecated.class);
+      if(fieldNames.contains(field.getName())) {
+        Assert.assertEquals(field.getDeclaredAnnotations()[0].annotationType(), Deprecated.class);
+      }
     }
   }
 

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -446,7 +446,11 @@ public class SpecificRecordClassGenerator {
       // Add public/private fields
       Modifier accessModifier = (config.hasPublicFields())? Modifier.PUBLIC : Modifier.PRIVATE;
       for (AvroSchemaField field : recordSchema.getFields()) {
-        classBuilder.addField(getFieldSpecBuilder(field, config).addModifiers(accessModifier).build());
+        FieldSpec.Builder fieldBuilder = getFieldSpecBuilder(field, config).addModifiers(accessModifier);
+        if(config.hasPublicFields()) {
+          fieldBuilder.addAnnotation(Deprecated.class);
+        }
+        classBuilder.addField(fieldBuilder.build());
 
         //if declared schema, use fully qualified class (no import)
         addFullyQualified(field, config.getDefaultFieldStringRepresentation());


### PR DESCRIPTION
public fields @Deprecated.
Users should prefer using accessors.