### PR TITLE
update generated code post-processing for WRITER$ to avoid deadlock in 1.11

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AvroAdapter.java
@@ -24,10 +24,13 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 
 
@@ -73,6 +76,10 @@ public interface AvroAdapter {
   Decoder newBoundedMemoryDecoder(byte[] data) throws IOException;
 
   <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass);
+
+  DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData);
+
+  DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData);
 
   //parsing and Schema-related
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/CodeTransformations.java
@@ -55,9 +55,9 @@ public class CodeTransformations {
   private static final String  IMPORT_SPECIFICDATA = "import org.apache.avro.specific.SpecificData;";
   private static final Pattern GET_SPECIFICDATA_METHOD_PATTERN = Pattern.compile("(@Override\n\\s*)public\\s*org\\.apache\\.avro\\.specific\\.SpecificData\\s*getSpecificData\\s*\\(\\s*\\)\\s*\\{\\s*return\\s*MODEL\\$\\s*;\\s*}");
   private static final Pattern WRITER_DOLLAR_DECL = Pattern.compile("WRITER\\$\\s*=\\s*([^;]+);");
-  private static final String  WRITER_DOLLAR_DECL_REPLACEMENT = Matcher.quoteReplacement("WRITER$ = new org.apache.avro.specific.SpecificDatumWriter<>(SCHEMA$);");
+  private static final String  WRITER_DOLLAR_DECL_REPLACEMENT = Matcher.quoteReplacement("WRITER$ = " + HelperConsts.HELPER_SIMPLE_NAME + ".newSpecificDatumWriter(SCHEMA$, MODEL$);");
   private static final Pattern READER_DOLLAR_DECL = Pattern.compile("READER\\$\\s*=\\s*([^;]+);");
-  private static final String  READER_DOLLAR_DECL_REPLACEMENT = Matcher.quoteReplacement("READER$ = new org.apache.avro.specific.SpecificDatumReader<>(SCHEMA$);");
+  private static final String  READER_DOLLAR_DECL_REPLACEMENT = Matcher.quoteReplacement("READER$ = " + HelperConsts.HELPER_SIMPLE_NAME + ".newSpecificDatumReader(SCHEMA$, SCHEMA$, MODEL$);");
   private static final Pattern WRITE_EXTERNAL_SIGNATURE = Pattern.compile(Pattern.quote("@Override public void writeExternal(java.io.ObjectOutput out)"));
   private static final String  WRITE_EXTERNAL_WITHOUT_OVERRIDE = Matcher.quoteReplacement("public void writeExternal(java.io.ObjectOutput out)");
   private static final Pattern READ_EXTERNAL_SIGNATURE = Pattern.compile(Pattern.quote("@Override public void readExternal(java.io.ObjectInput in)"));

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCompatibilityHelper.java
@@ -33,10 +33,13 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
 
@@ -345,6 +348,16 @@ public class AvroCompatibilityHelper  extends AvroCompatibilityHelperCommon{
   public static <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writerSchema, Class<T> readerClass) {
     assertAvroAvailable();
     return ADAPTER.newAliasAwareSpecificDatumReader(writerSchema, readerClass);
+  }
+
+  public static DatumWriter newSpecificDatumWriter(Schema schema, SpecificData specificData) {
+    assertAvroAvailable();
+    return ADAPTER.newSpecificDatumWriter(schema, specificData);
+  }
+
+  public static DatumReader newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    assertAvroAvailable();
+    return ADAPTER.newSpecificDatumReader(writer, reader, specificData);
   }
 
   // schema parsing, and other Schema-related operations

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110Adapter.java
@@ -37,6 +37,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro110BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -45,6 +47,7 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
 
@@ -221,6 +224,16 @@ public class Avro110Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriter<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReader<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111Adapter.java
@@ -37,6 +37,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro111BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -45,6 +47,7 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
 
@@ -221,6 +224,16 @@ public class Avro111Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriter<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReader<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14Adapter.java
@@ -24,6 +24,7 @@ import com.linkedin.avroutil1.compatibility.StringPropertyUtils;
 import com.linkedin.avroutil1.compatibility.StringRepresentation;
 import com.linkedin.avroutil1.compatibility.avro14.backports.Avro14DefaultValuesCache;
 import com.linkedin.avroutil1.compatibility.avro14.backports.Avro18BufferedBinaryEncoder;
+import com.linkedin.avroutil1.compatibility.avro14.backports.SpecificDatumWriterExt;
 import com.linkedin.avroutil1.compatibility.avro14.codec.AliasAwareSpecificDatumReader;
 import com.linkedin.avroutil1.compatibility.avro14.codec.BoundedMemoryDecoder;
 import com.linkedin.avroutil1.compatibility.avro14.codec.CachedResolvingDecoder;
