### PR TITLE
Updated codegen builder initializer and Avrorecord deepcopy

### DIFF
--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import noutf8.TestCollections;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
@@ -1711,6 +1712,25 @@ public class SpecificRecordTest {
         Assert.assertEquals(field.getDeclaredAnnotations()[0].annotationType(), Deprecated.class);
       }
     }
+  }
+
+  @Test
+  public void testNewBuilder() throws Exception {
+    RandomRecordGenerator generator = new RandomRecordGenerator();
+    TestCollections instance = generator.randomSpecific(TestCollections.class, RecordGenerationConfig.newConfig().withAvoidNulls(true));
+    TestCollections.Builder builder = TestCollections.newBuilder()
+        .setStr(instance.getStr())
+        .setStrAr(instance.getStrAr())
+        .setStrArAr(instance.getStrArAr())
+        .setUnionOfArray(instance.getUnionOfArray())
+        .setArOfMap(instance.getArOfMap())
+        .setUnionOfMap(instance.getUnionOfMap())
+        .setArOfUnionOfStr(instance.getArOfUnionOfStr())
+        .setArOfMapOfUnionOfArray(instance.getArOfMapOfUnionOfArray());
+
+    TestCollections.newBuilder(builder);
+
+    compareIndexedRecords(instance, builder.build());
   }
 
   @BeforeClass

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -750,14 +750,14 @@ public class SpecificRecordClassGenerator {
       otherBuilderConstructorFromRecordBlockBuilder.beginControlFlow("if (isValidValue(fields()[$L], other.$L))", fieldIndex,
           escapedFieldName)
           .addStatement("this.$1L = deepCopyField(other.$1L, fields()[$2L].schema(), $3S)", escapedFieldName, fieldIndex,
-              config.getDefaultFieldStringRepresentation().getJsonValue())
+              config.getDefaultMethodStringRepresentation().getJsonValue())
           .addStatement("fieldSetFlags()[$L] = true", fieldIndex)
           .endControlFlow();
 
       otherBuilderConstructorFromOtherBuilderBlockBuilder.beginControlFlow("if (isValidValue(fields()[$L], other.$L))", fieldIndex,
           escapedFieldName)
           .addStatement("this.$1L = deepCopyField(other.$1L, fields()[$2L].schema(), $3S)", escapedFieldName, fieldIndex,
-              config.getDefaultFieldStringRepresentation().getJsonValue())
+              config.getDefaultMethodStringRepresentation().getJsonValue())
           .addStatement("fieldSetFlags()[$1L] = other.fieldSetFlags()[$1L]", fieldIndex)
           .endControlFlow();
 

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroRecordUtil.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroRecordUtil.java
@@ -711,6 +711,11 @@ public class AvroRecordUtil {
           outputMap.put(outputKey, outputElement);
         }
         return outputMap;
+
+      case UNION:
+        inputValueActualSchema = AvroSchemaUtil.resolveUnionBranchOf(inputValue, inputSchema);
+        outputValueActualSchema = AvroSchemaUtil.resolveUnionBranchOf(inputValue, outputSchema);
+        return deepConvert(inputValue, inputValueActualSchema, outputValueActualSchema, context, stringRepresentation);
     }
     String inputClassName = inputValue == null ? "null" : inputValue.getClass().getName();
     throw new UnsupportedOperationException("dont know how to convert " + inputType + " " + inputValue
@@ -776,6 +781,7 @@ public class AvroRecordUtil {
     switch (desired) {
       case String:
         return String.valueOf(inputStr);
+      case CharSequence:
       case Utf8:
         return new Utf8(String.valueOf(inputStr));
       default:

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroRecordUtil.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroRecordUtil.java
@@ -782,6 +782,7 @@ public class AvroRecordUtil {
       case String:
         return String.valueOf(inputStr);
       case CharSequence:
+        // intentional pass through
       case Utf8:
         return new Utf8(String.valueOf(inputStr));
       default:
@@ -793,6 +794,8 @@ public class AvroRecordUtil {
     switch (desired) {
       case String:
         return new String(inputBytes, StandardCharsets.UTF_8);
+      case CharSequence:
+        // intentional pass through
       case Utf8:
         return new Utf8(inputBytes);
       default:


### PR DESCRIPTION
- AvroRecordUtil deepcopy handles Union and Charseq type
- newBuilder expected string type is same as field type used in builder.