### PR TITLE
make testing code-gen tasks declare inputs and outputs for incremental build support

### DIFF
--- a/avro-builder/tests/codegen-110/build.gradle
+++ b/avro-builder/tests/codegen-110/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-111/build.gradle
+++ b/avro-builder/tests/codegen-111/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-14/build.gradle
+++ b/avro-builder/tests/codegen-14/build.gradle
@@ -26,8 +26,15 @@ sourceSets {
   }
 }
 
+dependencies {
+  codegen project(":avro-builder:builder")
+}
+
 task runOwnCodegen {
   description = 'generate specific classes using own codegen utility'
+
+  dependsOn configurations.codegen
+
   doLast {
     javaexec {
       classpath configurations.codegen

--- a/avro-builder/tests/codegen-15/build.gradle
+++ b/avro-builder/tests/codegen-15/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-16/build.gradle
+++ b/avro-builder/tests/codegen-16/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-17/build.gradle
+++ b/avro-builder/tests/codegen-17/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-18/build.gradle
+++ b/avro-builder/tests/codegen-18/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-19/build.gradle
+++ b/avro-builder/tests/codegen-19/build.gradle
@@ -26,9 +26,15 @@ sourceSets {
     }
 }
 
-task runOwnCodegen {
+dependencies {
+    codegen project(":avro-builder:builder")
+}
 
+task runOwnCodegen {
     description = 'generate specific classes using own codegen utility'
+
+    dependsOn configurations.codegen
+
     doLast {
         javaexec {
             classpath configurations.codegen

--- a/avro-builder/tests/codegen-charseq-method/build.gradle
+++ b/avro-builder/tests/codegen-charseq-method/build.gradle
@@ -26,8 +26,15 @@ sourceSets {
   }
 }
 
+dependencies {
+  codegen project(":avro-builder:builder")
+}
+
 task runOwnCodegen {
   description = 'generate specific classes using own codegen utility'
+
+  dependsOn configurations.codegen
+
   doLast {
     javaexec {
       classpath configurations.codegen

--- a/avro-builder/tests/codegen-no-utf8-in-putbyindex/build.gradle
+++ b/avro-builder/tests/codegen-no-utf8-in-putbyindex/build.gradle
@@ -26,8 +26,15 @@ sourceSets {
   }
 }
 
+dependencies {
+  codegen project(":avro-builder:builder")
+}
+
 task runOwnCodegen {
   description = 'generate specific classes using own codegen utility'
+
+  dependsOn configurations.codegen
+
   doLast {
     javaexec {
       classpath configurations.codegen

--- a/helper/tests/codegen-110/build.gradle
+++ b/helper/tests/codegen-110/build.gradle
@@ -36,6 +36,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -49,7 +56,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -69,7 +82,13 @@ task runCompatAvroCodegen {
 
 task runCompatAvroCodegenWithBuilders {
   description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -88,7 +107,13 @@ task runCompatAvroCodegenWithBuilders {
 
 task runCompatAvroCodegenWithBuildersMinAvro18 {
   description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders-min-avro18")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-111/build.gradle
+++ b/helper/tests/codegen-111/build.gradle
@@ -36,6 +36,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -49,7 +56,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -69,7 +82,13 @@ task runCompatAvroCodegen {
 
 task runCompatAvroCodegenWithBuilders {
   description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -88,7 +107,13 @@ task runCompatAvroCodegenWithBuilders {
 
 task runCompatAvroCodegenWithBuildersMinAvro18 {
   description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders-min-avro18")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-14/build.gradle
+++ b/helper/tests/codegen-14/build.gradle
@@ -43,6 +43,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main")
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -56,7 +63,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -78,7 +91,13 @@ task runCompatAvroCodegen {
 
 task runCompatAvroCodegenWith702 {
   description = 'generate specific classes using compatibility helper producing bad (avro-702) schemas'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-702")
   outputs.dir("$buildDir/generated/sources/compat-avro-702/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-702', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -98,7 +117,13 @@ task runCompatAvroCodegenWith702 {
 
 task runCompatAvroCodegenWith702Mitigated {
   description = 'generate specific classes using compatibility helper producing bad (avro-702) schemas with aliases'
-  outputs.dir("$buildDir/generated/sources/compat-avro-702-mitigated/java/main").withPropertyName('outputDir')
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-702-mitigated")
+  outputs.dir("$buildDir/generated/sources/compat-avro-702/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-702-mitigated', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-15/build.gradle
+++ b/helper/tests/codegen-15/build.gradle
@@ -34,6 +34,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -47,7 +54,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-16/build.gradle
+++ b/helper/tests/codegen-16/build.gradle
@@ -34,6 +34,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -47,7 +54,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-17/build.gradle
+++ b/helper/tests/codegen-17/build.gradle
@@ -35,6 +35,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -48,7 +55,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -67,7 +80,13 @@ task runCompatAvroCodegen {
 
 task runCompatAvroCodegenTarget17 {
   description = 'generate specific classes using compatibility helper with a minimum target of avro 1.7'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-target17")
   outputs.dir("$buildDir/generated/sources/compat-avro-target17/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-target17', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-18/build.gradle
+++ b/helper/tests/codegen-18/build.gradle
@@ -36,6 +36,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -49,7 +56,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -68,7 +81,13 @@ task runCompatAvroCodegen {
 
 task runCompatAvroCodegenWithBuilders {
   description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -87,7 +106,13 @@ task runCompatAvroCodegenWithBuilders {
 
 task runCompatAvroCodegenWithBuildersMinAvro18 {
   description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders-min-avro18")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {

--- a/helper/tests/codegen-19/build.gradle
+++ b/helper/tests/codegen-19/build.gradle
@@ -36,6 +36,13 @@ sourceSets {
 
 task runVanillaAvroCodegen {
   description = 'generate specific classes using vanilla avro'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/raw-avro")
+  outputs.dir("$buildDir/generated/sources/raw-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/raw-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -49,7 +56,13 @@ task runVanillaAvroCodegen {
 
 task runCompatAvroCodegen {
   description = 'generate specific classes using compatibility helper'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro")
   outputs.dir("$buildDir/generated/sources/compat-avro/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -68,7 +81,13 @@ task runCompatAvroCodegen {
 
 task runCompatAvroCodegenWithBuilders {
   description = 'generate specific classes using compatibility helper with minimum avro 1.6 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {
@@ -87,7 +106,13 @@ task runCompatAvroCodegenWithBuilders {
 
 task runCompatAvroCodegenWithBuildersMinAvro18 {
   description = 'generate specific classes using compatibility helper with minimum avro 1.8 target'
+
+  dependsOn configurations.codegen
+  // define input and output files so we can have incremental build when nothing changes
+  inputs.files(configurations.codegen)
+  inputs.dir("src/main/compat-avro-w-builders-min-avro18")
   outputs.dir("$buildDir/generated/sources/compat-avro-w-builders-min-avro18/java/main").withPropertyName('outputDir')
+
   fileTree(dir: 'src/main/compat-avro-w-builders-min-avro18', include:'**/*.avsc').each { file ->
     doLast {
       javaexec {


### PR DESCRIPTION
this drops the 2nd+ run time for ./gradlew :helper:tests:helper-tests-allavro:test down from ~50 seconds to ~8 seconds on my machine