### PR TITLE
Adds ability to ignore json props to ConfigurableSchemaComparator

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -142,10 +142,9 @@ public interface AvroAdapter {
    * @param compareStringProps true to compare string properties (otherwise ignored)
    * @param compareNonStringProps true to compare all other properties (otherwise ignored). this exists because avro 1.4
    *                              doesnt handle non-string props at all and we want to be able to match that behaviour under any avro
+   * @param jsonPropNamesToIgnore a set of json property names to ignore. if null, no properties will be ignored
    * @return if field properties are equal, under the configuration parameters above
    */
-  boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps);
-
   boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps,
       Set<String> jsonPropNamesToIgnore);
 
@@ -160,10 +159,9 @@ public interface AvroAdapter {
    * @param compareStringProps true to compare string properties (otherwise ignored)
    * @param compareNonStringProps true to compare all other properties (otherwise ignored). this exists because avro 1.4
    *                              doesnt handle non-string props at all and we want to be able to match that behaviour under any avro
+   * @param jsonPropNamesToIgnore a set of json property names to ignore. if null, all properties are considered
    * @return if schema properties are equal, under the configuration parameters above
    */
-  boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps);
-
   boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
       Set<String> jsonPropNamesToIgnore);
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -52,8 +52,7 @@ public interface AvroAdapter {
 
   BinaryDecoder newBinaryDecoder(ObjectInput in);
 
-  BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
-      int length, BinaryDecoder reuse);
+  BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse);
 
   JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException;
 
@@ -147,6 +146,9 @@ public interface AvroAdapter {
    */
   boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps);
 
+  boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore);
+
   String getSchemaPropAsJsonString(Schema schema, String propName);
 
   void setSchemaPropFromJsonString(Schema field, String propName, String valueAsJsonLiteral, boolean strict);
@@ -162,7 +164,11 @@ public interface AvroAdapter {
    */
   boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps);
 
+  boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore);
+
   List<String> getAllPropNames(Schema schema);
+
   List<String> getAllPropNames(Schema.Field field);
 
   String getEnumDefault(Schema s);
@@ -226,10 +232,6 @@ public interface AvroAdapter {
 
   //code generation
 
-  Collection<AvroGeneratedSourceCode> compile(
-      Collection<Schema> toCompile,
-      AvroVersion minSupportedVersion,
-      AvroVersion maxSupportedVersion,
-      CodeGenerationConfig config
-  );
+  Collection<AvroGeneratedSourceCode> compile(Collection<Schema> toCompile, AvroVersion minSupportedVersion,
+      AvroVersion maxSupportedVersion, CodeGenerationConfig config);
 }

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -6,22 +6,25 @@
 
 package com.linkedin.avroutil1.compatibility;
 
+import java.util.Collections;
+import java.util.Set;
+
 
 public class SchemaComparisonConfiguration {
   /**
    * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
    */
   public static final SchemaComparisonConfiguration PRE_1_7_3 = new SchemaComparisonConfiguration(
-      true, false, false, false, true, false
+      true, false, false, false, true, false,  Collections.emptySet()
   );
   /**
    * same as {@link #STRICT} but allows int default values to match (round) float default values
    */
   public static final SchemaComparisonConfiguration LOOSE_NUMERICS = new SchemaComparisonConfiguration(
-      true, true, true, true, true, true
+      true, true, true, true, true, true, Collections.emptySet()
   );
   public static final SchemaComparisonConfiguration STRICT = new SchemaComparisonConfiguration(
-      true, true, true, false, true, true
+      true, true, true, false, true, true,  Collections.emptySet()
   );
 
   private final boolean compareStringJsonProps;
@@ -30,6 +33,7 @@ public class SchemaComparisonConfiguration {
   private final boolean compareIntToFloatDefaults;
   private final boolean compareFieldOrder;
   private final boolean compareFieldLogicalTypes;
+  private final Set<String> jsonPropNamesToIgnore;
 
   public SchemaComparisonConfiguration(
       boolean compareStringJsonProps,
@@ -37,7 +41,8 @@ public class SchemaComparisonConfiguration {
       boolean compareAliases,
       boolean compareIntToFloatDefaults,
       boolean compareFieldOrder,
-      boolean compareFieldLogicalTypes
+      boolean compareFieldLogicalTypes,
+      Set<String> jsonPropNamesToIgnore
   ) {
     this.compareStringJsonProps = compareStringJsonProps;
     this.compareNonStringJsonProps = compareNonStringJsonProps;
@@ -45,6 +50,7 @@ public class SchemaComparisonConfiguration {
     this.compareIntToFloatDefaults = compareIntToFloatDefaults;
     this.compareFieldOrder = compareFieldOrder;
     this.compareFieldLogicalTypes = compareFieldLogicalTypes;
+    this.jsonPropNamesToIgnore = jsonPropNamesToIgnore;
   }
 
   public boolean isCompareStringJsonProps() {
@@ -71,6 +77,10 @@ public class SchemaComparisonConfiguration {
     return compareFieldLogicalTypes;
   }
 
+  public Set<String> getJsonPropNamesToIgnore() {
+    return jsonPropNamesToIgnore;
+  }
+
   public SchemaComparisonConfiguration compareStringJsonProps(boolean compare) {
     return new SchemaComparisonConfiguration(
         compare,
@@ -78,7 +88,8 @@ public class SchemaComparisonConfiguration {
         compareAliases,
         compareIntToFloatDefaults,
         compareFieldOrder,
-        compareFieldLogicalTypes
+        compareFieldLogicalTypes,
+        jsonPropNamesToIgnore
     );
   }
 
@@ -89,7 +100,8 @@ public class SchemaComparisonConfiguration {
         compareAliases,
         compareIntToFloatDefaults,
         compareFieldOrder,
-        compareFieldLogicalTypes
+        compareFieldLogicalTypes,
+        jsonPropNamesToIgnore
     );
   }
 
@@ -100,7 +112,8 @@ public class SchemaComparisonConfiguration {
         compare,
         compareIntToFloatDefaults,
         compareFieldOrder,
-        compareFieldLogicalTypes
+        compareFieldLogicalTypes,
+        jsonPropNamesToIgnore
     );
   }
 
@@ -111,7 +124,8 @@ public class SchemaComparisonConfiguration {
         compareAliases,
         compare,
         compareFieldOrder,
-        compareFieldLogicalTypes
+        compareFieldLogicalTypes,
+        jsonPropNamesToIgnore
     );
   }
 
@@ -122,7 +136,8 @@ public class SchemaComparisonConfiguration {
         compareAliases,
         compareIntToFloatDefaults,
         compare,
-        compareFieldLogicalTypes
+        compareFieldLogicalTypes,
+        jsonPropNamesToIgnore
     );
   }
 
@@ -133,7 +148,20 @@ public class SchemaComparisonConfiguration {
         compareAliases,
         compareIntToFloatDefaults,
         compareFieldOrder,
-        compare
+        compare,
+        jsonPropNamesToIgnore
+    );
+  }
+
+  public SchemaComparisonConfiguration jsonPropNamesToIgnore(Set<String> jsonPropNamesToIgnore) {
+    return new SchemaComparisonConfiguration(
+        compareStringJsonProps,
+        compareNonStringJsonProps,
+        compareAliases,
+        compareIntToFloatDefaults,
+        compareFieldOrder,
+        compareFieldLogicalTypes,
+        jsonPropNamesToIgnore
     );
   }
 }

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -981,7 +981,7 @@ public class AvroCompatibilityHelper  extends AvroCompatibilityHelperCommon{
   public static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps) {
     assertAvroAvailable();
-    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, null);
   }
 
   public static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
@@ -1051,7 +1051,7 @@ public class AvroCompatibilityHelper  extends AvroCompatibilityHelperCommon{
   public static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps,
       boolean compareNonStringProps) {
     assertAvroAvailable();
-    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, null);
   }
 
   public static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps,

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -978,10 +978,18 @@ public class AvroCompatibilityHelper  extends AvroCompatibilityHelperCommon{
     ADAPTER.setFieldPropFromJsonString(field, propName, valueAsJsonLiteral, strict);
   }
 
-  public static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+  public static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps) {
     assertAvroAvailable();
     return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
   }