@@ -40,12 +41,15 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro14BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificCompiler;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.JsonFactory;
@@ -209,6 +213,18 @@ public class Avro14Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriterExt<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    //SDRs in 1.4 do not allow for specifying an instance of SpecificData
+    //TODO - get back here if we want to try backporting this to 1.4
+    return new SpecificDatumReader<>(writer, reader);
   }
 
   @Override

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/backports/SpecificDatumWriterExt.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/backports/SpecificDatumWriterExt.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro14.backports;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+
+/**
+ * this class allows constructing a {@link SpecificDatumWriter} with
+ * a specified {@link SpecificData} instance under avro 1.4
+ * @param <T>
+ */
+public class SpecificDatumWriterExt<T> extends SpecificDatumWriter<T> {
+  public SpecificDatumWriterExt(Schema root, SpecificData specificData) {
+    super(root, specificData);
+  }
+}

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15Adapter.java
@@ -25,6 +25,8 @@ import com.linkedin.avroutil1.compatibility.SkipDecoder;
 import com.linkedin.avroutil1.compatibility.StringPropertyUtils;
 import com.linkedin.avroutil1.compatibility.StringRepresentation;
 import com.linkedin.avroutil1.compatibility.avro15.backports.Avro15DefaultValuesCache;
+import com.linkedin.avroutil1.compatibility.avro15.backports.SpecificDatumReaderExt;
+import com.linkedin.avroutil1.compatibility.avro15.backports.SpecificDatumWriterExt;
 import com.linkedin.avroutil1.compatibility.avro15.codec.AliasAwareSpecificDatumReader;
 import com.linkedin.avroutil1.compatibility.avro15.codec.BoundedMemoryDecoder;
 import com.linkedin.avroutil1.compatibility.avro15.codec.CachedResolvingDecoder;
@@ -39,12 +41,15 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro15BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
+import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.codehaus.jackson.JsonEncoding;
 import org.codehaus.jackson.JsonFactory;
@@ -218,6 +223,16 @@ public class Avro15Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriterExt<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReaderExt<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/backports/SpecificDatumReaderExt.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/backports/SpecificDatumReaderExt.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro15.backports;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+
+
+/**
+ * this class allows constructing a {@link SpecificDatumReader} with
+ * a specified {@link SpecificData} instance under avro 1.5
+ * @param <T>
+ */
+public class SpecificDatumReaderExt<T> extends SpecificDatumReader<T> {
+  public SpecificDatumReaderExt(Schema writer, Schema reader, SpecificData specificData) {
+    super(writer, reader, specificData);
+  }
+}

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/backports/SpecificDatumWriterExt.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/backports/SpecificDatumWriterExt.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro15.backports;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+
+/**
+ * this class allows constructing a {@link SpecificDatumWriter} with
+ * a specified {@link SpecificData} instance under avro 1.5
+ * @param <T>
+ */
+public class SpecificDatumWriterExt<T> extends SpecificDatumWriter<T> {
+  public SpecificDatumWriterExt(Schema root, SpecificData specificData) {
+    super(root, specificData);
+  }
+}

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16Adapter.java
@@ -24,6 +24,7 @@ import com.linkedin.avroutil1.compatibility.SkipDecoder;
 import com.linkedin.avroutil1.compatibility.StringPropertyUtils;
 import com.linkedin.avroutil1.compatibility.StringRepresentation;
 import com.linkedin.avroutil1.compatibility.avro16.backports.Avro16DefaultValuesCache;
+import com.linkedin.avroutil1.compatibility.avro16.backports.SpecificDatumWriterExt;
 import com.linkedin.avroutil1.compatibility.avro16.codec.AliasAwareSpecificDatumReader;
 import com.linkedin.avroutil1.compatibility.avro16.codec.BoundedMemoryDecoder;
 import com.linkedin.avroutil1.compatibility.avro16.codec.CachedResolvingDecoder;
@@ -38,6 +39,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro16BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -217,6 +220,16 @@ public class Avro16Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriterExt<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReader<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/backports/SpecificDatumWriterExt.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/backports/SpecificDatumWriterExt.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro16.backports;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+
+/**
+ * this class allows constructing a {@link SpecificDatumWriter} with
+ * a specified {@link SpecificData} instance under avro 1.6
+ * @param <T>
+ */
+public class SpecificDatumWriterExt<T> extends SpecificDatumWriter<T> {
+  public SpecificDatumWriterExt(Schema root, SpecificData specificData) {
+    super(root, specificData);
+  }
+}

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17Adapter.java
@@ -22,6 +22,7 @@ import com.linkedin.avroutil1.compatibility.SchemaParseResult;
 import com.linkedin.avroutil1.compatibility.SkipDecoder;
 import com.linkedin.avroutil1.compatibility.StringRepresentation;
 import com.linkedin.avroutil1.compatibility.avro17.backports.Avro17DefaultValuesCache;