+
+  public static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    assertAvroAvailable();
+    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
+  }
+
 
   /**
    * returns the value of the specified schema prop as a json literal.
@@ -1040,9 +1048,16 @@ public class AvroCompatibilityHelper  extends AvroCompatibilityHelperCommon{
     ADAPTER.setSchemaPropFromJsonString(schema, propName, valueAsJsonLiteral, strict);
   }
 
-  public static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+  public static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps,
+      boolean compareNonStringProps) {
     assertAvroAvailable();
     return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+  }
+
+  public static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    assertAvroAvailable();
+    return ADAPTER.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
   }
 
   public static List<String> getAllPropNames(Schema schema) {

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -357,25 +357,6 @@ public class Avro110Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA;
-    Map<String, JsonNode> propsB;
-    try {
-      //noinspection unchecked
-      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-      //noinspection unchecked
-      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access JsonProperties.props", e);
-    }
-    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (a == null || b == null) {
       return false;
@@ -423,24 +404,6 @@ public class Avro110Adapter implements AvroAdapter {
     // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
     JsonNode node = Jackson2Utils.toJsonNode(value, strict);
     schema.addProp(name, JacksonUtils.toObject(node));
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA;
-    Map<String, JsonNode> propsB;
-    try {
-      //noinspection unchecked
-      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-      //noinspection unchecked
-      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access JsonProperties.props", e);
-    }
-    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -66,509 +66,578 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+
 public class Avro110Adapter implements AvroAdapter {
 
-    private final Field jsonPropertiesPropsField;
-    private boolean compilerSupported;
-    private Throwable compilerSupportIssue;
-    private String compilerSupportMessage;
-    private Constructor<?> specificCompilerCtr;
-    private Method compilerEnqueueMethod;
-    private Method compilerCompileMethod;
-    private Field outputFilePathField;
-    private Field outputFileContentsField;
-    private Object publicFieldVisibilityEnumInstance;
-    private Method setFieldVisibilityMethod;
-    private Object charSequenceStringTypeEnumInstance;
-    private Object javaLangStringTypeEnumInstance;
-    private Object utf8TypeEnumInstance;
-    private Method setStringTypeMethod;
+  private final Field jsonPropertiesPropsField;
+  private boolean compilerSupported;
+  private Throwable compilerSupportIssue;
+  private String compilerSupportMessage;
+  private Constructor<?> specificCompilerCtr;
+  private Method compilerEnqueueMethod;
+  private Method compilerCompileMethod;
+  private Field outputFilePathField;
+  private Field outputFileContentsField;
+  private Object publicFieldVisibilityEnumInstance;
+  private Method setFieldVisibilityMethod;
+  private Object charSequenceStringTypeEnumInstance;
+  private Object javaLangStringTypeEnumInstance;
+  private Object utf8TypeEnumInstance;
+  private Method setStringTypeMethod;
 
-    public Avro110Adapter() {
-        try {
-            jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
-            jsonPropertiesPropsField.setAccessible(true);
-        } catch (Exception e) {
-            throw new IllegalStateException("error initializing adapter", e);
+  public Avro110Adapter() {
+    try {
+      jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
+      jsonPropertiesPropsField.setAccessible(true);
+    } catch (Exception e) {
+      throw new IllegalStateException("error initializing adapter", e);
+    }
+    tryInitializeCompilerFields();
+  }
+
+  private void tryInitializeCompilerFields() {
+    //compiler was moved out into a separate jar in avro 1.5+, so compiler functionality is optional
+    try {
+      Class<?> compilerClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler");
+      specificCompilerCtr = compilerClass.getConstructor(Schema.class);
+      compilerEnqueueMethod = compilerClass.getDeclaredMethod("enqueue", Schema.class);
+      compilerEnqueueMethod.setAccessible(true); //its normally private
+      compilerCompileMethod = compilerClass.getDeclaredMethod("compile");
+      compilerCompileMethod.setAccessible(true); //package-protected
+      Class<?> outputFileClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$OutputFile");
+      outputFilePathField = outputFileClass.getDeclaredField("path");
+      outputFilePathField.setAccessible(true);
+      outputFileContentsField = outputFileClass.getDeclaredField("contents");
+      outputFileContentsField.setAccessible(true);
+      Class<?> fieldVisibilityEnum =
+          Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
+      Field publicVisibilityField = fieldVisibilityEnum.getDeclaredField("PUBLIC");
+      publicFieldVisibilityEnumInstance = publicVisibilityField.get(null);
+      setFieldVisibilityMethod = compilerClass.getDeclaredMethod("setFieldVisibility", fieldVisibilityEnum);
+      Class<?> fieldTypeEnum = Class.forName("org.apache.avro.generic.GenericData$StringType");
+      Field charSequenceField = fieldTypeEnum.getDeclaredField("CharSequence");
+      charSequenceStringTypeEnumInstance = charSequenceField.get(null);
+      Field javaLangStringField = fieldTypeEnum.getDeclaredField("String");
+      javaLangStringTypeEnumInstance = javaLangStringField.get(null);
+      Field utf8Field = fieldTypeEnum.getDeclaredField("Utf8");
+      utf8TypeEnumInstance = utf8Field.get(null);
+      setStringTypeMethod = compilerClass.getDeclaredMethod("setStringType", fieldTypeEnum);
+      compilerSupported = true;
+    } catch (Exception | LinkageError e) {
+      //if a class we directly look for above isnt found, we get ClassNotFoundException
+      //but if we're missing a transitive dependency we will get NoClassDefFoundError
+      compilerSupported = false;
+      compilerSupportIssue = e;
+      String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
+      compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
+          + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
+      //ignore
+    }
+  }
+
+  @Override
+  public AvroVersion supportedMajorVersion() {
+    return AvroVersion.AVRO_1_10;
+  }
+
+  @Override
+  public BinaryEncoder newBinaryEncoder(OutputStream out, boolean buffered, BinaryEncoder reuse) {
+    if (buffered) {
+      return EncoderFactory.get().binaryEncoder(out, reuse);
+    } else {
+      return EncoderFactory.get().directBinaryEncoder(out, reuse);
+    }
+  }
+
+  @Override
+  public BinaryEncoder newBinaryEncoder(ObjectOutput out) {
+    return SpecificData.getEncoder(out);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(InputStream in, boolean buffered, BinaryDecoder reuse) {
+    DecoderFactory factory = DecoderFactory.get();
+    return buffered ? factory.binaryDecoder(in, reuse) : factory.directBinaryDecoder(in, reuse);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(ObjectInput in) {
+    return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro110BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
+  }
+
+  @Override
+  public JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException {
+    return EncoderFactory.get().jsonEncoder(schema, out, pretty);
+  }
+
+  @Override
+  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat)
+      throws IOException {
+    return new CompatibleJsonEncoder(schema, out, pretty,
+        jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
+  }
+
+  @Override
+  public JsonDecoder newJsonDecoder(Schema schema, InputStream in) throws IOException {
+    return DecoderFactory.get().jsonDecoder(schema, in);
+  }
+
+  @Override
+  public JsonDecoder newJsonDecoder(Schema schema, String in) throws IOException {
+    return DecoderFactory.get().jsonDecoder(schema, in);
+  }
+
+  @Override
+  public Decoder newCompatibleJsonDecoder(Schema schema, InputStream in) throws IOException {
+    return new CompatibleJsonDecoder(schema, in);
+  }
+
+  @Override
+  public Decoder newCompatibleJsonDecoder(Schema schema, String in) throws IOException {
+    return new CompatibleJsonDecoder(schema, in);
+  }
+
+  @Override
+  public SkipDecoder newCachedResolvingDecoder(Schema writer, Schema reader, Decoder in) throws IOException {
+    return new CachedResolvingDecoder(writer, reader, in);
+  }
+
+  @Override
+  public Decoder newBoundedMemoryDecoder(InputStream in) throws IOException {
+    return new BoundedMemoryDecoder(in);
+  }
+
+  @Override
+  public Decoder newBoundedMemoryDecoder(byte[] data) throws IOException {
+    return new BoundedMemoryDecoder(data);
+  }
+
+  @Override
+  public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
+    Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
+    return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public SchemaParseResult parse(String schemaJson, SchemaParseConfiguration desiredConf, Collection<Schema> known) {
+    Schema.Parser parser = new Schema.Parser();
+    boolean validateNames = true;
+    boolean validateDefaults = true;
+    boolean validateNumericDefaultValueTypes = false;
+    boolean validateNoDanglingContent = false;
+    if (desiredConf != null) {
+      validateNames = desiredConf.validateNames();
+      validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
+      validateNoDanglingContent = desiredConf.validateNoDanglingContent();
+    }
+    SchemaParseConfiguration configUsed =
+        new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes,
+            validateNoDanglingContent);
+    parser.setValidate(validateNames);
+    //avro 1.10 default validation also validates numeric types, so if we want to be
+    //more nuanced we cant use avro's default value validation
+    if (validateDefaults && validateNumericDefaultValueTypes) {
+      parser.setValidateDefaults(true);
+    } else {
+      parser.setValidateDefaults(false);
+    }
+    if (known != null && !known.isEmpty()) {
+      Map<String, Schema> knownByFullName = new HashMap<>(known.size());
+      for (Schema s : known) {
+        knownByFullName.put(s.getFullName(), s);
+      }
+      parser.addTypes(knownByFullName);
+    }
+    Schema mainSchema = parser.parse(schemaJson);
+    Map<String, Schema> knownByFullName = parser.getTypes();
+
+    if (configUsed.validateDefaultValues()) {
+      //dont trust avro, also run our own. also we might have told avro not to validate over numerics
+      Avro110SchemaValidator validator = new Avro110SchemaValidator(configUsed, known);
+      AvroSchemaUtil.traverseSchema(mainSchema, validator);
+    }
+    if (configUsed.validateNoDanglingContent()) {
+      Jackson2Utils.assertNoTrailingContent(schemaJson);
+    }
+    //todo - depending on how https://issues.apache.org/jira/browse/AVRO-2742 is settled, may need to use our own validator here
+    return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
+  }
+
+  @Override
+  public String toParsingForm(Schema s) {
+    return SchemaNormalization.toParsingForm(s);
+  }
+
+  @Override
+  public String getDefaultValueAsJsonString(Schema.Field field) {
+    JsonNode json = Accessor.defaultValue(field);
+    if (json == null) {
+      throw new AvroRuntimeException("Field " + field + " has no default value");
+    }
+    return json.toString();
+  }
+
+  @Override
+  public Object newInstance(Class<?> clazz, Schema schema) {
+    return SpecificData.newInstance(clazz, schema);
+  }
+
+  @Override
+  public Object getSpecificDefaultValue(Schema.Field field) {
+    return SpecificData.get().getDefaultValue(field);
+  }
+
+  @Override
+  public GenericData.EnumSymbol newEnumSymbol(Schema enumSchema, String enumValue) {
+    return new GenericData.EnumSymbol(enumSchema, enumValue);
+  }
+
+  @Override
+  public GenericData.Fixed newFixedField(Schema fixedSchema) {
+    return new GenericData.Fixed(fixedSchema);
+  }
+
+  @Override
+  public GenericData.Fixed newFixedField(Schema fixedSchema, byte[] contents) {
+    return new GenericData.Fixed(fixedSchema, contents);
+  }
+
+  @Override
+  public Object getGenericDefaultValue(Schema.Field field) {
+    //always use our cache for the validation
+    return Avro110DefaultValuesCache.getDefaultValue(field, false);
+  }
+
+  @Override
+  public boolean fieldHasDefault(Schema.Field field) {
+    return field.hasDefaultValue();
+  }
+
+  @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
+    JsonNode aVal = Accessor.defaultValue(a);
+    JsonNode bVal = Accessor.defaultValue(b);
+    return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
+  }
+
+  @Override
+  public Set<String> getFieldAliases(Schema.Field field) {
+    return field.aliases();
+  }
+
+  @Override
+  public FieldBuilder newFieldBuilder(Schema.Field other) {
+    return new FieldBuilder110(other);
+  }
+
+  @Override
+  public SchemaBuilder newSchemaBuilder(Schema other) {
+    return new SchemaBuilder110(this, other);
+  }
+
+  @Override
+  public String getFieldPropAsJsonString(Schema.Field field, String name) {
+    // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
+    JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
+    return Jackson2Utils.toJsonString(node);
+  }
+
+  @Override
+  public void setFieldPropFromJsonString(Schema.Field field, String name, String value, boolean strict) {
+    // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
+    JsonNode node = Jackson2Utils.toJsonNode(value, strict);
+    field.addProp(name, JacksonUtils.toObject(node));
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA;
+    Map<String, JsonNode> propsB;
+    try {
+      //noinspection unchecked
+      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> unfilteredPropsA;
+    Map<String, JsonNode> unfilteredPropsB;
+    try {
+      //noinspection unchecked
+      unfilteredPropsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      unfilteredPropsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson2Utils.compareJsonProperties(unfilteredPropsA, unfilteredPropsB, compareStringProps,
+          compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
         }
-        tryInitializeCompilerFields();
-    }
-
-    private void tryInitializeCompilerFields() {
-        //compiler was moved out into a separate jar in avro 1.5+, so compiler functionality is optional
-        try {
-            Class<?> compilerClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler");
-            specificCompilerCtr = compilerClass.getConstructor(Schema.class);
-            compilerEnqueueMethod = compilerClass.getDeclaredMethod("enqueue", Schema.class);
-            compilerEnqueueMethod.setAccessible(true); //its normally private
-            compilerCompileMethod = compilerClass.getDeclaredMethod("compile");
-            compilerCompileMethod.setAccessible(true); //package-protected
-            Class<?> outputFileClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$OutputFile");
-            outputFilePathField = outputFileClass.getDeclaredField("path");
-            outputFilePathField.setAccessible(true);
-            outputFileContentsField = outputFileClass.getDeclaredField("contents");
-            outputFileContentsField.setAccessible(true);
-            Class<?> fieldVisibilityEnum = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
-            Field publicVisibilityField = fieldVisibilityEnum.getDeclaredField("PUBLIC");
-            publicFieldVisibilityEnumInstance = publicVisibilityField.get(null);
-            setFieldVisibilityMethod = compilerClass.getDeclaredMethod("setFieldVisibility", fieldVisibilityEnum);
-            Class<?> fieldTypeEnum = Class.forName("org.apache.avro.generic.GenericData$StringType");
-            Field charSequenceField = fieldTypeEnum.getDeclaredField("CharSequence");
-            charSequenceStringTypeEnumInstance = charSequenceField.get(null);
-            Field javaLangStringField = fieldTypeEnum.getDeclaredField("String");
-            javaLangStringTypeEnumInstance = javaLangStringField.get(null);
-            Field utf8Field = fieldTypeEnum.getDeclaredField("Utf8");
-            utf8TypeEnumInstance = utf8Field.get(null);
-            setStringTypeMethod = compilerClass.getDeclaredMethod("setStringType", fieldTypeEnum);
-            compilerSupported = true;
-        } catch (Exception | LinkageError e) {
-            //if a class we directly look for above isnt found, we get ClassNotFoundException
-            //but if we're missing a transitive dependency we will get NoClassDefFoundError
-            compilerSupported = false;
-            compilerSupportIssue = e;
-            String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
-            compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
-                    + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
-            //ignore
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
         }
+      }
+      return Jackson2Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
+    }
+  }
+
+  @Override
+  public String getSchemaPropAsJsonString(Schema schema, String name) {
+    // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
+    JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
+    return Jackson2Utils.toJsonString(node);
+  }
+
+  @Override
+  public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
+    // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
+    JsonNode node = Jackson2Utils.toJsonNode(value, strict);
+    schema.addProp(name, JacksonUtils.toObject(node));
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA;
+    Map<String, JsonNode> propsB;
+    try {
+      //noinspection unchecked
+      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> unfilteredPropsA;
+    Map<String, JsonNode> unfilteredPropsB;
+    try {
+      //noinspection unchecked
+      unfilteredPropsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      unfilteredPropsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
     }
 
-    @Override
-    public AvroVersion supportedMajorVersion() {
-        return AvroVersion.AVRO_1_10;
-    }
-
-    @Override
-    public BinaryEncoder newBinaryEncoder(OutputStream out, boolean buffered, BinaryEncoder reuse) {
-        if (buffered) {
-            return EncoderFactory.get().binaryEncoder(out, reuse);
-        } else {
-            return EncoderFactory.get().directBinaryEncoder(out, reuse);
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson2Utils.compareJsonProperties(unfilteredPropsA, unfilteredPropsB, compareStringProps,
+          compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
         }
-    }
-
-    @Override
-    public BinaryEncoder newBinaryEncoder(ObjectOutput out) {
-        return SpecificData.getEncoder(out);
-    }
-
-    @Override
-    public BinaryDecoder newBinaryDecoder(InputStream in, boolean buffered, BinaryDecoder reuse) {
-        DecoderFactory factory = DecoderFactory.get();
-        return buffered ? factory.binaryDecoder(in, reuse) : factory.directBinaryDecoder(in, reuse);
-    }
-
-    @Override
-    public BinaryDecoder newBinaryDecoder(ObjectInput in) {
-        return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
-    }
-
-    @Override
-    public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
-        return Avro110BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
-    }
-
-    @Override
-    public JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException {
-        return EncoderFactory.get().jsonEncoder(schema, out, pretty);
-    }
-
-    @Override
-    public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat) throws IOException {
-        return new CompatibleJsonEncoder(schema, out, pretty, jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
-    }
-
-    @Override
-    public JsonDecoder newJsonDecoder(Schema schema, InputStream in) throws IOException {
-        return DecoderFactory.get().jsonDecoder(schema, in);
-    }
-
-    @Override
-    public JsonDecoder newJsonDecoder(Schema schema, String in) throws IOException {
-        return DecoderFactory.get().jsonDecoder(schema, in);
-    }
-
-    @Override
-    public Decoder newCompatibleJsonDecoder(Schema schema, InputStream in) throws IOException {
-        return new CompatibleJsonDecoder(schema, in);
-    }
-
-    @Override
-    public Decoder newCompatibleJsonDecoder(Schema schema, String in) throws IOException {
-        return new CompatibleJsonDecoder(schema, in);
-    }
-
-    @Override
-    public SkipDecoder newCachedResolvingDecoder(Schema writer, Schema reader, Decoder in) throws IOException {
-        return new CachedResolvingDecoder(writer, reader, in);
-    }
-
-    @Override
-    public Decoder newBoundedMemoryDecoder(InputStream in) throws IOException {
-        return new BoundedMemoryDecoder(in);
-    }
-
-    @Override
-    public Decoder newBoundedMemoryDecoder(byte[] data) throws IOException {
-        return new BoundedMemoryDecoder(data);
-    }
-
-    @Override
-    public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
-        Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
-        return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
-    }
-
-    @Override
-    public SchemaParseResult parse(String schemaJson, SchemaParseConfiguration desiredConf, Collection<Schema> known) {
-        Schema.Parser parser = new Schema.Parser();
-        boolean validateNames = true;
-        boolean validateDefaults = true;
-        boolean validateNumericDefaultValueTypes = false;
-        boolean validateNoDanglingContent = false;
-        if (desiredConf != null) {
-            validateNames = desiredConf.validateNames();
-            validateDefaults = desiredConf.validateDefaultValues();
-            validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
-            validateNoDanglingContent = desiredConf.validateNoDanglingContent();
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
         }
-        SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
-            validateNames,
-            validateDefaults,
-            validateNumericDefaultValueTypes,
-            validateNoDanglingContent
-        );
-        parser.setValidate(validateNames);
-        //avro 1.10 default validation also validates numeric types, so if we want to be
-        //more nuanced we cant use avro's default value validation
-        if (validateDefaults && validateNumericDefaultValueTypes) {
-            parser.setValidateDefaults(true);
-        } else {
-            parser.setValidateDefaults(false);
+      }
+      return Jackson2Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
+    }
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(schema.getObjectProps().keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(field.getObjectProps().keySet());
+  }
+
+  @Override
+  public String getEnumDefault(Schema s) {
+    return s.getEnumDefault();
+  }
+
+  @Override
+  public Schema newEnumSchema(String name, String doc, String namespace, List<String> values, String enumDefault) {
+    return Schema.createEnum(name, doc, namespace, values, enumDefault);
+  }
+
+  @Override
+  public String toAvsc(Schema schema, AvscGenerationConfig config) {
+    boolean useRuntime;
+    if (!isRuntimeAvroCapableOf(config)) {
+      if (config.isForceUseOfRuntimeAvro()) {
+        throw new UnsupportedOperationException(
+            "desired configuration " + config + " is forced yet runtime avro " + supportedMajorVersion()
+                + " is not capable of it");
+      }
+      useRuntime = false;
+    } else {
+      useRuntime = config.isPreferUseOfRuntimeAvro();
+    }
+
+    if (useRuntime) {
+      return schema.toString(config.isPrettyPrint());
+    } else {
+      //if the user does not specify do whatever runtime avro would (which for 1.10 means produce correct schema)
+      boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+      Avro110AvscWriter writer =
+          new Avro110AvscWriter(config.isPrettyPrint(), usePre702Logic, config.isAddAvro702Aliases());
+      return writer.toAvsc(schema);
+    }
+  }
+
+  @Override
+  public Collection<AvroGeneratedSourceCode> compile(Collection<Schema> toCompile, AvroVersion minSupportedVersion,
+      AvroVersion maxSupportedVersion, CodeGenerationConfig config) {
+    if (!compilerSupported) {
+      throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
+    }
+    if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(
+        config.getStringRepresentation())) {
+      throw new IllegalArgumentException(
+          "StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro "
+              + minSupportedVersion);
+    }
+    if (toCompile == null || toCompile.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Map<String, String> fullNameToAlternativeAvsc;
+    if (!config.isAvro702HandlingEnabled()) {
+      fullNameToAlternativeAvsc = Collections.emptyMap();
+    } else {
+      fullNameToAlternativeAvsc = createAlternativeAvscs(toCompile, config);
+    }
+
+    Iterator<Schema> schemaIter = toCompile.iterator();
+    Schema first = schemaIter.next();
+    try {
+      //since avro-compiler may not be on the CP, we use pure reflection to deal with the compiler
+      Object compiler = specificCompilerCtr.newInstance(first);
+
+      //configure the compiler
+
+      switch (config.getStringRepresentation()) {
+        case CharSequence:
+          //this is the (only) way avro 1.4/5 generates code
+          setStringTypeMethod.invoke(compiler, charSequenceStringTypeEnumInstance);
+          break;
+        case String:
+          setStringTypeMethod.invoke(compiler, javaLangStringTypeEnumInstance);
+          break;
+        case Utf8:
+          setStringTypeMethod.invoke(compiler, utf8TypeEnumInstance);
+          break;
+        default:
+          throw new IllegalStateException("unhandled StringRepresentation " + config.getStringRepresentation());
+      }
+
+      //make fields public (as avro 1.4 and 1.5 do)
+      setFieldVisibilityMethod.invoke(compiler, publicFieldVisibilityEnumInstance);
+
+      while (schemaIter.hasNext()) {
+        compilerEnqueueMethod.invoke(compiler, schemaIter.next());
+      }
+
+      Collection<?> outputFiles = (Collection<?>) compilerCompileMethod.invoke(compiler);
+
+      List<AvroGeneratedSourceCode> sourceFiles = new ArrayList<>(outputFiles.size());
+      for (Object outputFile : outputFiles) {
+        AvroGeneratedSourceCode sourceCode = new AvroGeneratedSourceCode(getPath(outputFile), getContents(outputFile));
+        String altAvsc = fullNameToAlternativeAvsc.get(sourceCode.getFullyQualifiedClassName());
+        if (altAvsc != null) {
+          sourceCode.setAlternativeAvsc(altAvsc);
         }
-        if (known != null && !known.isEmpty()) {
-            Map<String, Schema> knownByFullName = new HashMap<>(known.size());
-            for (Schema s : known) {
-                knownByFullName.put(s.getFullName(), s);
-            }
-            parser.addTypes(knownByFullName);
-        }
-        Schema mainSchema = parser.parse(schemaJson);
-        Map<String, Schema> knownByFullName = parser.getTypes();
+        sourceFiles.add(sourceCode);
+      }
 
-        if (configUsed.validateDefaultValues()) {
-            //dont trust avro, also run our own. also we might have told avro not to validate over numerics
-            Avro110SchemaValidator validator = new Avro110SchemaValidator(configUsed, known);
-            AvroSchemaUtil.traverseSchema(mainSchema, validator);
-        }
-        if (configUsed.validateNoDanglingContent()) {
-            Jackson2Utils.assertNoTrailingContent(schemaJson);
-        }
-        //todo - depending on how https://issues.apache.org/jira/browse/AVRO-2742 is settled, may need to use our own validator here
-        return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
+      return transform(sourceFiles, minSupportedVersion, maxSupportedVersion);
+    } catch (UnsupportedOperationException e) {
+      throw e; //as-is
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
     }
+  }
 
-    @Override
-    public String toParsingForm(Schema s) {
-        return SchemaNormalization.toParsingForm(s);
+  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated,
+      AvroVersion minAvro, AvroVersion maxAvro) {
+    List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
+    for (AvroGeneratedSourceCode generated : avroGenerated) {
+      String fixed = CodeTransformations.applyAll(generated.getContents(), supportedMajorVersion(), minAvro, maxAvro,
+          generated.getAlternativeAvsc());
+      transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
     }
+    return transformed;
+  }
 
-    @Override
-    public String getDefaultValueAsJsonString(Schema.Field field) {
-        JsonNode json = Accessor.defaultValue(field);
-        if (json == null) {
-            throw new AvroRuntimeException("Field " + field + " has no default value");
-        }
-        return json.toString();
+  private String getPath(Object shouldBeOutputFile) {
+    try {
+      return (String) outputFilePathField.get(shouldBeOutputFile);
+    } catch (Exception e) {
+      throw new IllegalStateException("cant extract path from avro OutputFile", e);
     }
+  }
 
-    @Override
-    public Object newInstance(Class<?> clazz, Schema schema) {
-        return SpecificData.newInstance(clazz, schema);
+  private String getContents(Object shouldBeOutputFile) {
+    try {
+      return (String) outputFileContentsField.get(shouldBeOutputFile);
+    } catch (Exception e) {
+      throw new IllegalStateException("cant extract contents from avro OutputFile", e);
     }
+  }
 
-    @Override
-    public Object getSpecificDefaultValue(Schema.Field field) {
-        return SpecificData.get().getDefaultValue(field);
+  private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config cannot be null");
     }
-
-    @Override
-    public GenericData.EnumSymbol newEnumSymbol(Schema enumSchema, String enumValue) {
-        return new GenericData.EnumSymbol(enumSchema, enumValue);
+    if (config.isAddAvro702Aliases()) {
+      return false;
     }
-
-    @Override
-    public GenericData.Fixed newFixedField(Schema fixedSchema) {
-        return new GenericData.Fixed(fixedSchema);
+    Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+    //noinspection RedundantIfStatement
+    if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+      //avro 1.10 can only do correct avsc
+      return false;
     }
-
-    @Override
-    public GenericData.Fixed newFixedField(Schema fixedSchema, byte[] contents) {
-        return new GenericData.Fixed(fixedSchema, contents);
-    }
-
-    @Override
-    public Object getGenericDefaultValue(Schema.Field field) {
-        //always use our cache for the validation
-        return Avro110DefaultValuesCache.getDefaultValue(field, false);
-    }
-
-    @Override
-    public boolean fieldHasDefault(Schema.Field field) {
-        return field.hasDefaultValue();
-    }
-
-    @Override
-    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
-        JsonNode aVal = Accessor.defaultValue(a);
-        JsonNode bVal = Accessor.defaultValue(b);
-        return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
-    }
-
-    @Override
-    public Set<String> getFieldAliases(Schema.Field field) {
-        return field.aliases();
-    }
-
-    @Override
-    public FieldBuilder newFieldBuilder(Schema.Field other) {
-        return new FieldBuilder110(other);
-    }
-
-    @Override
-    public SchemaBuilder newSchemaBuilder(Schema other) {
-        return new SchemaBuilder110(this, other);
-    }
-
-    @Override
-    public String getFieldPropAsJsonString(Schema.Field field, String name) {
-        // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
-        JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
-        return Jackson2Utils.toJsonString(node);
-    }
-
-    @Override
-    public void setFieldPropFromJsonString(Schema.Field field, String name, String value, boolean strict) {
-        // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
-        JsonNode node = Jackson2Utils.toJsonNode(value, strict);
-        field.addProp(name, JacksonUtils.toObject(node));
-    }
-
-    @Override
-    public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
-        if (a == null || b == null) {
-            return false;
-        }
-        Map<String, JsonNode> propsA;
-        Map<String, JsonNode> propsB;
-        try {
-            //noinspection unchecked
-            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-            //noinspection unchecked
-            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-        } catch (Exception e) {
-            throw new IllegalStateException("unable to access JsonProperties.props", e);
-        }
-        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-    }
-
-    @Override
-    public String getSchemaPropAsJsonString(Schema schema, String name) {
-        // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
-        JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
-        return Jackson2Utils.toJsonString(node);
-    }
-
-    @Override
-    public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
-        // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
-        JsonNode node = Jackson2Utils.toJsonNode(value, strict);
-        schema.addProp(name, JacksonUtils.toObject(node));
-    }
-
-    @Override
-    public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-        if (a == null || b == null) {
-            return false;
-        }
-        Map<String, JsonNode> propsA;
-        Map<String, JsonNode> propsB;
-        try {
-            //noinspection unchecked
-            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-            //noinspection unchecked
-            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-        } catch (Exception e) {
-            throw new IllegalStateException("unable to access JsonProperties.props", e);
-        }
-        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-    }
-
-    @Override
-    public List<String> getAllPropNames(Schema schema) {
-        return new ArrayList<>(schema.getObjectProps().keySet());
-    }
-
-    @Override
-    public List<String> getAllPropNames(Schema.Field field) {
-        return new ArrayList<>(field.getObjectProps().keySet());
-    }
-
-    @Override
-    public String getEnumDefault(Schema s) {
-        return s.getEnumDefault();
-    }
-
-    @Override
-    public Schema newEnumSchema(String name, String doc, String namespace, List<String> values, String enumDefault) {
-        return Schema.createEnum(name, doc, namespace, values, enumDefault);
-    }
-
-    @Override
-    public String toAvsc(Schema schema, AvscGenerationConfig config) {
-        boolean useRuntime;
-        if (!isRuntimeAvroCapableOf(config)) {
-            if (config.isForceUseOfRuntimeAvro()) {
-                throw new UnsupportedOperationException("desired configuration " + config
-                        + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
-            }
-            useRuntime = false;
-        } else {
-            useRuntime = config.isPreferUseOfRuntimeAvro();
-        }
-
-        if (useRuntime) {
-            return schema.toString(config.isPrettyPrint());
-        } else {
-            //if the user does not specify do whatever runtime avro would (which for 1.10 means produce correct schema)
-            boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
-            Avro110AvscWriter writer = new Avro110AvscWriter(
-                    config.isPrettyPrint(),
-                    usePre702Logic,
-                    config.isAddAvro702Aliases()
-            );
-            return writer.toAvsc(schema);
-        }
-    }
-
-    @Override
-    public Collection<AvroGeneratedSourceCode> compile(
-        Collection<Schema> toCompile,
-        AvroVersion minSupportedVersion,
-        AvroVersion maxSupportedVersion,
-        CodeGenerationConfig config
-    ) {
-        if (!compilerSupported) {
-            throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
-        }
-        if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(config.getStringRepresentation())) {
-            throw new IllegalArgumentException("StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro " + minSupportedVersion);
-        }
-        if (toCompile == null || toCompile.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Map<String, String> fullNameToAlternativeAvsc;
-        if (!config.isAvro702HandlingEnabled()) {
-            fullNameToAlternativeAvsc = Collections.emptyMap();
-        } else {
-            fullNameToAlternativeAvsc = createAlternativeAvscs(toCompile, config);
-        }
-
-        Iterator<Schema> schemaIter = toCompile.iterator();
-        Schema first = schemaIter.next();
-        try {
-            //since avro-compiler may not be on the CP, we use pure reflection to deal with the compiler
-            Object compiler = specificCompilerCtr.newInstance(first);
-
-            //configure the compiler
-
-            switch (config.getStringRepresentation()) {
-                case CharSequence:
-                    //this is the (only) way avro 1.4/5 generates code
-                    setStringTypeMethod.invoke(compiler, charSequenceStringTypeEnumInstance);
-                    break;
-                case String:
-                    setStringTypeMethod.invoke(compiler, javaLangStringTypeEnumInstance);
-                    break;
-                case Utf8:
-                    setStringTypeMethod.invoke(compiler, utf8TypeEnumInstance);
-                    break;
-                default:
-                    throw new IllegalStateException("unhandled StringRepresentation " + config.getStringRepresentation());
-            }
-
-            //make fields public (as avro 1.4 and 1.5 do)
-            setFieldVisibilityMethod.invoke(compiler, publicFieldVisibilityEnumInstance);
-
-            while (schemaIter.hasNext()) {
-                compilerEnqueueMethod.invoke(compiler, schemaIter.next());
-            }
-
-            Collection<?> outputFiles = (Collection<?>) compilerCompileMethod.invoke(compiler);
-
-            List<AvroGeneratedSourceCode> sourceFiles = new ArrayList<>(outputFiles.size());
-            for (Object outputFile : outputFiles) {
-                AvroGeneratedSourceCode sourceCode = new AvroGeneratedSourceCode(getPath(outputFile), getContents(outputFile));
-                String altAvsc = fullNameToAlternativeAvsc.get(sourceCode.getFullyQualifiedClassName());
-                if (altAvsc != null) {
-                    sourceCode.setAlternativeAvsc(altAvsc);
-                }
-                sourceFiles.add(sourceCode);
-            }
-
-            return transform(sourceFiles, minSupportedVersion, maxSupportedVersion);
-        } catch (UnsupportedOperationException e) {
-            throw e; //as-is
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated, AvroVersion minAvro, AvroVersion maxAvro) {
-        List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
-        for (AvroGeneratedSourceCode generated : avroGenerated) {
-            String fixed = CodeTransformations.applyAll(
-                generated.getContents(),
-                supportedMajorVersion(),
-                minAvro,
-                maxAvro,
-                generated.getAlternativeAvsc()
-            );
-            transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
-        }
-        return transformed;
-    }
-
-    private String getPath(Object shouldBeOutputFile) {
-        try {
-            return (String) outputFilePathField.get(shouldBeOutputFile);
-        } catch (Exception e) {
-            throw new IllegalStateException("cant extract path from avro OutputFile", e);
-        }
-    }
-
-    private String getContents(Object shouldBeOutputFile) {
-        try {
-            return (String) outputFileContentsField.get(shouldBeOutputFile);
-        } catch (Exception e) {
-            throw new IllegalStateException("cant extract contents from avro OutputFile", e);
-        }
-    }
-
-    private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
-        if (config == null) {
-            throw new IllegalArgumentException("config cannot be null");
-        }
-        if (config.isAddAvro702Aliases()) {
-            return false;
-        }
-        Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
-        //noinspection RedundantIfStatement
-        if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
-            //avro 1.10 can only do correct avsc
-            return false;
-        }
-        return true;
-    }
+    return true;
+  }
 }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -66,507 +66,576 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+
 public class Avro111Adapter implements AvroAdapter {
 
-    private final Field jsonPropertiesPropsField;
-    private boolean compilerSupported;
-    private Throwable compilerSupportIssue;
-    private String compilerSupportMessage;
-    private Constructor<?> specificCompilerCtr;
-    private Method compilerEnqueueMethod;
-    private Method compilerCompileMethod;
-    private Field outputFilePathField;
-    private Field outputFileContentsField;
-    private Object publicFieldVisibilityEnumInstance;
-    private Method setFieldVisibilityMethod;
-    private Object charSequenceStringTypeEnumInstance;
-    private Object javaLangStringTypeEnumInstance;
-    private Object utf8TypeEnumInstance;
-    private Method setStringTypeMethod;
+  private final Field jsonPropertiesPropsField;
+  private boolean compilerSupported;
+  private Throwable compilerSupportIssue;
+  private String compilerSupportMessage;
+  private Constructor<?> specificCompilerCtr;
+  private Method compilerEnqueueMethod;
+  private Method compilerCompileMethod;
+  private Field outputFilePathField;
+  private Field outputFileContentsField;
+  private Object publicFieldVisibilityEnumInstance;
+  private Method setFieldVisibilityMethod;
+  private Object charSequenceStringTypeEnumInstance;
+  private Object javaLangStringTypeEnumInstance;
+  private Object utf8TypeEnumInstance;
+  private Method setStringTypeMethod;
 
-    public Avro111Adapter() {
-        try {
-            jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
-            jsonPropertiesPropsField.setAccessible(true);
-        } catch (Exception e) {
-            throw new IllegalStateException("error initializing adapter", e);
+  public Avro111Adapter() {
+    try {
+      jsonPropertiesPropsField = JsonProperties.class.getDeclaredField("props");
+      jsonPropertiesPropsField.setAccessible(true);
+    } catch (Exception e) {
+      throw new IllegalStateException("error initializing adapter", e);
+    }
+    tryInitializeCompilerFields();
+  }
+
+  private void tryInitializeCompilerFields() {
+    //compiler was moved out into a separate jar in avro 1.5+, so compiler functionality is optional
+    try {
+      Class<?> compilerClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler");
+      specificCompilerCtr = compilerClass.getConstructor(Schema.class);
+      compilerEnqueueMethod = compilerClass.getDeclaredMethod("enqueue", Schema.class);
+      compilerEnqueueMethod.setAccessible(true); //its normally private
+      compilerCompileMethod = compilerClass.getDeclaredMethod("compile");
+      compilerCompileMethod.setAccessible(true); //package-protected
+      Class<?> outputFileClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$OutputFile");
+      outputFilePathField = outputFileClass.getDeclaredField("path");
+      outputFilePathField.setAccessible(true);
+      outputFileContentsField = outputFileClass.getDeclaredField("contents");
+      outputFileContentsField.setAccessible(true);
+      Class<?> fieldVisibilityEnum =
+          Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
+      Field publicVisibilityField = fieldVisibilityEnum.getDeclaredField("PUBLIC");
+      publicFieldVisibilityEnumInstance = publicVisibilityField.get(null);
+      setFieldVisibilityMethod = compilerClass.getDeclaredMethod("setFieldVisibility", fieldVisibilityEnum);
+      Class<?> fieldTypeEnum = Class.forName("org.apache.avro.generic.GenericData$StringType");
+      Field charSequenceField = fieldTypeEnum.getDeclaredField("CharSequence");
+      charSequenceStringTypeEnumInstance = charSequenceField.get(null);
+      Field javaLangStringField = fieldTypeEnum.getDeclaredField("String");
+      javaLangStringTypeEnumInstance = javaLangStringField.get(null);
+      Field utf8Field = fieldTypeEnum.getDeclaredField("Utf8");
+      utf8TypeEnumInstance = utf8Field.get(null);
+      setStringTypeMethod = compilerClass.getDeclaredMethod("setStringType", fieldTypeEnum);
+      compilerSupported = true;
+    } catch (Exception | LinkageError e) {
+      //if a class we directly look for above isnt found, we get ClassNotFoundException
+      //but if we're missing a transitive dependency we will get NoClassDefFoundError
+      compilerSupported = false;
+      compilerSupportIssue = e;
+      String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
+      compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
+          + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
+      //ignore
+    }
+  }
+
+  @Override
+  public AvroVersion supportedMajorVersion() {
+    return AvroVersion.AVRO_1_11;
+  }
+
+  @Override
+  public BinaryEncoder newBinaryEncoder(OutputStream out, boolean buffered, BinaryEncoder reuse) {
+    if (buffered) {
+      return EncoderFactory.get().binaryEncoder(out, reuse);
+    } else {
+      return EncoderFactory.get().directBinaryEncoder(out, reuse);
+    }
+  }
+
+  @Override
+  public BinaryEncoder newBinaryEncoder(ObjectOutput out) {
+    return SpecificData.getEncoder(out);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(InputStream in, boolean buffered, BinaryDecoder reuse) {
+    DecoderFactory factory = DecoderFactory.get();
+    return buffered ? factory.binaryDecoder(in, reuse) : factory.directBinaryDecoder(in, reuse);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(ObjectInput in) {
+    return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
+  }
+
+  @Override
+  public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
+    return Avro111BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
+  }
+
+  @Override
+  public JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException {
+    return EncoderFactory.get().jsonEncoder(schema, out, pretty);
+  }
+
+  @Override
+  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat)
+      throws IOException {
+    return new CompatibleJsonEncoder(schema, out, pretty,
+        jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
+  }
+
+  @Override
+  public JsonDecoder newJsonDecoder(Schema schema, InputStream in) throws IOException {
+    return DecoderFactory.get().jsonDecoder(schema, in);
+  }
+
+  @Override
+  public JsonDecoder newJsonDecoder(Schema schema, String in) throws IOException {
+    return DecoderFactory.get().jsonDecoder(schema, in);
+  }
+
+  @Override
+  public Decoder newCompatibleJsonDecoder(Schema schema, InputStream in) throws IOException {
+    return new CompatibleJsonDecoder(schema, in);
+  }
+
+  @Override
+  public Decoder newCompatibleJsonDecoder(Schema schema, String in) throws IOException {
+    return new CompatibleJsonDecoder(schema, in);
+  }
+
+  @Override
+  public SkipDecoder newCachedResolvingDecoder(Schema writer, Schema reader, Decoder in) throws IOException {
+    return new CachedResolvingDecoder(writer, reader, in);
+  }
+
+  @Override
+  public Decoder newBoundedMemoryDecoder(InputStream in) throws IOException {
+    return new BoundedMemoryDecoder(in);
+  }
+
+  @Override
+  public Decoder newBoundedMemoryDecoder(byte[] data) throws IOException {
+    return new BoundedMemoryDecoder(data);
+  }
+
+  @Override
+  public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
+    Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
+    return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public SchemaParseResult parse(String schemaJson, SchemaParseConfiguration desiredConf, Collection<Schema> known) {
+    Schema.Parser parser = new Schema.Parser();
+    boolean validateNames = true;
+    boolean validateDefaults = true;
+    boolean validateNumericDefaultValueTypes = false;
+    boolean validateNoDanglingContent = false;
+    if (desiredConf != null) {
+      validateNames = desiredConf.validateNames();
+      validateDefaults = desiredConf.validateDefaultValues();
+      validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
+      validateNoDanglingContent = desiredConf.validateNoDanglingContent();
+    }
+    SchemaParseConfiguration configUsed =
+        new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes,
+            validateNoDanglingContent);
+    parser.setValidate(validateNames);
+    //avro 1.11 default validation also validates numeric types, so if we want to be
+    //more nuanced we cant use avro's default value validation
+    if (validateDefaults && validateNumericDefaultValueTypes) {
+      parser.setValidateDefaults(true);
+    } else {
+      parser.setValidateDefaults(false);
+    }
+    if (known != null && !known.isEmpty()) {
+      Map<String, Schema> knownByFullName = new HashMap<>(known.size());
+      for (Schema s : known) {
+        knownByFullName.put(s.getFullName(), s);
+      }
+      parser.addTypes(knownByFullName);
+    }
+    Schema mainSchema = parser.parse(schemaJson);
+    Map<String, Schema> knownByFullName = parser.getTypes();
+    if (configUsed.validateDefaultValues()) {
+      //dont trust avro, also run our own. also we might have told avro not to validate over numerics
+      Avro111SchemaValidator validator = new Avro111SchemaValidator(configUsed, known);
+      AvroSchemaUtil.traverseSchema(mainSchema, validator);
+    }
+    if (configUsed.validateNoDanglingContent()) {
+      Jackson2Utils.assertNoTrailingContent(schemaJson);
+    }
+    return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
+  }
+
+  @Override
+  public String toParsingForm(Schema s) {
+    return SchemaNormalization.toParsingForm(s);
+  }
+
+  @Override
+  public String getDefaultValueAsJsonString(Schema.Field field) {
+    JsonNode json = Accessor.defaultValue(field);
+    if (json == null) {
+      throw new AvroRuntimeException("Field " + field + " has no default value");
+    }
+    return json.toString();
+  }
+
+  @Override
+  public Object newInstance(Class<?> clazz, Schema schema) {
+    return SpecificData.newInstance(clazz, schema);
+  }
+
+  @Override
+  public Object getSpecificDefaultValue(Schema.Field field) {
+    return SpecificData.get().getDefaultValue(field);
+  }
+
+  @Override
+  public GenericData.EnumSymbol newEnumSymbol(Schema enumSchema, String enumValue) {
+    return new GenericData.EnumSymbol(enumSchema, enumValue);
+  }
+
+  @Override
+  public GenericData.Fixed newFixedField(Schema fixedSchema) {
+    return new GenericData.Fixed(fixedSchema);
+  }
+
+  @Override
+  public GenericData.Fixed newFixedField(Schema fixedSchema, byte[] contents) {
+    return new GenericData.Fixed(fixedSchema, contents);
+  }
+
+  @Override
+  public Object getGenericDefaultValue(Schema.Field field) {
+    //always use our cache for the validation
+    return Avro111DefaultValuesCache.getDefaultValue(field, false);
+  }
+
+  @Override
+  public boolean fieldHasDefault(Schema.Field field) {
+    return field.hasDefaultValue();
+  }
+
+  @Override
+  public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
+    JsonNode aVal = Accessor.defaultValue(a);
+    JsonNode bVal = Accessor.defaultValue(b);
+    return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
+  }
+
+  @Override
+  public Set<String> getFieldAliases(Schema.Field field) {
+    return field.aliases();
+  }
+
+  @Override
+  public FieldBuilder newFieldBuilder(Schema.Field other) {
+    return new FieldBuilder111(other);
+  }
+
+  @Override
+  public SchemaBuilder newSchemaBuilder(Schema other) {
+    return new SchemaBuilder111(this, other);
+  }
+
+  @Override
+  public String getFieldPropAsJsonString(Schema.Field field, String name) {
+    // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
+    JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
+    return Jackson2Utils.toJsonString(node);
+  }
+
+  @Override
+  public void setFieldPropFromJsonString(Schema.Field field, String name, String value, boolean strict) {
+    // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
+    JsonNode node = Jackson2Utils.toJsonNode(value, strict);
+    field.addProp(name, JacksonUtils.toObject(node));
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA;
+    Map<String, JsonNode> propsB;
+    try {
+      //noinspection unchecked
+      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> unfilteredPropsA;
+    Map<String, JsonNode> unfilteredPropsB;
+    try {
+      //noinspection unchecked
+      unfilteredPropsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      unfilteredPropsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson2Utils.compareJsonProperties(unfilteredPropsA, unfilteredPropsB, compareStringProps,
+          compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
         }
-        tryInitializeCompilerFields();
-    }
-
-    private void tryInitializeCompilerFields() {
-        //compiler was moved out into a separate jar in avro 1.5+, so compiler functionality is optional
-        try {
-            Class<?> compilerClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler");
-            specificCompilerCtr = compilerClass.getConstructor(Schema.class);
-            compilerEnqueueMethod = compilerClass.getDeclaredMethod("enqueue", Schema.class);
-            compilerEnqueueMethod.setAccessible(true); //its normally private
-            compilerCompileMethod = compilerClass.getDeclaredMethod("compile");
-            compilerCompileMethod.setAccessible(true); //package-protected
-            Class<?> outputFileClass = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$OutputFile");
-            outputFilePathField = outputFileClass.getDeclaredField("path");
-            outputFilePathField.setAccessible(true);
-            outputFileContentsField = outputFileClass.getDeclaredField("contents");
-            outputFileContentsField.setAccessible(true);
-            Class<?> fieldVisibilityEnum = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
-            Field publicVisibilityField = fieldVisibilityEnum.getDeclaredField("PUBLIC");
-            publicFieldVisibilityEnumInstance = publicVisibilityField.get(null);
-            setFieldVisibilityMethod = compilerClass.getDeclaredMethod("setFieldVisibility", fieldVisibilityEnum);
-            Class<?> fieldTypeEnum = Class.forName("org.apache.avro.generic.GenericData$StringType");
-            Field charSequenceField = fieldTypeEnum.getDeclaredField("CharSequence");
-            charSequenceStringTypeEnumInstance = charSequenceField.get(null);
-            Field javaLangStringField = fieldTypeEnum.getDeclaredField("String");
-            javaLangStringTypeEnumInstance = javaLangStringField.get(null);
-            Field utf8Field = fieldTypeEnum.getDeclaredField("Utf8");
-            utf8TypeEnumInstance = utf8Field.get(null);
-            setStringTypeMethod = compilerClass.getDeclaredMethod("setStringType", fieldTypeEnum);
-            compilerSupported = true;
-        } catch (Exception | LinkageError e) {
-            //if a class we directly look for above isnt found, we get ClassNotFoundException
-            //but if we're missing a transitive dependency we will get NoClassDefFoundError
-            compilerSupported = false;
-            compilerSupportIssue = e;
-            String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
-            compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
-                    + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
-            //ignore
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
         }
+      }
+      return Jackson2Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
+    }
+  }
+
+  @Override
+  public String getSchemaPropAsJsonString(Schema schema, String name) {
+    // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
+    JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
+    return Jackson2Utils.toJsonString(node);
+  }
+
+  @Override
+  public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
+    // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
+    JsonNode node = Jackson2Utils.toJsonNode(value, strict);
+    schema.addProp(name, JacksonUtils.toObject(node));
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> propsA;
+    Map<String, JsonNode> propsB;
+    try {
+      //noinspection unchecked
+      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
+    }
+    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore) {
+    if (a == null || b == null) {
+      return false;
+    }
+    Map<String, JsonNode> unfilteredPropsA;
+    Map<String, JsonNode> unfilteredPropsB;
+    try {
+      //noinspection unchecked
+      unfilteredPropsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
+      //noinspection unchecked
+      unfilteredPropsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties.props", e);
     }
 
-    @Override
-    public AvroVersion supportedMajorVersion() {
-        return AvroVersion.AVRO_1_11;
-    }
-
-    @Override
-    public BinaryEncoder newBinaryEncoder(OutputStream out, boolean buffered, BinaryEncoder reuse) {
-        if (buffered) {
-            return EncoderFactory.get().binaryEncoder(out, reuse);
-        } else {
-            return EncoderFactory.get().directBinaryEncoder(out, reuse);
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson2Utils.compareJsonProperties(unfilteredPropsA, unfilteredPropsB, compareStringProps,
+          compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
         }
-    }
-
-    @Override
-    public BinaryEncoder newBinaryEncoder(ObjectOutput out) {
-        return SpecificData.getEncoder(out);
-    }
-
-    @Override
-    public BinaryDecoder newBinaryDecoder(InputStream in, boolean buffered, BinaryDecoder reuse) {
-        DecoderFactory factory = DecoderFactory.get();
-        return buffered ? factory.binaryDecoder(in, reuse) : factory.directBinaryDecoder(in, reuse);
-    }
-
-    @Override
-    public BinaryDecoder newBinaryDecoder(ObjectInput in) {
-        return newBinaryDecoder(new ObjectInputToInputStreamAdapter(in), false, null);
-    }
-
-    @Override
-    public BinaryDecoder newBinaryDecoder(byte[] bytes, int offset, int length, BinaryDecoder reuse) {
-        return Avro111BinaryDecoderAccessUtil.newBinaryDecoder(bytes, offset, length, reuse);
-    }
-
-    @Override
-    public JsonEncoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty) throws IOException {
-        return EncoderFactory.get().jsonEncoder(schema, out, pretty);
-    }
-
-    @Override
-    public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat) throws IOException {
-        return new CompatibleJsonEncoder(schema, out, pretty, jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
-    }
-
-    @Override
-    public JsonDecoder newJsonDecoder(Schema schema, InputStream in) throws IOException {
-        return DecoderFactory.get().jsonDecoder(schema, in);
-    }
-
-    @Override
-    public JsonDecoder newJsonDecoder(Schema schema, String in) throws IOException {
-        return DecoderFactory.get().jsonDecoder(schema, in);
-    }
-
-    @Override
-    public Decoder newCompatibleJsonDecoder(Schema schema, InputStream in) throws IOException {
-        return new CompatibleJsonDecoder(schema, in);
-    }
-
-    @Override
-    public Decoder newCompatibleJsonDecoder(Schema schema, String in) throws IOException {
-        return new CompatibleJsonDecoder(schema, in);
-    }
-
-    @Override
-    public SkipDecoder newCachedResolvingDecoder(Schema writer, Schema reader, Decoder in) throws IOException {
-        return new CachedResolvingDecoder(writer, reader, in);
-    }
-
-    @Override
-    public Decoder newBoundedMemoryDecoder(InputStream in) throws IOException {
-        return new BoundedMemoryDecoder(in);
-    }
-
-    @Override
-    public Decoder newBoundedMemoryDecoder(byte[] data) throws IOException {
-        return new BoundedMemoryDecoder(data);
-    }
-
-    @Override
-    public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
-        Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
-        return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
-    }
-
-    @Override
-    public SchemaParseResult parse(String schemaJson, SchemaParseConfiguration desiredConf, Collection<Schema> known) {
-        Schema.Parser parser = new Schema.Parser();
-        boolean validateNames = true;
-        boolean validateDefaults = true;
-        boolean validateNumericDefaultValueTypes = false;
-        boolean validateNoDanglingContent = false;
-        if (desiredConf != null) {
-            validateNames = desiredConf.validateNames();
-            validateDefaults = desiredConf.validateDefaultValues();
-            validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
-            validateNoDanglingContent = desiredConf.validateNoDanglingContent();
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
         }
-        SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
-            validateNames,
-            validateDefaults,
-            validateNumericDefaultValueTypes,
-            validateNoDanglingContent
-        );
-        parser.setValidate(validateNames);
-        //avro 1.11 default validation also validates numeric types, so if we want to be
-        //more nuanced we cant use avro's default value validation
-        if (validateDefaults && validateNumericDefaultValueTypes) {
-            parser.setValidateDefaults(true);
-        } else {
-            parser.setValidateDefaults(false);
+      }
+      return Jackson2Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
+    }
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema schema) {
+    return new ArrayList<>(schema.getObjectProps().keySet());
+  }
+
+  @Override
+  public List<String> getAllPropNames(Schema.Field field) {
+    return new ArrayList<>(field.getObjectProps().keySet());
+  }
+
+  @Override
+  public String getEnumDefault(Schema s) {
+    return s.getEnumDefault();
+  }
+
+  @Override
+  public Schema newEnumSchema(String name, String doc, String namespace, List<String> values, String enumDefault) {
+    return Schema.createEnum(name, doc, namespace, values, enumDefault);
+  }
+
+  @Override
+  public String toAvsc(Schema schema, AvscGenerationConfig config) {
+    boolean useRuntime;
+    if (!isRuntimeAvroCapableOf(config)) {
+      if (config.isForceUseOfRuntimeAvro()) {
+        throw new UnsupportedOperationException(
+            "desired configuration " + config + " is forced yet runtime avro " + supportedMajorVersion()
+                + " is not capable of it");
+      }
+      useRuntime = false;
+    } else {
+      useRuntime = config.isPreferUseOfRuntimeAvro();
+    }
+
+    if (useRuntime) {
+      return schema.toString(config.isPrettyPrint());
+    } else {
+      //if the user does not specify do whatever runtime avro would (which for 1.11 means produce correct schema)
+      boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
+      Avro111AvscWriter writer =
+          new Avro111AvscWriter(config.isPrettyPrint(), usePre702Logic, config.isAddAvro702Aliases());
+      return writer.toAvsc(schema);
+    }
+  }
+
+  @Override
+  public Collection<AvroGeneratedSourceCode> compile(Collection<Schema> toCompile, AvroVersion minSupportedVersion,
+      AvroVersion maxSupportedVersion, CodeGenerationConfig config) {
+    if (!compilerSupported) {
+      throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
+    }
+    if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(
+        config.getStringRepresentation())) {
+      throw new IllegalArgumentException(
+          "StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro "
+              + minSupportedVersion);
+    }
+    if (toCompile == null || toCompile.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Map<String, String> fullNameToAlternativeAvsc;
+    if (!config.isAvro702HandlingEnabled()) {
+      fullNameToAlternativeAvsc = Collections.emptyMap();
+    } else {
+      fullNameToAlternativeAvsc = createAlternativeAvscs(toCompile, config);
+    }
+
+    Iterator<Schema> schemaIter = toCompile.iterator();
+    Schema first = schemaIter.next();
+    try {
+      //since avro-compiler may not be on the CP, we use pure reflection to deal with the compiler
+      Object compiler = specificCompilerCtr.newInstance(first);
+
+      //configure the compiler
+
+      switch (config.getStringRepresentation()) {
+        case CharSequence:
+          //this is the (only) way avro 1.4/5 generates code
+          setStringTypeMethod.invoke(compiler, charSequenceStringTypeEnumInstance);
+          break;
+        case String:
+          setStringTypeMethod.invoke(compiler, javaLangStringTypeEnumInstance);
+          break;
+        case Utf8:
+          setStringTypeMethod.invoke(compiler, utf8TypeEnumInstance);
+          break;
+        default:
+          throw new IllegalStateException("unhandled StringRepresentation " + config.getStringRepresentation());
+      }
+
+      //make fields public (as avro 1.4 and 1.5 do)
+      setFieldVisibilityMethod.invoke(compiler, publicFieldVisibilityEnumInstance);
+
+      while (schemaIter.hasNext()) {
+        compilerEnqueueMethod.invoke(compiler, schemaIter.next());
+      }
+
+      Collection<?> outputFiles = (Collection<?>) compilerCompileMethod.invoke(compiler);
+
+      List<AvroGeneratedSourceCode> sourceFiles = new ArrayList<>(outputFiles.size());
+      for (Object outputFile : outputFiles) {
+        AvroGeneratedSourceCode sourceCode = new AvroGeneratedSourceCode(getPath(outputFile), getContents(outputFile));
+        String altAvsc = fullNameToAlternativeAvsc.get(sourceCode.getFullyQualifiedClassName());
+        if (altAvsc != null) {
+          sourceCode.setAlternativeAvsc(altAvsc);
         }
-        if (known != null && !known.isEmpty()) {
-            Map<String, Schema> knownByFullName = new HashMap<>(known.size());
-            for (Schema s : known) {
-                knownByFullName.put(s.getFullName(), s);
-            }
-            parser.addTypes(knownByFullName);
-        }
-        Schema mainSchema = parser.parse(schemaJson);
-        Map<String, Schema> knownByFullName = parser.getTypes();
-        if (configUsed.validateDefaultValues()) {
-            //dont trust avro, also run our own. also we might have told avro not to validate over numerics
-            Avro111SchemaValidator validator = new Avro111SchemaValidator(configUsed, known);
-            AvroSchemaUtil.traverseSchema(mainSchema, validator);
-        }
-        if (configUsed.validateNoDanglingContent()) {
-            Jackson2Utils.assertNoTrailingContent(schemaJson);
-        }
-        return new SchemaParseResult(mainSchema, knownByFullName, configUsed);
+        sourceFiles.add(sourceCode);
+      }
+
+      return transform(sourceFiles, minSupportedVersion, maxSupportedVersion);
+    } catch (UnsupportedOperationException e) {
+      throw e; //as-is
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
     }
+  }
 
-    @Override
-    public String toParsingForm(Schema s) {
-        return SchemaNormalization.toParsingForm(s);
+  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated,
+      AvroVersion minAvro, AvroVersion maxAvro) {
+    List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
+    for (AvroGeneratedSourceCode generated : avroGenerated) {
+      String fixed = CodeTransformations.applyAll(generated.getContents(), supportedMajorVersion(), minAvro, maxAvro,
+          generated.getAlternativeAvsc());
+      transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
     }
+    return transformed;
+  }
 
-    @Override
-    public String getDefaultValueAsJsonString(Schema.Field field) {
-        JsonNode json = Accessor.defaultValue(field);
-        if (json == null) {
-            throw new AvroRuntimeException("Field " + field + " has no default value");
-        }
-        return json.toString();
+  private String getPath(Object shouldBeOutputFile) {
+    try {
+      return (String) outputFilePathField.get(shouldBeOutputFile);
+    } catch (Exception e) {
+      throw new IllegalStateException("cant extract path from avro OutputFile", e);
     }
+  }
 
-    @Override
-    public Object newInstance(Class<?> clazz, Schema schema) {
-        return SpecificData.newInstance(clazz, schema);
+  private String getContents(Object shouldBeOutputFile) {
+    try {
+      return (String) outputFileContentsField.get(shouldBeOutputFile);
+    } catch (Exception e) {
+      throw new IllegalStateException("cant extract contents from avro OutputFile", e);
     }
+  }
 
-    @Override
-    public Object getSpecificDefaultValue(Schema.Field field) {
-        return SpecificData.get().getDefaultValue(field);
+  private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
+    if (config == null) {
+      throw new IllegalArgumentException("config cannot be null");
     }
-
-    @Override
-    public GenericData.EnumSymbol newEnumSymbol(Schema enumSchema, String enumValue) {
-        return new GenericData.EnumSymbol(enumSchema, enumValue);
+    if (config.isAddAvro702Aliases()) {
+      return false;
     }
-
-    @Override
-    public GenericData.Fixed newFixedField(Schema fixedSchema) {
-        return new GenericData.Fixed(fixedSchema);
+    Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
+    //noinspection RedundantIfStatement
+    if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
+      //avro 1.11 can only do correct avsc
+      return false;
     }
-
-    @Override
-    public GenericData.Fixed newFixedField(Schema fixedSchema, byte[] contents) {
-        return new GenericData.Fixed(fixedSchema, contents);
-    }
-
-    @Override
-    public Object getGenericDefaultValue(Schema.Field field) {
-        //always use our cache for the validation
-        return Avro111DefaultValuesCache.getDefaultValue(field, false);
-    }
-
-    @Override
-    public boolean fieldHasDefault(Schema.Field field) {
-        return field.hasDefaultValue();
-    }
-
-    @Override
-    public boolean defaultValuesEqual(Schema.Field a, Schema.Field b, boolean allowLooseNumerics) {
-        JsonNode aVal = Accessor.defaultValue(a);
-        JsonNode bVal = Accessor.defaultValue(b);
-        return Jackson2Utils.JsonNodesEqual(aVal, bVal, allowLooseNumerics);
-    }
-
-    @Override
-    public Set<String> getFieldAliases(Schema.Field field) {
-        return field.aliases();
-    }
-
-    @Override
-    public FieldBuilder newFieldBuilder(Schema.Field other) {
-        return new FieldBuilder111(other);
-    }
-
-    @Override
-    public SchemaBuilder newSchemaBuilder(Schema other) {
-        return new SchemaBuilder111(this, other);
-    }
-
-    @Override
-    public String getFieldPropAsJsonString(Schema.Field field, String name) {
-        // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
-        JsonNode node = JacksonUtils.toJsonNode(field.getObjectProp(name));
-        return Jackson2Utils.toJsonString(node);
-    }
-
-    @Override
-    public void setFieldPropFromJsonString(Schema.Field field, String name, String value, boolean strict) {
-        // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
-        JsonNode node = Jackson2Utils.toJsonNode(value, strict);
-        field.addProp(name, JacksonUtils.toObject(node));
-    }
-
-    @Override
-    public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
-        if (a == null || b == null) {
-            return false;
-        }
-        Map<String, JsonNode> propsA;
-        Map<String, JsonNode> propsB;
-        try {
-            //noinspection unchecked
-            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-            //noinspection unchecked
-            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-        } catch (Exception e) {
-            throw new IllegalStateException("unable to access JsonProperties.props", e);
-        }
-        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-    }
-
-    @Override
-    public String getSchemaPropAsJsonString(Schema schema, String name) {
-        // Goes from JsonNode to Object to JsonNode (again) to String. Painful, but suffices until somebody complains.
-        JsonNode node = JacksonUtils.toJsonNode(schema.getObjectProp(name));
-        return Jackson2Utils.toJsonString(node);
-    }
-
-    @Override
-    public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
-        // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
-        JsonNode node = Jackson2Utils.toJsonNode(value, strict);
-        schema.addProp(name, JacksonUtils.toObject(node));
-    }
-
-    @Override
-    public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-        if (a == null || b == null) {
-            return false;
-        }
-        Map<String, JsonNode> propsA;
-        Map<String, JsonNode> propsB;
-        try {
-            //noinspection unchecked
-            propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-            //noinspection unchecked
-            propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-        } catch (Exception e) {
-            throw new IllegalStateException("unable to access JsonProperties.props", e);
-        }
-        return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-    }
-
-    @Override
-    public List<String> getAllPropNames(Schema schema) {
-        return new ArrayList<>(schema.getObjectProps().keySet());
-    }
-
-    @Override
-    public List<String> getAllPropNames(Schema.Field field) {
-        return new ArrayList<>(field.getObjectProps().keySet());
-    }
-
-    @Override
-    public String getEnumDefault(Schema s) {
-        return s.getEnumDefault();
-    }
-
-    @Override
-    public Schema newEnumSchema(String name, String doc, String namespace, List<String> values, String enumDefault) {
-        return Schema.createEnum(name, doc, namespace, values, enumDefault);
-    }
-
-    @Override
-    public String toAvsc(Schema schema, AvscGenerationConfig config) {
-        boolean useRuntime;
-        if (!isRuntimeAvroCapableOf(config)) {
-            if (config.isForceUseOfRuntimeAvro()) {
-                throw new UnsupportedOperationException("desired configuration " + config
-                        + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
-            }
-            useRuntime = false;
-        } else {
-            useRuntime = config.isPreferUseOfRuntimeAvro();
-        }
-
-        if (useRuntime) {
-            return schema.toString(config.isPrettyPrint());
-        } else {
-            //if the user does not specify do whatever runtime avro would (which for 1.11 means produce correct schema)
-            boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
-            Avro111AvscWriter writer = new Avro111AvscWriter(
-                    config.isPrettyPrint(),
-                    usePre702Logic,
-                    config.isAddAvro702Aliases()
-            );
-            return writer.toAvsc(schema);
-        }
-    }
-
-    @Override
-    public Collection<AvroGeneratedSourceCode> compile(
-        Collection<Schema> toCompile,
-        AvroVersion minSupportedVersion,
-        AvroVersion maxSupportedVersion,
-        CodeGenerationConfig config
-    ) {
-        if (!compilerSupported) {
-            throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
-        }
-        if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(config.getStringRepresentation())) {
-            throw new IllegalArgumentException("StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro " + minSupportedVersion);
-        }
-        if (toCompile == null || toCompile.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Map<String, String> fullNameToAlternativeAvsc;
-        if (!config.isAvro702HandlingEnabled()) {
-            fullNameToAlternativeAvsc = Collections.emptyMap();
-        } else {
-            fullNameToAlternativeAvsc = createAlternativeAvscs(toCompile, config);
-        }
-
-        Iterator<Schema> schemaIter = toCompile.iterator();
-        Schema first = schemaIter.next();
-        try {
-            //since avro-compiler may not be on the CP, we use pure reflection to deal with the compiler
-            Object compiler = specificCompilerCtr.newInstance(first);
-
-            //configure the compiler
-
-            switch (config.getStringRepresentation()) {
-                case CharSequence:
-                    //this is the (only) way avro 1.4/5 generates code
-                    setStringTypeMethod.invoke(compiler, charSequenceStringTypeEnumInstance);
-                    break;
-                case String:
-                    setStringTypeMethod.invoke(compiler, javaLangStringTypeEnumInstance);
-                    break;
-                case Utf8:
-                    setStringTypeMethod.invoke(compiler, utf8TypeEnumInstance);
-                    break;
-                default:
-                    throw new IllegalStateException("unhandled StringRepresentation " + config.getStringRepresentation());
-            }
-
-            //make fields public (as avro 1.4 and 1.5 do)
-            setFieldVisibilityMethod.invoke(compiler, publicFieldVisibilityEnumInstance);
-
-            while (schemaIter.hasNext()) {
-                compilerEnqueueMethod.invoke(compiler, schemaIter.next());
-            }
-
-            Collection<?> outputFiles = (Collection<?>) compilerCompileMethod.invoke(compiler);
-
-            List<AvroGeneratedSourceCode> sourceFiles = new ArrayList<>(outputFiles.size());
-            for (Object outputFile : outputFiles) {
-                AvroGeneratedSourceCode sourceCode = new AvroGeneratedSourceCode(getPath(outputFile), getContents(outputFile));
-                String altAvsc = fullNameToAlternativeAvsc.get(sourceCode.getFullyQualifiedClassName());
-                if (altAvsc != null) {
-                    sourceCode.setAlternativeAvsc(altAvsc);
-                }
-                sourceFiles.add(sourceCode);
-            }
-
-            return transform(sourceFiles, minSupportedVersion, maxSupportedVersion);
-        } catch (UnsupportedOperationException e) {
-            throw e; //as-is
-        } catch (Exception e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated, AvroVersion minAvro, AvroVersion maxAvro) {
-        List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
-        for (AvroGeneratedSourceCode generated : avroGenerated) {
-            String fixed = CodeTransformations.applyAll(
-                generated.getContents(),
-                supportedMajorVersion(),
-                minAvro,
-                maxAvro,
-                generated.getAlternativeAvsc()
-            );
-            transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
-        }
-        return transformed;
-    }
-
-    private String getPath(Object shouldBeOutputFile) {
-        try {
-            return (String) outputFilePathField.get(shouldBeOutputFile);
-        } catch (Exception e) {
-            throw new IllegalStateException("cant extract path from avro OutputFile", e);
-        }
-    }
-
-    private String getContents(Object shouldBeOutputFile) {
-        try {
-            return (String) outputFileContentsField.get(shouldBeOutputFile);
-        } catch (Exception e) {
-            throw new IllegalStateException("cant extract contents from avro OutputFile", e);
-        }
-    }
-
-    private boolean isRuntimeAvroCapableOf(AvscGenerationConfig config) {
-        if (config == null) {
-            throw new IllegalArgumentException("config cannot be null");
-        }
-        if (config.isAddAvro702Aliases()) {
-            return false;
-        }
-        Optional<Boolean> preAvro702Output = config.getRetainPreAvro702Logic();
-        //noinspection RedundantIfStatement
-        if (preAvro702Output.isPresent() && preAvro702Output.get().equals(Boolean.TRUE)) {
-            //avro 1.11 can only do correct avsc
-            return false;
-        }
-        return true;
-    }
+    return true;
+  }
 }

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -355,25 +355,6 @@ public class Avro111Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA;
-    Map<String, JsonNode> propsB;
-    try {
-      //noinspection unchecked
-      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-      //noinspection unchecked
-      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access JsonProperties.props", e);
-    }
-    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (a == null || b == null) {
       return false;
@@ -421,24 +402,6 @@ public class Avro111Adapter implements AvroAdapter {
     // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
     JsonNode node = Jackson2Utils.toJsonNode(value, strict);
     schema.addProp(name, JacksonUtils.toObject(node));
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA;
-    Map<String, JsonNode> propsB;
-    try {
-      //noinspection unchecked
-      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-      //noinspection unchecked
-      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access JsonProperties.props", e);
-    }
-    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -341,24 +341,6 @@ public class Avro14Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (compareNonStringProps) {
-      throw new IllegalArgumentException(
-          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
-    }
-    if (a == null || b == null) {
-      return false;
-    }
-    if (!compareStringProps) {
-      return true;
-    }
-    Map<String, String> aProps = getPropsMap(a);
-    Map<String, String> bProps = getPropsMap(b);
-    return Objects.equals(aProps, bProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (compareNonStringProps) {
       throw new IllegalArgumentException(
@@ -400,23 +382,6 @@ public class Avro14Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (compareNonStringProps) {
-      throw new IllegalArgumentException(
-          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
-    }
-    if (a == null || b == null) {
-      return false;
-    }
-    if (!compareStringProps) {
-      return true;
-    }
-    Map<String, String> aProps = getPropsMap(a);
-    Map<String, String> bProps = getPropsMap(b);
-    return Objects.equals(aProps, bProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -368,24 +368,6 @@ public class Avro15Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (compareNonStringProps) {
-      throw new IllegalArgumentException(
-          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
-    }
-    if (a == null || b == null) {
-      return false;
-    }
-    if (!compareStringProps) {
-      return true;
-    }
-    Map<String, String> aProps = getPropsMap(a);
-    Map<String, String> bProps = getPropsMap(b);
-    return Objects.equals(aProps, bProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (compareNonStringProps) {
       throw new IllegalArgumentException(
@@ -427,23 +409,6 @@ public class Avro15Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (compareNonStringProps) {
-      throw new IllegalArgumentException(
-          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
-    }
-    if (a == null || b == null) {
-      return false;
-    }
-    if (!compareStringProps) {
-      return true;
-    }
-    Map<String, String> aProps = getPropsMap(a);
-    Map<String, String> bProps = getPropsMap(b);
-    return Objects.equals(aProps, bProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -123,7 +123,7 @@ public class Avro15Adapter implements AvroAdapter {
       compilerSupportIssue = e;
       String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
       compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
-              + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
+          + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
       //ignore
     }
   }
@@ -173,8 +173,10 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
-  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat) throws IOException {
-    return new CompatibleJsonEncoder(schema, out, pretty, jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
+  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat)
+      throws IOException {
+    return new CompatibleJsonEncoder(schema, out, pretty,
+        jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
   }
 
   @Override
@@ -231,12 +233,9 @@ public class Avro15Adapter implements AvroAdapter {
       validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
       validateNoDanglingContent = desiredConf.validateNoDanglingContent();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
-        validateNames,
-        validateDefaults,
-        validateNumericDefaultValueTypes,
-        validateNoDanglingContent
-    );
+    SchemaParseConfiguration configUsed =
+        new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes,
+            validateNoDanglingContent);
 
     parser.setValidate(validateNames);
     if (known != null && !known.isEmpty()) {
@@ -368,10 +367,11 @@ public class Avro15Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps) {
     if (compareNonStringProps) {
-      throw new IllegalArgumentException("avro " + supportedMajorVersion()
-          + " does not preserve non-string props and so cannot compare them");
+      throw new IllegalArgumentException(
+          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
     }
     if (a == null || b == null) {
       return false;
@@ -382,6 +382,41 @@ public class Avro15Adapter implements AvroAdapter {
     Map<String, String> aProps = getPropsMap(a);
     Map<String, String> bProps = getPropsMap(b);
     return Objects.equals(aProps, bProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    if (compareNonStringProps) {
+      throw new IllegalArgumentException(
+          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    if (!compareStringProps) {
+      return true;
+    }
+    Map<String, String> unfilteredPropsA = getPropsMap(a);
+    Map<String, String> unfilteredPropsB = getPropsMap(b);
+
+    if (jsonPropNamesToIgnore == null) {
+      return Objects.equals(unfilteredPropsA, unfilteredPropsB);
+    } else {
+      Map<String, String> aProps = new HashMap<>();
+      Map<String, String> bProps = new HashMap<>();
+      for (Map.Entry<String, String> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      for (Map.Entry<String, String> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return Objects.equals(aProps, bProps);
+    }
   }
 
   @Override
@@ -397,8 +432,8 @@ public class Avro15Adapter implements AvroAdapter {
   @Override
   public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
     if (compareNonStringProps) {
-      throw new IllegalArgumentException("avro " + supportedMajorVersion()
-          + " does not preserve non-string props and so cannot compare them");
+      throw new IllegalArgumentException(
+          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
     }
     if (a == null || b == null) {
       return false;
@@ -409,6 +444,41 @@ public class Avro15Adapter implements AvroAdapter {
     Map<String, String> aProps = getPropsMap(a);
     Map<String, String> bProps = getPropsMap(b);
     return Objects.equals(aProps, bProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore) {
+    if (compareNonStringProps) {
+      throw new IllegalArgumentException(
+          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
+    }
+    if (a == null || b == null) {
+      return false;
+    }
+    if (!compareStringProps) {
+      return true;
+    }
+    Map<String, String> unfilteredPropsA = getPropsMap(a);
+    Map<String, String> unfilteredPropsB = getPropsMap(b);
+
+    if (jsonPropNamesToIgnore == null) {
+      return Objects.equals(unfilteredPropsA, unfilteredPropsB);
+    } else {
+      Map<String, String> aProps = new HashMap<>();
+      Map<String, String> bProps = new HashMap<>();
+      for (Map.Entry<String, String> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      for (Map.Entry<String, String> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return Objects.equals(aProps, bProps);
+    }
   }
 
   @Override
@@ -431,8 +501,9 @@ public class Avro15Adapter implements AvroAdapter {
     boolean useRuntime;
     if (!isRuntimeAvroCapableOf(config)) {
       if (config.isForceUseOfRuntimeAvro()) {
-        throw new UnsupportedOperationException("desired configuration " + config
-                + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+        throw new UnsupportedOperationException(
+            "desired configuration " + config + " is forced yet runtime avro " + supportedMajorVersion()
+                + " is not capable of it");
       }
       useRuntime = false;
     } else {
@@ -444,27 +515,22 @@ public class Avro15Adapter implements AvroAdapter {
     } else {
       //if the user does not specify do whatever runtime avro would (which for 1.5 means produce correct schema)
       boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
-      Avro15AvscWriter writer = new Avro15AvscWriter(
-              config.isPrettyPrint(),
-              usePre702Logic,
-              config.isAddAvro702Aliases()
-      );
+      Avro15AvscWriter writer =
+          new Avro15AvscWriter(config.isPrettyPrint(), usePre702Logic, config.isAddAvro702Aliases());
       return writer.toAvsc(schema);
     }
   }
 
   @Override
-  public Collection<AvroGeneratedSourceCode> compile(
-      Collection<Schema> toCompile,
-      AvroVersion minSupportedVersion,
-      AvroVersion maxSupportedVersion,
-      CodeGenerationConfig config
-  ) {
+  public Collection<AvroGeneratedSourceCode> compile(Collection<Schema> toCompile, AvroVersion minSupportedVersion,
+      AvroVersion maxSupportedVersion, CodeGenerationConfig config) {
     if (!compilerSupported) {
       throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
     }
     if (!StringRepresentation.CharSequence.equals(config.getStringRepresentation())) {
-      throw new UnsupportedOperationException("generating String fields as " + config.getStringRepresentation() + " unsupported under avro " + supportedMajorVersion());
+      throw new UnsupportedOperationException(
+          "generating String fields as " + config.getStringRepresentation() + " unsupported under avro "
+              + supportedMajorVersion());
     }
     if (toCompile == null || toCompile.isEmpty()) {
       return Collections.emptyList();
@@ -509,16 +575,12 @@ public class Avro15Adapter implements AvroAdapter {
     }
   }
 
-  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated, AvroVersion minAvro, AvroVersion maxAvro) {
+  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated,
+      AvroVersion minAvro, AvroVersion maxAvro) {
     List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
     for (AvroGeneratedSourceCode generated : avroGenerated) {
-      String fixed = CodeTransformations.applyAll(
-          generated.getContents(),
-          supportedMajorVersion(),
-          minAvro,
-          maxAvro,
-          generated.getAlternativeAvsc()
-      );
+      String fixed = CodeTransformations.applyAll(generated.getContents(), supportedMajorVersion(), minAvro, maxAvro,
+          generated.getAlternativeAvsc());
       transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
     }
     return transformed;

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -340,24 +340,6 @@ public class Avro16Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (compareNonStringProps) {
-      throw new IllegalArgumentException(
-          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
-    }
-    if (a == null || b == null) {
-      return false;
-    }
-    if (!compareStringProps) {
-      return true;
-    }
-    Map<String, String> aProps = a.props();
-    Map<String, String> bProps = b.props();
-    return Objects.equals(aProps, bProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (compareNonStringProps) {
       throw new IllegalArgumentException(
@@ -399,23 +381,6 @@ public class Avro16Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (compareNonStringProps) {
-      throw new IllegalArgumentException(
-          "avro " + supportedMajorVersion() + " does not preserve non-string props and so cannot compare them");
-    }
-    if (a == null || b == null) {
-      return false;
-    }
-    if (!compareStringProps) {
-      return true;
-    }
-    Map<String, String> aProps = a.getProps();
-    Map<String, String> bProps = b.getProps();
-    return Objects.equals(aProps, bProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -387,12 +387,6 @@ public class Avro17Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, null);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
   }
@@ -405,11 +399,6 @@ public class Avro17Adapter implements AvroAdapter {
   @Override
   public void setSchemaPropFromJsonString(Schema schema, String name, String value, boolean strict) {
     Avro17Utils.setJsonProp(schema, name, value, strict);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, null);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -118,7 +118,8 @@ public class Avro17Adapter implements AvroAdapter {
       outputFilePathField.setAccessible(true);
       outputFileContentsField = outputFileClass.getDeclaredField("contents");
       outputFileContentsField.setAccessible(true);
-      Class<?> fieldVisibilityEnum = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
+      Class<?> fieldVisibilityEnum =
+          Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
       Field publicVisibilityField = fieldVisibilityEnum.getDeclaredField("PUBLIC");
       publicFieldVisibilityEnumInstance = publicVisibilityField.get(null);
       setFieldVisibilityMethod = compilerClass.getDeclaredMethod("setFieldVisibility", fieldVisibilityEnum);
@@ -138,7 +139,7 @@ public class Avro17Adapter implements AvroAdapter {
       compilerSupportIssue = e;
       String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
       compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
-              + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
+          + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
       //ignore
     }
 
@@ -206,8 +207,10 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
-  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat) throws IOException {
-    return new CompatibleJsonEncoder(schema, out, pretty, jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
+  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat)
+      throws IOException {
+    return new CompatibleJsonEncoder(schema, out, pretty,
+        jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
   }
 
   @Override
@@ -264,12 +267,9 @@ public class Avro17Adapter implements AvroAdapter {
       validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
       validateNoDanglingContent = desiredConf.validateNoDanglingContent();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
-        validateNames,
-        validateDefaults,
-        validateNumericDefaultValueTypes,
-        validateNoDanglingContent
-    );
+    SchemaParseConfiguration configUsed =
+        new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes,
+            validateNoDanglingContent);
 
     parser.setValidate(validateNames);
 
@@ -386,8 +386,15 @@ public class Avro17Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
-    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps) {
+    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, null);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
   }
 
   @Override
@@ -402,7 +409,13 @@ public class Avro17Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps);
+    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, null);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore) {
+    return Avro17Utils.sameJsonProperties(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
   }
 
   @Override
@@ -425,8 +438,9 @@ public class Avro17Adapter implements AvroAdapter {
     boolean useRuntime;
     if (!isRuntimeAvroCapableOf(config)) {
       if (config.isForceUseOfRuntimeAvro()) {
-        throw new UnsupportedOperationException("desired configuration " + config
-                + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+        throw new UnsupportedOperationException(
+            "desired configuration " + config + " is forced yet runtime avro " + supportedMajorVersion()
+                + " is not capable of it");
       }
       useRuntime = false;
     } else {
@@ -438,27 +452,23 @@ public class Avro17Adapter implements AvroAdapter {
     } else {
       //if the user does not specify do whatever runtime avro would (which for 1.7 means produce correct schema)
       boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
-      Avro17AvscWriter writer = new Avro17AvscWriter(
-              config.isPrettyPrint(),
-              usePre702Logic,
-              config.isAddAvro702Aliases()
-      );
+      Avro17AvscWriter writer =
+          new Avro17AvscWriter(config.isPrettyPrint(), usePre702Logic, config.isAddAvro702Aliases());
       return writer.toAvsc(schema);
     }
   }
 
   @Override
-  public Collection<AvroGeneratedSourceCode> compile(
-      Collection<Schema> toCompile,
-      AvroVersion minSupportedVersion,
-      AvroVersion maxSupportedVersion,
-      CodeGenerationConfig config
-  ) {
+  public Collection<AvroGeneratedSourceCode> compile(Collection<Schema> toCompile, AvroVersion minSupportedVersion,
+      AvroVersion maxSupportedVersion, CodeGenerationConfig config) {
     if (!compilerSupported) {
       throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
     }
-    if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(config.getStringRepresentation())) {
-      throw new IllegalArgumentException("StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro " + minSupportedVersion);
+    if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(
+        config.getStringRepresentation())) {
+      throw new IllegalArgumentException(
+          "StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro "
+              + minSupportedVersion);
     }
     if (toCompile == null || toCompile.isEmpty()) {
       return Collections.emptyList();
@@ -521,16 +531,12 @@ public class Avro17Adapter implements AvroAdapter {
     }
   }
 
-  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated, AvroVersion minAvro, AvroVersion maxAvro) {
+  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated,
+      AvroVersion minAvro, AvroVersion maxAvro) {
     List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
     for (AvroGeneratedSourceCode generated : avroGenerated) {
-      String fixed = CodeTransformations.applyAll(
-          generated.getContents(),
-          supportedMajorVersion(),
-          minAvro,
-          maxAvro,
-          generated.getAlternativeAvsc()
-      );
+      String fixed = CodeTransformations.applyAll(generated.getContents(), supportedMajorVersion(), minAvro, maxAvro,
+          generated.getAlternativeAvsc());
       transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
     }
     return transformed;

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Utils.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Utils.java
@@ -307,7 +307,7 @@ public class Avro17Utils {
       }
 
       Map<String, String> unfilteredJsonPropsA = a.getProps();
-      Map<String, String> unfilteredJsonPropsB = a.getProps();
+      Map<String, String> unfilteredJsonPropsB = b.getProps();
 
       if (jsonPropNamesToIgnore == null) {
         return Objects.equals(unfilteredJsonPropsA, unfilteredJsonPropsB);

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Utils.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Utils.java
@@ -11,6 +11,7 @@ import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.compatibility.StringPropertyUtils;
 import com.linkedin.avroutil1.compatibility.VersionDetectionUtil;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.avro.Schema;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.node.TextNode;
@@ -26,285 +27,338 @@ import org.slf4j.LoggerFactory;
  * utility code specific to avro 1.7
  */
 public class Avro17Utils {
-    private final static Logger LOG = LoggerFactory.getLogger(Avro17Utils.class);
+  private final static Logger LOG = LoggerFactory.getLogger(Avro17Utils.class);
 
-    private final static boolean IS_AT_LEAST_1_7_3;
-    private final static Class<?> JSONPROPERTIES_CLASS;
-    private final static Method GET_JSON_PROPS_METHOD;
-    private final static Method GET_JSON_PROP_METHOD;
-    private final static Method ADD_JSON_PROP_METHOD;
+  private final static boolean IS_AT_LEAST_1_7_3;
+  private final static Class<?> JSONPROPERTIES_CLASS;
+  private final static Method GET_JSON_PROPS_METHOD;
+  private final static Method GET_JSON_PROP_METHOD;
+  private final static Method ADD_JSON_PROP_METHOD;
 
-    static {
-        //class org.apache.avro.JsonProperties was created as part of AVRO-1157 for 1.7.3
-        //however, if we naively just test for its existence we risk finding it in some extra
-        //avro jar at the end of the classpath, with the "dominant" avro being an older jar
-        //at the beginning of the classpath (this is horrible, but such is life).
-        //as such a safer approach is to look up class org.apache.avro.Schema (which exists
-        //in all supported avro versions and so we assume originates from the "dominant" jar)
-        //and see if it extends org.apache.avro.JsonProperties
-        Class<? super Schema> parentOfSchema = Schema.class.getSuperclass();
-        if ("org.apache.avro.JsonProperties".equals(parentOfSchema.getName())) {
-            JSONPROPERTIES_CLASS = parentOfSchema;
-            VersionDetectionUtil.markUsedForCoreAvro(JSONPROPERTIES_CLASS);
-            IS_AT_LEAST_1_7_3 = true;
-        } else {
-            JSONPROPERTIES_CLASS = null;
-            IS_AT_LEAST_1_7_3 = false; //presumably the parent is "java.lang.Object"
-        }
-
-        //print warning about avro 1.7 soup if we find it
-        try {
-            Class<?> jsonPropertiesClass = ClassLoaderUtil.forName("org.apache.avro.JsonProperties");
-            VersionDetectionUtil.markUsedForCoreAvro(jsonPropertiesClass);
-            if (jsonPropertiesClass != JSONPROPERTIES_CLASS) {
-                LOG.warn(
-                    "multiple versions of avro 1.7 found on the classpath. sources of avro: {}",
-                    VersionDetectionUtil.uniqueSourcesForCoreAvro()
-                );
-            }
-        } catch (Exception ignored) {
-            //ignored
-        }
-
-        if (IS_AT_LEAST_1_7_3) {
-            GET_JSON_PROPS_METHOD = findNewerGetPropsMethod();
-            GET_JSON_PROP_METHOD = findNewerGetPropMethod();
-            ADD_JSON_PROP_METHOD = findNewerAddPropMethod();
-        } else {
-            GET_JSON_PROPS_METHOD = null;
-            GET_JSON_PROP_METHOD = null;
-            ADD_JSON_PROP_METHOD = null;
-        }
+  static {
+    //class org.apache.avro.JsonProperties was created as part of AVRO-1157 for 1.7.3
+    //however, if we naively just test for its existence we risk finding it in some extra
+    //avro jar at the end of the classpath, with the "dominant" avro being an older jar
+    //at the beginning of the classpath (this is horrible, but such is life).
+    //as such a safer approach is to look up class org.apache.avro.Schema (which exists
+    //in all supported avro versions and so we assume originates from the "dominant" jar)
+    //and see if it extends org.apache.avro.JsonProperties
+    Class<? super Schema> parentOfSchema = Schema.class.getSuperclass();
+    if ("org.apache.avro.JsonProperties".equals(parentOfSchema.getName())) {
+      JSONPROPERTIES_CLASS = parentOfSchema;
+      VersionDetectionUtil.markUsedForCoreAvro(JSONPROPERTIES_CLASS);
+      IS_AT_LEAST_1_7_3 = true;
+    } else {
+      JSONPROPERTIES_CLASS = null;
+      IS_AT_LEAST_1_7_3 = false; //presumably the parent is "java.lang.Object"
     }
 
-    public static boolean isIsAtLeast173() {
-        return IS_AT_LEAST_1_7_3;
+    //print warning about avro 1.7 soup if we find it
+    try {
+      Class<?> jsonPropertiesClass = ClassLoaderUtil.forName("org.apache.avro.JsonProperties");
+      VersionDetectionUtil.markUsedForCoreAvro(jsonPropertiesClass);
+      if (jsonPropertiesClass != JSONPROPERTIES_CLASS) {
+        LOG.warn("multiple versions of avro 1.7 found on the classpath. sources of avro: {}",
+            VersionDetectionUtil.uniqueSourcesForCoreAvro());
+      }
+    } catch (Exception ignored) {
+      //ignored
     }
 
-    static Method findNewerGetPropsMethod() {
-        try {
-            return JSONPROPERTIES_CLASS.getDeclaredMethod("getJsonProps");
-        } catch (Exception e) {
-            String msg = "unable to locate expected method org.apache.avro.JsonProperties.getJsonProps(). "
-                + "sources of avro classes are " + VersionDetectionUtil.uniqueSourcesForCoreAvro();
-            throw new IllegalStateException(msg, e);
+    if (IS_AT_LEAST_1_7_3) {
+      GET_JSON_PROPS_METHOD = findNewerGetPropsMethod();
+      GET_JSON_PROP_METHOD = findNewerGetPropMethod();
+      ADD_JSON_PROP_METHOD = findNewerAddPropMethod();
+    } else {
+      GET_JSON_PROPS_METHOD = null;
+      GET_JSON_PROP_METHOD = null;
+      ADD_JSON_PROP_METHOD = null;
+    }
+  }
+
+  public static boolean isIsAtLeast173() {
+    return IS_AT_LEAST_1_7_3;
+  }
+
+  static Method findNewerGetPropsMethod() {
+    try {
+      return JSONPROPERTIES_CLASS.getDeclaredMethod("getJsonProps");
+    } catch (Exception e) {
+      String msg = "unable to locate expected method org.apache.avro.JsonProperties.getJsonProps(). "
+          + "sources of avro classes are " + VersionDetectionUtil.uniqueSourcesForCoreAvro();
+      throw new IllegalStateException(msg, e);
+    }
+  }
+
+  static Method findNewerGetPropMethod() {
+    try {
+      return JSONPROPERTIES_CLASS.getDeclaredMethod("getJsonProp", String.class);
+    } catch (Exception e) {
+      String msg = "unable to locate expected method org.apache.avro.JsonProperties.getJsonProp(). "
+          + "sources of avro classes are " + VersionDetectionUtil.uniqueSourcesForCoreAvro();
+      throw new IllegalStateException(msg, e);
+    }
+  }
+
+  static Method findNewerAddPropMethod() {
+    try {
+      return JSONPROPERTIES_CLASS.getDeclaredMethod("addProp", String.class, JsonNode.class);
+    } catch (Exception e) {
+      String msg =
+          "unable to locate expected method org.apache.avro.JsonProperties.addProp(). " + "sources of avro classes are "
+              + VersionDetectionUtil.uniqueSourcesForCoreAvro();
+      throw new IllegalStateException(msg, e);
+    }
+  }
+
+  static String getJsonProp(Schema.Field field, String name) {
+    if (GET_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
+      JsonNode node;
+      try {
+        node = (JsonNode) GET_JSON_PROP_METHOD.invoke(field, name);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+      return Jackson1Utils.toJsonString(node);
+    } else {  // <= Avro 1.7.2
+      return StringPropertyUtils.getFieldPropAsJsonString(field, name);
+    }
+  }
+
+  static void setJsonProp(Schema.Field field, String name, String value, boolean strict) {
+    if (ADD_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
+      JsonNode node = Jackson1Utils.toJsonNode(value, strict);
+      try {
+        ADD_JSON_PROP_METHOD.invoke(field, name, node);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    } else {  // <= Avro 1.7.2
+      StringPropertyUtils.setFieldPropFromJsonString(field, name, value, strict);
+    }
+  }
+
+  static String getJsonProp(Schema schema, String name) {
+    if (GET_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
+      JsonNode node;
+      try {
+        node = (JsonNode) GET_JSON_PROP_METHOD.invoke(schema, name);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+      return Jackson1Utils.toJsonString(node);
+    } else {  // <= Avro 1.7.2
+      return StringPropertyUtils.getSchemaPropAsJsonString(schema, name);
+    }
+  }
+
+  static void setJsonProp(Schema schema, String name, String value, boolean strict) {
+    if (ADD_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
+      JsonNode node = Jackson1Utils.toJsonNode(value, strict);
+      try {
+        ADD_JSON_PROP_METHOD.invoke(schema, name, node);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    } else {  // <= Avro 1.7.2
+      StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
+    }
+  }
+
+  static Map<String, JsonNode> getProps(Schema.Field field) {
+    if (GET_JSON_PROPS_METHOD != null) {
+      try {
+        //noinspection unchecked
+        return (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(field);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    //this must be < 1.7.3
+    @SuppressWarnings("deprecation")
+    Map<String, String> strProps = field.props();
+    if (strProps == null) {
+      return null;
+    }
+    Map<String, JsonNode> jsonProps = new HashMap<>(strProps.size());
+    for (Map.Entry<String, String> entry : strProps.entrySet()) {
+      jsonProps.put(entry.getKey(), new TextNode(entry.getValue()));
+    }
+    return jsonProps;
+  }
+
+  static Map<String, JsonNode> getProps(Schema schema) {
+    if (GET_JSON_PROPS_METHOD != null) {
+      try {
+        //noinspection unchecked
+        return (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(schema);
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    }
+    //this must be < 1.7.3
+    @SuppressWarnings("deprecation")
+    Map<String, String> strProps = schema.getProps();
+    ;
+    if (strProps == null) {
+      return null;
+    }
+    Map<String, JsonNode> jsonProps = new HashMap<>(strProps.size());
+    for (Map.Entry<String, String> entry : strProps.entrySet()) {
+      jsonProps.put(entry.getKey(), new TextNode(entry.getValue()));
+    }
+    return jsonProps;
+  }
+
+  static void setProps(Schema.Field field, Map<String, JsonNode> jsonProps) {
+    if (IS_AT_LEAST_1_7_3) {
+      try {
+        for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
+          ADD_JSON_PROP_METHOD.invoke(field, entry.getKey(), entry.getValue());
         }
+        return;
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    } else {
+      //this must be < 1.7.3
+      for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
+        JsonNode jsonValue = entry.getValue();
+        if (jsonValue.isTextual()) {
+          field.addProp(entry.getKey(), jsonValue.getTextValue());
+        }
+      }
+    }
+  }
+
+  static void setProps(Schema schema, Map<String, JsonNode> jsonProps) {
+    if (IS_AT_LEAST_1_7_3) {
+      try {
+        for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
+          ADD_JSON_PROP_METHOD.invoke(schema, entry.getKey(), entry.getValue());
+        }
+      } catch (Exception e) {
+        throw new IllegalStateException(e);
+      }
+    } else {
+      for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
+        JsonNode jsonValue = entry.getValue();
+        if (jsonValue.isTextual()) {
+          schema.addProp(entry.getKey(), jsonValue.getTextValue());
+        }
+      }
+    }
+  }
+
+  static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    if (IS_AT_LEAST_1_7_3) {
+      return sameJsonPropertiesNewer17(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
+    } else {
+      //older avro 1.7
+      if (compareNonStringProps) {
+        throw new IllegalArgumentException(
+            "older avro 1.7 does not preserve non-string props and so cannot compare them");
+      }
+      if (a == null || b == null) {
+        return false;
+      }
+      if (!compareStringProps) {
+        return true;
+      }
+      Map<String, String> unfilteredJsonPropsA = a.props();
+      Map<String, String> unfilteredJsonPropsB = a.props();
+
+      if (jsonPropNamesToIgnore == null) {
+        return Objects.equals(unfilteredJsonPropsA, unfilteredJsonPropsB);
+      } else {
+        Map<String, String> aProps = new HashMap<>();
+        Map<String, String> bProps = new HashMap<>();
+        for (Map.Entry<String, String> entry : unfilteredJsonPropsA.entrySet()) {
+          if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+            aProps.put(entry.getKey(), entry.getValue());
+          }
+        }
+        for (Map.Entry<String, String> entry : unfilteredJsonPropsB.entrySet()) {
+          if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+            bProps.put(entry.getKey(), entry.getValue());
+          }
+        }
+        return Objects.equals(aProps, bProps);
+      }
+    }
+  }
+
+  static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore) {
+    if (IS_AT_LEAST_1_7_3) {
+      return sameJsonPropertiesNewer17(a, b, compareStringProps, compareNonStringProps, jsonPropNamesToIgnore);
+    } else {
+      //older avro 1.7
+      if (compareNonStringProps) {
+        throw new IllegalArgumentException(
+            "older avro 1.7 does not preserve non-string props and so cannot compare them");
+      }
+      if (a == null || b == null) {
+        return false;
+      }
+      if (!compareStringProps) {
+        return true;
+      }
+
+      Map<String, String> unfilteredJsonPropsA = a.getProps();
+      Map<String, String> unfilteredJsonPropsB = a.getProps();
+
+      if (jsonPropNamesToIgnore == null) {
+        return Objects.equals(unfilteredJsonPropsA, unfilteredJsonPropsB);
+      } else {
+        Map<String, String> aProps = new HashMap<>();
+        Map<String, String> bProps = new HashMap<>();
+        for (Map.Entry<String, String> entry : unfilteredJsonPropsA.entrySet()) {
+          if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+            aProps.put(entry.getKey(), entry.getValue());
+          }
+        }
+        for (Map.Entry<String, String> entry : unfilteredJsonPropsB.entrySet()) {
+          if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+            bProps.put(entry.getKey(), entry.getValue());
+          }
+        }
+        return Objects.equals(aProps, bProps);
+      }
+    }
+  }
+
+  private static boolean sameJsonPropertiesNewer17(Object jsonPropertiesA, Object jsonPropertiesB,
+      boolean compareStringProps, boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    Map<String, JsonNode> unfilteredJsonPropsA;
+    Map<String, JsonNode> unfilteredJsonPropsB;
+    try {
+      //noinspection unchecked
+      unfilteredJsonPropsA = (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(jsonPropertiesA);
+      //noinspection unchecked
+      unfilteredJsonPropsB = (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(jsonPropertiesB);
+    } catch (Exception e) {
+      throw new IllegalStateException("unable to access JsonProperties", e);
     }
 
-    static Method findNewerGetPropMethod() {
-        try {
-            return JSONPROPERTIES_CLASS.getDeclaredMethod("getJsonProp", String.class);
-        } catch (Exception e) {
-            String msg = "unable to locate expected method org.apache.avro.JsonProperties.getJsonProp(). "
-                + "sources of avro classes are " + VersionDetectionUtil.uniqueSourcesForCoreAvro();
-            throw new IllegalStateException(msg, e);
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson1Utils.compareJsonProperties(unfilteredJsonPropsA, unfilteredJsonPropsB, compareStringProps,
+          compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredJsonPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
         }
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredJsonPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return Jackson1Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
     }
-
-    static Method findNewerAddPropMethod() {
-        try {
-            return JSONPROPERTIES_CLASS.getDeclaredMethod("addProp", String.class, JsonNode.class);
-        } catch (Exception e) {
-            String msg = "unable to locate expected method org.apache.avro.JsonProperties.addProp(). "
-                + "sources of avro classes are " + VersionDetectionUtil.uniqueSourcesForCoreAvro();
-            throw new IllegalStateException(msg, e);
-        }
-    }
-
-    static String getJsonProp(Schema.Field field, String name) {
-        if (GET_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
-            JsonNode node;
-            try {
-                node = (JsonNode) GET_JSON_PROP_METHOD.invoke(field, name);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-            return Jackson1Utils.toJsonString(node);
-        } else {  // <= Avro 1.7.2
-            return StringPropertyUtils.getFieldPropAsJsonString(field, name);
-        }
-    }
-
-    static void setJsonProp(Schema.Field field, String name, String value, boolean strict) {
-        if (ADD_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
-            JsonNode node = Jackson1Utils.toJsonNode(value, strict);
-            try {
-                ADD_JSON_PROP_METHOD.invoke(field, name, node);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        } else {  // <= Avro 1.7.2
-            StringPropertyUtils.setFieldPropFromJsonString(field, name, value, strict);
-        }
-    }
-
-    static String getJsonProp(Schema schema, String name) {
-        if (GET_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
-            JsonNode node;
-            try {
-                node = (JsonNode) GET_JSON_PROP_METHOD.invoke(schema, name);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-            return Jackson1Utils.toJsonString(node);
-        } else {  // <= Avro 1.7.2
-            return StringPropertyUtils.getSchemaPropAsJsonString(schema, name);
-        }
-    }
-
-    static void setJsonProp(Schema schema, String name, String value, boolean strict) {
-        if (ADD_JSON_PROP_METHOD != null) {  // >= Avro 1.7.3
-            JsonNode node = Jackson1Utils.toJsonNode(value, strict);
-            try {
-                ADD_JSON_PROP_METHOD.invoke(schema, name, node);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        } else {  // <= Avro 1.7.2
-            StringPropertyUtils.setSchemaPropFromJsonString(schema, name, value, strict);
-        }
-    }
-
-    static Map<String, JsonNode> getProps(Schema.Field field) {
-        if (GET_JSON_PROPS_METHOD != null) {
-            try {
-                //noinspection unchecked
-                return (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(field);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        }
-        //this must be < 1.7.3
-        @SuppressWarnings("deprecation")
-        Map<String, String> strProps = field.props();
-        if (strProps == null) {
-            return null;
-        }
-        Map<String, JsonNode> jsonProps = new HashMap<>(strProps.size());
-        for (Map.Entry<String, String> entry : strProps.entrySet()) {
-            jsonProps.put(entry.getKey(), new TextNode(entry.getValue()));
-        }
-        return jsonProps;
-    }
-
-    static Map<String, JsonNode> getProps(Schema schema) {
-        if (GET_JSON_PROPS_METHOD != null) {
-            try {
-                //noinspection unchecked
-                return (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(schema);
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        }
-        //this must be < 1.7.3
-        @SuppressWarnings("deprecation")
-        Map<String, String> strProps = schema.getProps();;
-        if (strProps == null) {
-            return null;
-        }
-        Map<String, JsonNode> jsonProps = new HashMap<>(strProps.size());
-        for (Map.Entry<String, String> entry : strProps.entrySet()) {
-            jsonProps.put(entry.getKey(), new TextNode(entry.getValue()));
-        }
-        return jsonProps;
-    }
-
-    static void setProps(Schema.Field field, Map<String, JsonNode> jsonProps) {
-        if (IS_AT_LEAST_1_7_3) {
-            try {
-                for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
-                    ADD_JSON_PROP_METHOD.invoke(field, entry.getKey(), entry.getValue());
-                }
-                return;
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        } else {
-            //this must be < 1.7.3
-            for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
-                JsonNode jsonValue = entry.getValue();
-                if (jsonValue.isTextual()) {
-                    field.addProp(entry.getKey(), jsonValue.getTextValue());
-                }
-            }
-        }
-    }
-
-    static void setProps(Schema schema, Map<String, JsonNode> jsonProps) {
-        if (IS_AT_LEAST_1_7_3) {
-            try {
-                for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
-                    ADD_JSON_PROP_METHOD.invoke(schema, entry.getKey(), entry.getValue());
-                }
-            } catch (Exception e) {
-                throw new IllegalStateException(e);
-            }
-        } else {
-            for (Map.Entry<String, JsonNode> entry : jsonProps.entrySet()) {
-                JsonNode jsonValue = entry.getValue();
-                if (jsonValue.isTextual()) {
-                    schema.addProp(entry.getKey(), jsonValue.getTextValue());
-                }
-            }
-        }
-    }
-
-    static boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
-        if (IS_AT_LEAST_1_7_3) {
-            return sameJsonPropertiesNewer17(a, b, compareStringProps, compareNonStringProps);
-        } else {
-            //older avro 1.7
-            if (compareNonStringProps) {
-                throw new IllegalArgumentException("older avro 1.7 does not preserve non-string props and so cannot compare them");
-            }
-            if (a == null || b == null) {
-                return false;
-            }
-            if (!compareStringProps) {
-                return true;
-            }
-            Map<String, String> jsonPropsA = a.props();
-            Map<String, String> jsonPropsB = a.props();
-            return Objects.equals(jsonPropsA, jsonPropsB);
-        }
-    }
-
-    static boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-        if (IS_AT_LEAST_1_7_3) {
-            return sameJsonPropertiesNewer17(a, b, compareStringProps, compareNonStringProps);
-        } else {
-            //older avro 1.7
-            if (compareNonStringProps) {
-                throw new IllegalArgumentException("older avro 1.7 does not preserve non-string props and so cannot compare them");
-            }
-            if (a == null || b == null) {
-                return false;
-            }
-            if (!compareStringProps) {
-                return true;
-            }
-            Map<String, String> jsonPropsA = a.getProps();
-            Map<String, String> jsonPropsB = a.getProps();
-            return Objects.equals(jsonPropsA, jsonPropsB);
-        }
-    }
-
-    private static boolean sameJsonPropertiesNewer17(
-        Object jsonPropertiesA,
-        Object jsonPropertiesB,
-        boolean compareStringProps,
-        boolean compareNonStringProps
-    ) {
-        Map<String, JsonNode> jsonPropsA;
-        Map<String, JsonNode> jsonPropsB;
-        try {
-            //noinspection unchecked
-            jsonPropsA = (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(jsonPropertiesA);
-            //noinspection unchecked
-            jsonPropsB = (Map<String, JsonNode>) GET_JSON_PROPS_METHOD.invoke(jsonPropertiesB);
-        } catch (Exception e) {
-            throw new IllegalStateException("unable to access JsonProperties", e);
-        }
-        return Jackson1Utils.compareJsonProperties(jsonPropsA, jsonPropsB, compareStringProps, compareNonStringProps);
-    }
+  }
 }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -102,7 +102,8 @@ public class Avro18Adapter implements AvroAdapter {
       outputFilePathField.setAccessible(true);
       outputFileContentsField = outputFileClass.getDeclaredField("contents");
       outputFileContentsField.setAccessible(true);
-      Class<?> fieldVisibilityEnum = Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
+      Class<?> fieldVisibilityEnum =
+          Class.forName("org.apache.avro.compiler.specific.SpecificCompiler$FieldVisibility");
       Field publicVisibilityField = fieldVisibilityEnum.getDeclaredField("PUBLIC");
       publicFieldVisibilityEnumInstance = publicVisibilityField.get(null);
       setFieldVisibilityMethod = compilerClass.getDeclaredMethod("setFieldVisibility", fieldVisibilityEnum);
@@ -122,7 +123,7 @@ public class Avro18Adapter implements AvroAdapter {
       compilerSupportIssue = e;
       String reason = ExceptionUtils.rootCause(compilerSupportIssue).getMessage();
       compilerSupportMessage = "avro SpecificCompiler class could not be found or instantiated because " + reason
-              + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
+          + ". please make sure you have a dependency on org.apache.avro:avro-compiler";
       //ignore
     }
   }
@@ -168,8 +169,10 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
-  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat) throws IOException {
-    return new CompatibleJsonEncoder(schema, out, pretty, jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
+  public Encoder newJsonEncoder(Schema schema, OutputStream out, boolean pretty, AvroVersion jsonFormat)
+      throws IOException {
+    return new CompatibleJsonEncoder(schema, out, pretty,
+        jsonFormat == null || jsonFormat.laterThan(AvroVersion.AVRO_1_4));
   }
 
   @Override
@@ -226,12 +229,9 @@ public class Avro18Adapter implements AvroAdapter {
       validateNumericDefaultValueTypes = desiredConf.validateNumericDefaultValueTypes();
       validateNoDanglingContent = desiredConf.validateNoDanglingContent();
     }
-    SchemaParseConfiguration configUsed = new SchemaParseConfiguration(
-        validateNames,
-        validateDefaults,
-        validateNumericDefaultValueTypes,
-        validateNoDanglingContent
-    );
+    SchemaParseConfiguration configUsed =
+        new SchemaParseConfiguration(validateNames, validateDefaults, validateNumericDefaultValueTypes,
+            validateNoDanglingContent);
 
     parser.setValidate(validateNames);
     parser.setValidateDefaults(validateDefaults);
@@ -342,13 +342,43 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps, boolean compareNonStringProps) {
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps) {
     if (a == null || b == null) {
       return false;
     }
     Map<String, JsonNode> propsA = a.getJsonProps();
     Map<String, JsonNode> propsB = b.getJsonProps();
     return Jackson1Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
+  }
+
+  @Override
+  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
+      boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
+    if (a == null || b == null) {
+      return false;
+    }
+
+    Map<String, JsonNode> unfilteredPropsA = a.getJsonProps();
+    Map<String, JsonNode> unfilteredPropsB = b.getJsonProps();
+
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson1Utils.compareJsonProperties(unfilteredPropsA, unfilteredPropsB, compareStringProps, compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return Jackson1Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
+    }
   }
 
   @Override
@@ -376,6 +406,35 @@ public class Avro18Adapter implements AvroAdapter {
   }
 
   @Override
+  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps,
+      Set<String> jsonPropNamesToIgnore) {
+    if (a == null || b == null) {
+      return false;
+    }
+
+    Map<String, JsonNode> unfilteredPropsA = a.getJsonProps();
+    Map<String, JsonNode> unfilteredPropsB = b.getJsonProps();
+
+    if (jsonPropNamesToIgnore == null) {
+      return Jackson1Utils.compareJsonProperties(unfilteredPropsA, unfilteredPropsB, compareStringProps, compareNonStringProps);
+    } else {
+      Map<String, JsonNode> aProps = new HashMap<>();
+      Map<String, JsonNode> bProps = new HashMap<>();
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsA.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          aProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      for (Map.Entry<String, JsonNode> entry : unfilteredPropsB.entrySet()) {
+        if (!jsonPropNamesToIgnore.contains(entry.getKey())) {
+          bProps.put(entry.getKey(), entry.getValue());
+        }
+      }
+      return Jackson1Utils.compareJsonProperties(aProps, bProps, compareStringProps, compareNonStringProps);
+    }
+  }
+
+  @Override
   public List<String> getAllPropNames(Schema schema) {
     return new ArrayList<>(schema.getObjectProps().keySet());
   }
@@ -395,8 +454,9 @@ public class Avro18Adapter implements AvroAdapter {
     boolean useRuntime;
     if (!isRuntimeAvroCapableOf(config)) {
       if (config.isForceUseOfRuntimeAvro()) {
-        throw new UnsupportedOperationException("desired configuration " + config
-                + " is forced yet runtime avro " + supportedMajorVersion() + " is not capable of it");
+        throw new UnsupportedOperationException(
+            "desired configuration " + config + " is forced yet runtime avro " + supportedMajorVersion()
+                + " is not capable of it");
       }
       useRuntime = false;
     } else {
@@ -408,27 +468,23 @@ public class Avro18Adapter implements AvroAdapter {
     } else {
       //if the user does not specify do whatever runtime avro would (which for 1.8 means produce correct schema)
       boolean usePre702Logic = config.getRetainPreAvro702Logic().orElse(Boolean.FALSE);
-      Avro18AvscWriter writer = new Avro18AvscWriter(
-              config.isPrettyPrint(),
-              usePre702Logic,
-              config.isAddAvro702Aliases()
-      );
+      Avro18AvscWriter writer =
+          new Avro18AvscWriter(config.isPrettyPrint(), usePre702Logic, config.isAddAvro702Aliases());
       return writer.toAvsc(schema);
     }
   }
 
   @Override
-  public Collection<AvroGeneratedSourceCode> compile(
-      Collection<Schema> toCompile,
-      AvroVersion minSupportedVersion,
-      AvroVersion maxSupportedVersion,
-      CodeGenerationConfig config
-  ) {
+  public Collection<AvroGeneratedSourceCode> compile(Collection<Schema> toCompile, AvroVersion minSupportedVersion,
+      AvroVersion maxSupportedVersion, CodeGenerationConfig config) {
     if (!compilerSupported) {
       throw new UnsupportedOperationException(compilerSupportMessage, compilerSupportIssue);
     }
-    if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(config.getStringRepresentation())) {
-      throw new IllegalArgumentException("StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro " + minSupportedVersion);
+    if (minSupportedVersion.earlierThan(AvroVersion.AVRO_1_6) && !StringRepresentation.CharSequence.equals(
+        config.getStringRepresentation())) {
+      throw new IllegalArgumentException(
+          "StringRepresentation " + config.getStringRepresentation() + " incompatible with minimum supported avro "
+              + minSupportedVersion);
     }
     if (toCompile == null || toCompile.isEmpty()) {
       return Collections.emptyList();
@@ -491,16 +547,12 @@ public class Avro18Adapter implements AvroAdapter {
     }
   }
 
-  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated, AvroVersion minAvro, AvroVersion maxAvro) {
+  private Collection<AvroGeneratedSourceCode> transform(List<AvroGeneratedSourceCode> avroGenerated,
+      AvroVersion minAvro, AvroVersion maxAvro) {
     List<AvroGeneratedSourceCode> transformed = new ArrayList<>(avroGenerated.size());
     for (AvroGeneratedSourceCode generated : avroGenerated) {
-      String fixed = CodeTransformations.applyAll(
-          generated.getContents(),
-          supportedMajorVersion(),
-          minAvro,
-          maxAvro,
-          generated.getAlternativeAvsc()
-      );
+      String fixed = CodeTransformations.applyAll(generated.getContents(), supportedMajorVersion(), minAvro, maxAvro,
+          generated.getAlternativeAvsc());
       transformed.add(new AvroGeneratedSourceCode(generated.getPath(), fixed));
     }
     return transformed;

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -343,17 +343,6 @@ public class Avro18Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA = a.getJsonProps();
-    Map<String, JsonNode> propsB = b.getJsonProps();
-    return Jackson1Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (a == null || b == null) {
       return false;
@@ -393,16 +382,6 @@ public class Avro18Adapter implements AvroAdapter {
     JsonNode node = Jackson1Utils.toJsonNode(value, strict);
     //noinspection deprecation this is faster
     schema.addProp(name, node);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA = a.getJsonProps();
-    Map<String, JsonNode> propsB = b.getJsonProps();
-    return Jackson1Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -352,25 +352,6 @@ public class Avro19Adapter implements AvroAdapter {
 
   @Override
   public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
-      boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA;
-    Map<String, JsonNode> propsB;
-    try {
-      //noinspection unchecked
-      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-      //noinspection unchecked
-      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access JsonProperties.props", e);
-    }
-    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema.Field a, Schema.Field b, boolean compareStringProps,
       boolean compareNonStringProps, Set<String> jsonPropNamesToIgnore) {
     if (a == null || b == null) {
       return false;
@@ -418,24 +399,6 @@ public class Avro19Adapter implements AvroAdapter {
     // Goes from String to JsonNode to Object to JsonNode (again). Painful, but suffices until somebody complains.
     JsonNode node = Jackson2Utils.toJsonNode(value, strict);
     schema.addProp(name, JacksonUtils.toObject(node));
-  }
-
-  @Override
-  public boolean sameJsonProperties(Schema a, Schema b, boolean compareStringProps, boolean compareNonStringProps) {
-    if (a == null || b == null) {
-      return false;
-    }
-    Map<String, JsonNode> propsA;
-    Map<String, JsonNode> propsB;
-    try {
-      //noinspection unchecked
-      propsA = (Map<String, JsonNode>) jsonPropertiesPropsField.get(a);
-      //noinspection unchecked
-      propsB = (Map<String, JsonNode>) jsonPropertiesPropsField.get(b);
-    } catch (Exception e) {
-      throw new IllegalStateException("unable to access JsonProperties.props", e);
-    }
-    return Jackson2Utils.compareJsonProperties(propsA, propsB, compareStringProps, compareNonStringProps);
   }
 
   @Override

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -244,7 +244,7 @@ public class ConfigurableSchemaComparatorTest {
     String avscB = "{\n"
         + "  \"type\": \"record\",\n"
         + "  \"name\": \"Bob\",\n"
-        + "  \"myProp\": \"f2\"\n"
+        + "  \"myProp\": \"f2\",\n"
         + "  \"fields\": [\n"
         + "    {\n"
         + "      \"name\": \"f1\",\n"
@@ -257,7 +257,7 @@ public class ConfigurableSchemaComparatorTest {
     String avscC = "{\n"
         + "  \"type\": \"record\",\n"
         + "  \"name\": \"Bob\",\n"
-        + "  \"unknownProp\": \"f2\"\n"
+        + "  \"unknownProp\": \"f2\",\n"
         + "  \"fields\": [\n"
         + "    {\n"
         + "      \"name\": \"f1\",\n"
@@ -269,7 +269,7 @@ public class ConfigurableSchemaComparatorTest {
 
     Schema a = AvroCompatibilityHelper.parse(avscA, SchemaParseConfiguration.STRICT, null).getMainSchema();
     Schema b = AvroCompatibilityHelper.parse(avscB, SchemaParseConfiguration.STRICT, null).getMainSchema();
-    Schema c = AvroCompatibilityHelper.parse(avscB, SchemaParseConfiguration.STRICT, null).getMainSchema();
+    Schema c = AvroCompatibilityHelper.parse(avscC, SchemaParseConfiguration.STRICT, null).getMainSchema();
 
     SchemaComparisonConfiguration ignoreMyProp = SchemaComparisonConfiguration.STRICT
         .jsonPropNamesToIgnore(Collections.singleton("myProp"));

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -6,6 +6,7 @@
 
 package com.linkedin.avroutil1.compatibility;
 
+import java.util.Collections;
 import org.apache.avro.Schema;
 import org.testng.Assert;
 import org.testng.SkipException;
@@ -69,7 +70,8 @@ public class ConfigurableSchemaComparatorTest {
         false,
         true,
         true,
-        true
+        true,
+        Collections.emptySet()
     );
     switch (runtimeAvroVersion) {
       case AVRO_1_4:
@@ -224,6 +226,56 @@ public class ConfigurableSchemaComparatorTest {
     Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, strict));
     Assert.assertFalse(ConfigurableSchemaComparator.equals(a, c, strict));
     Assert.assertFalse(ConfigurableSchemaComparator.equals(b, c, strict));
+  }
+
+  @Test
+  public void testJsonPropNamesToIgnore() {
+    String avscA = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f1\",\n"
+        + "      \"type\": \"int\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    String avscB = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"myProp\": \"f2\"\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f1\",\n"
+        + "      \"type\": \"int\",\n"
+        + "      \"myProp\": \"f2\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    String avscC = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"unknownProp\": \"f2\"\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f1\",\n"
+        + "      \"type\": \"int\",\n"
+        + "      \"myProp\": \"f2\"\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+
+    Schema a = AvroCompatibilityHelper.parse(avscA, SchemaParseConfiguration.STRICT, null).getMainSchema();
+    Schema b = AvroCompatibilityHelper.parse(avscB, SchemaParseConfiguration.STRICT, null).getMainSchema();
+    Schema c = AvroCompatibilityHelper.parse(avscB, SchemaParseConfiguration.STRICT, null).getMainSchema();
+
+    SchemaComparisonConfiguration ignoreMyProp = SchemaComparisonConfiguration.STRICT
+        .jsonPropNamesToIgnore(Collections.singleton("myProp"));
+
+    Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, ignoreMyProp));
+    Assert.assertFalse(ConfigurableSchemaComparator.equals(b, c, ignoreMyProp));
   }
 
   @Test

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -272,7 +272,8 @@ public class ConfigurableSchemaComparatorTest {
     Schema c = AvroCompatibilityHelper.parse(avscC, SchemaParseConfiguration.STRICT, null).getMainSchema();
 
     SchemaComparisonConfiguration ignoreMyProp = SchemaComparisonConfiguration.STRICT
-        .jsonPropNamesToIgnore(Collections.singleton("myProp"));
+        .jsonPropNamesToIgnore(Collections.singleton("myProp"))
+        .compareNonStringJsonProps(false); //required to work under old avro
 
     Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, ignoreMyProp));
     Assert.assertFalse(ConfigurableSchemaComparator.equals(b, c, ignoreMyProp));


### PR DESCRIPTION
Adds the ability to ignore equality checks on a set of JSON prop names. 

Note that this will only ignore "junk" JSON and not JSON property names that are apart of the Avro spec.

Testing: Unit tests