+import com.linkedin.avroutil1.compatibility.avro17.backports.SpecificDatumWriterExt;
 import com.linkedin.avroutil1.compatibility.avro17.codec.AliasAwareSpecificDatumReader;
 import com.linkedin.avroutil1.compatibility.avro17.codec.BoundedMemoryDecoder;
 import com.linkedin.avroutil1.compatibility.avro17.codec.CachedResolvingDecoder;
@@ -36,6 +37,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro17BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -252,6 +255,16 @@ public class Avro17Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriterExt<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReader<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/backports/SpecificDatumWriterExt.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/backports/SpecificDatumWriterExt.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro17.backports;
+
+import org.apache.avro.Schema;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+
+/**
+ * this class allows constructing a {@link SpecificDatumWriter} with
+ * a specified {@link SpecificData} instance under avro 1.7
+ * <br>
+ * NOTE - the relevant constructor was made public only mid-1.7
+ * @param <T>
+ */
+public class SpecificDatumWriterExt<T> extends SpecificDatumWriter<T> {
+  public SpecificDatumWriterExt(Schema root, SpecificData specificData) {
+    super(root, specificData);
+  }
+}

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18Adapter.java
@@ -35,6 +35,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro18BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -43,6 +45,7 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.codehaus.jackson.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -214,6 +217,16 @@ public class Avro18Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriter<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReader<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19Adapter.java
@@ -37,6 +37,8 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.io.Avro19BinaryDecoderAccessUtil;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
@@ -45,6 +47,7 @@ import org.apache.avro.io.JsonDecoder;
 import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.util.internal.Accessor;
 import org.apache.avro.util.internal.JacksonUtils;
 import org.slf4j.Logger;
@@ -224,6 +227,16 @@ public class Avro19Adapter implements AvroAdapter {
   public <T> SpecificDatumReader<T> newAliasAwareSpecificDatumReader(Schema writer, Class<T> readerClass) {
     Schema readerSchema = AvroSchemaUtil.getDeclaredSchema(readerClass);
     return new AliasAwareSpecificDatumReader<>(writer, readerSchema);
+  }
+
+  @Override
+  public DatumWriter<?> newSpecificDatumWriter(Schema writer, SpecificData specificData) {
+    return new SpecificDatumWriter<>(writer, specificData);
+  }
+
+  @Override
+  public DatumReader<?> newSpecificDatumReader(Schema writer, Schema reader, SpecificData specificData) {
+    return new SpecificDatumReader<>(writer, reader, specificData);
   }
 
   @Override

--- a/helper/tests/codegen-111/src/main/compat-avro/under111/DeeplyNested.avsc
+++ b/helper/tests/codegen-111/src/main/compat-avro/under111/DeeplyNested.avsc
@@ -1,0 +1,29 @@
+{
+  "type": "record",
+  "name": "Outer",
+  "namespace": "under111",
+  "fields": [
+    {
+      "name": "outerRef",
+      "type": {
+        "type": "record",
+        "name": "Middle",
+        "fields": [
+          {
+            "name": "middleRef",
+            "type": {
+              "type": "record",
+              "name": "Inner",
+              "fields": [
+                {
+                  "name": "f",
+                  "type": "int"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SpecificDataDeadlockTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SpecificDataDeadlockTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility;
+
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import under111.Outer;
+
+
+public class SpecificDataDeadlockTest {
+
+    @Test
+    public void testNoDeadlock() throws Exception {
+        String json = TestUtil.load("allavro/serializedOuter.json");
+        SpecificDatumReader<Outer> reader = new SpecificDatumReader<>(Outer.class);
+        Decoder decoder = AvroCompatibilityHelper.newCompatibleJsonDecoder(Outer.getClassSchema(), json);
+        Outer instance = reader.read(null, decoder);
+        Assert.assertNotNull(instance);
+    }
+
+}

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/serializedOuter.json
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/serializedOuter.json
@@ -1,0 +1,1 @@
+{"outerRef":{"middleRef":{"f":42}}}


### PR DESCRIPTION
so, turns out
```
WRITER$ = new SpecificDatumWriter(SCHEMA$); 
```
creates a deadlock under avro 1.11, since as part of the ctr call it will call SpecificData.getForClass(), which will attempt to re-enter CHM.compute() in SpecificData.classCache.

the solution is to provide the instance of SpecificData to use
```
WRITER$ = new SpecificDatumWriter(SCHEMA$, MODEL$);
```
which is what modern avro does out of the box (supporting logical types in avro is via a per-class instance of SpecificData stored in MODEL$).

since the relevant ctr isnt available before avro ~1.7.4 i added a helper method to access it, making the resulting generated code be
```
WRITER$ = AvroCompatibilityHelper.newSpecificDatumWriter(SCHEMA$, MODEL$)
```