### PR TITLE
Improve Jacoco code coverage

### DIFF
--- a/avro-builder/builder-spi/build.gradle
+++ b/avro-builder/builder-spi/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java-library"
     id "checkstyle"
+    id "jacoco"
 }
 
 dependencies {

--- a/avro-builder/builder/build.gradle
+++ b/avro-builder/builder/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java-library"
     id "checkstyle"
+    id "jacoco"
     id "com.github.johnrengelman.shadow"
 }
 

--- a/avro-codegen/build.gradle
+++ b/avro-codegen/build.gradle
@@ -7,6 +7,7 @@
 plugins {
     id "java-library"
     id "checkstyle"
+    id "jacoco"
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,13 @@ task codeCoverageReport(type: JacocoReport) {
           //add source sets from all relevant submodules
           sourceSets subproject.sourceSets.main
         }
+        classDirectories.setFrom(files(classDirectories.files.collect {
+          fileTree(dir: it, exclude: [
+              "by*/*",
+              "under*/*",
+              "vs*/*"
+          ])
+        }))
       }
     }
     executionData.setFrom(fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec"))
@@ -281,7 +288,8 @@ task codeCoverageReport(type: JacocoReport) {
   reports {
     xml.enabled true
     xml.destination = new File("${buildDir}/reports/jacoco/report.xml")
-    html.enabled false //useful as a debug aid and for local dev
+    html.enabled true
+    html.destination = new File("${buildDir}/reports/jacoco/html")
     csv.enabled false
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,7 @@ task codeCoverageReport(type: JacocoReport) {
           //add source sets from all relevant submodules
           sourceSets subproject.sourceSets.main
         }
+        //exclude the generated classes from the code coverage report
         classDirectories.setFrom(files(classDirectories.files.collect {
           fileTree(dir: it, exclude: [
               "by*/*",

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -8,7 +8,3 @@ plugins {
     id "java-library"
     id "checkstyle"
 }
-
-dependencies {
-
-}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+plugins {
+    id "java-library"
+    id "checkstyle"
+}
+
+dependencies {
+
+}

--- a/common/src/main/java/com/linkedin/avroutil1/common/ExcludeFromJacocoGeneratedReport.java
+++ b/common/src/main/java/com/linkedin/avroutil1/common/ExcludeFromJacocoGeneratedReport.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.common;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Annotation that can be used to exclude code from jacoco coverage.
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD,
+    ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.LOCAL_VARIABLE, ElementType.PARAMETER})
+public @interface ExcludeFromJacocoGeneratedReport {
+}

--- a/common/src/main/java/com/linkedin/avroutil1/common/ExcludeFromJacocoGeneratedReport.java
+++ b/common/src/main/java/com/linkedin/avroutil1/common/ExcludeFromJacocoGeneratedReport.java
@@ -15,6 +15,8 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation that can be used to exclude code from jacoco coverage.
+ *
+ * Add @ExcludeFromJacocoGeneratedReport to the class or method that need to be excluded from jacoco coverage report.
  */
 
 @Retention(RetentionPolicy.RUNTIME)

--- a/helper/helper/build.gradle
+++ b/helper/helper/build.gradle
@@ -28,6 +28,11 @@ dependencies {
   implementation project(":helper:impls:helper-impl-19")
   implementation project(":helper:impls:helper-impl-110")
   implementation project(":helper:impls:helper-impl-111")
+  testImplementation project(":test-common")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }
 
 shadowJar {

--- a/helper/helper/src/test/java/com/linkedin/avroutil1/compatibility/exception/AvroUtilExceptionTest.java
+++ b/helper/helper/src/test/java/com/linkedin/avroutil1/compatibility/exception/AvroUtilExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.exception;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroUtilExceptionTest {
+
+  @Test
+  public void testAvroUtilExceptionCreatWithCause() throws Exception {
+    Exception cause = new Exception("cause");
+
+    AvroUtilException avroUtilException = new AvroUtilException(cause);
+
+    Assert.assertNotNull(avroUtilException);
+
+    Assert.assertEquals(avroUtilException.getCause(), cause);
+  }
+
+  @Test
+  public void testAvroUtilExceptionCreatWithMessage() throws Exception {
+    String message = "Avro exception message";
+
+    AvroUtilException avroUtilException = new AvroUtilException(message);
+
+    Assert.assertNotNull(avroUtilException);
+
+    Assert.assertEquals(avroUtilException.getMessage(), message);
+  }
+}

--- a/helper/helper/src/test/java/com/linkedin/avroutil1/compatibility/exception/AvroUtilMissingFieldExceptionTest.java
+++ b/helper/helper/src/test/java/com/linkedin/avroutil1/compatibility/exception/AvroUtilMissingFieldExceptionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.exception;
+
+import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Schema;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class AvroUtilMissingFieldExceptionTest {
+
+  @Test
+  public void testAvroUtilMissingFieldExceptionWithCause() throws Exception {
+    Throwable throwable = new Throwable("throwable");
+    AvroRuntimeException avroRuntimeException = new AvroRuntimeException(throwable);
+
+    AvroUtilMissingFieldException avroUtilMissingFieldException =
+        new AvroUtilMissingFieldException(avroRuntimeException);
+
+    Assert.assertNotNull(avroUtilMissingFieldException);
+
+    Assert.assertEquals(avroUtilMissingFieldException.getCause(), avroRuntimeException);
+  }
+
+  @Test
+  public void testAvroUtilMissingFieldExceptionWithMessage() throws Exception {
+    String message = "Avro exception message";
+    String fieldName = "field1";
+
+    Schema.Field field = new Schema.Field(fieldName, Schema.create(Schema.Type.LONG), "field doc", null);
+
+    AvroUtilMissingFieldException avroUtilMissingFieldException = new AvroUtilMissingFieldException(message, field);
+
+    Assert.assertNotNull(avroUtilMissingFieldException);
+
+    Assert.assertEquals(avroUtilMissingFieldException.getMessage(), message);
+
+    String expectedPathStr = "Path in schema: --> " + fieldName;
+
+    Assert.assertEquals(avroUtilMissingFieldException.toString(), expectedPathStr);
+  }
+
+  @Test
+  public void testaddParentField() throws Exception {
+    String message = "Avro exception message";
+
+    String fieldName1 = "field1";
+    Schema.Field field1 = new Schema.Field(fieldName1, Schema.create(Schema.Type.LONG), "field doc", null);
+
+    AvroUtilMissingFieldException avroUtilMissingFieldException = new AvroUtilMissingFieldException(message, field1);
+
+    Assert.assertNotNull(avroUtilMissingFieldException);
+
+    //add another field
+    String fieldName2 = "field2";
+    Schema.Field field2 = new Schema.Field(fieldName2, Schema.create(Schema.Type.LONG), "field2 doc", null);
+
+    avroUtilMissingFieldException.addParentField(field2);
+
+    String expectedPathStr = "Path in schema: --> " + fieldName2 + " --> " + fieldName1;
+
+    Assert.assertEquals(avroUtilMissingFieldException.toString(), expectedPathStr);
+  }
+}

--- a/helper/impls/helper-impl-110/build.gradle
+++ b/helper/impls/helper-impl-110/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.10.2")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-110/src/main/java/org/apache/avro/io/Avro110BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-110/src/main/java/org/apache/avro/io/Avro110BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports reusing a custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro110BinaryDecoderAccessUtil {
+  private Avro110BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-110/src/test/java/org/apache/avro/io/Avro110BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-110/src/test/java/org/apache/avro/io/Avro110BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro110BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro110BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro110BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}
+

--- a/helper/impls/helper-impl-111/build.gradle
+++ b/helper/impls/helper-impl-111/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.11.1")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-111/src/main/java/org/apache/avro/io/Avro111BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-111/src/main/java/org/apache/avro/io/Avro111BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports reusing a custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro111BinaryDecoderAccessUtil {
+  private Avro111BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-111/src/test/java/org/apache/avro/io/Avro111BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-111/src/test/java/org/apache/avro/io/Avro111BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro111BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro111BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro111BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/helper/impls/helper-impl-14/build.gradle
+++ b/helper/impls/helper-impl-14/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.4.1")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-14/src/main/java/org/apache/avro/io/Avro14BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-14/src/main/java/org/apache/avro/io/Avro14BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro14BinaryDecoderAccessUtil {
+  private Avro14BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null != reuse) {

--- a/helper/impls/helper-impl-14/src/test/java/org/apache/avro/io/Avro14BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-14/src/test/java/org/apache/avro/io/Avro14BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro14BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro14BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).init(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, mockedBinaryDecoder, "Verify the reused BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro14BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/helper/impls/helper-impl-15/build.gradle
+++ b/helper/impls/helper-impl-15/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.5.4")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-15/src/main/java/org/apache/avro/io/Avro15BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-15/src/main/java/org/apache/avro/io/Avro15BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro15BinaryDecoderAccessUtil {
+  private Avro15BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-15/src/test/java/org/apache/avro/io/Avro15BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-15/src/test/java/org/apache/avro/io/Avro15BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro15BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro15BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro15BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/helper/impls/helper-impl-16/build.gradle
+++ b/helper/impls/helper-impl-16/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.6.3")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-16/src/main/java/org/apache/avro/io/Avro16BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-16/src/main/java/org/apache/avro/io/Avro16BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro16BinaryDecoderAccessUtil {
+  private Avro16BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-16/src/test/java/org/apache/avro/io/Avro16BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-16/src/test/java/org/apache/avro/io/Avro16BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro16BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro16BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro16BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/helper/impls/helper-impl-17/build.gradle
+++ b/helper/impls/helper-impl-17/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.7.7")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-17/src/main/java/org/apache/avro/io/Avro17BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-17/src/main/java/org/apache/avro/io/Avro17BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro17BinaryDecoderAccessUtil {
+  private Avro17BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-17/src/test/java/org/apache/avro/io/Avro17BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-17/src/test/java/org/apache/avro/io/Avro17BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro17BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro17BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro17BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/helper/impls/helper-impl-18/build.gradle
+++ b/helper/impls/helper-impl-18/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.8.2")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-18/src/main/java/org/apache/avro/io/Avro18BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-18/src/main/java/org/apache/avro/io/Avro18BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports configuring custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro18BinaryDecoderAccessUtil {
+  private Avro18BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-18/src/test/java/org/apache/avro/io/Avro18BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-18/src/test/java/org/apache/avro/io/Avro18BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro18BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro18BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro18BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/helper/impls/helper-impl-19/build.gradle
+++ b/helper/impls/helper-impl-19/build.gradle
@@ -13,4 +13,10 @@ plugins {
 dependencies {
   implementation (project(":helper:helper-common"))
   compileOnly ("org.apache.avro:avro:1.9.2")
+  testImplementation project(":test-common")
+  testImplementation("org.mockito:mockito-inline:4.11.0")
+}
+
+configurations {
+  testImplementation.extendsFrom compileOnly
 }

--- a/helper/impls/helper-impl-19/src/main/java/org/apache/avro/io/Avro19BinaryDecoderAccessUtil.java
+++ b/helper/impls/helper-impl-19/src/main/java/org/apache/avro/io/Avro19BinaryDecoderAccessUtil.java
@@ -13,6 +13,9 @@ package org.apache.avro.io;
  * is that this method supports reusing a custom BinaryDecoder since it does not check class type of BinaryDecoder.
  */
 public class Avro19BinaryDecoderAccessUtil {
+  private Avro19BinaryDecoderAccessUtil() {
+  }
+
   public static BinaryDecoder newBinaryDecoder(byte[] bytes, int offset,
       int length, BinaryDecoder reuse) {
     if (null == reuse) {

--- a/helper/impls/helper-impl-19/src/test/java/org/apache/avro/io/Avro19BinaryDecoderAccessUtilTest.java
+++ b/helper/impls/helper-impl-19/src/test/java/org/apache/avro/io/Avro19BinaryDecoderAccessUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package org.apache.avro.io;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro19BinaryDecoderAccessUtilTest {
+  private static final byte[] BYTES = new byte[10];
+  private static final int OFFSET = 0;
+  private static final int LENGTH = 10;
+
+  @Test
+  public void testNewBinaryDecoderReuse() throws Exception {
+    BinaryDecoder mockedBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+    BinaryDecoder configuredBinaryDecoder = Mockito.mock(BinaryDecoder.class);
+
+    Mockito.when(mockedBinaryDecoder.configure(BYTES, OFFSET, LENGTH)).thenReturn(configuredBinaryDecoder);
+
+    BinaryDecoder returnedBinaryDecoder =
+        Avro19BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, mockedBinaryDecoder);
+
+    Mockito.verify(mockedBinaryDecoder, Mockito.times(1)).configure(BYTES, OFFSET, LENGTH);
+
+    Assert.assertEquals(returnedBinaryDecoder, configuredBinaryDecoder,
+        "Verify the configured BinaryDecoder is returned");
+  }
+
+  @Test
+  public void testNewBinaryDecoderNotReuse() throws Exception {
+    Map<BinaryDecoder, List<Object>> constructorArgs = new HashMap<>();
+
+    try (MockedConstruction<BinaryDecoder> mockedBinaryDecoder = Mockito.mockConstruction(BinaryDecoder.class,
+        (mock, context) -> constructorArgs.put(mock, new ArrayList<>(context.arguments())))) {
+
+      BinaryDecoder returnedBinaryDecoder = Avro19BinaryDecoderAccessUtil.newBinaryDecoder(BYTES, OFFSET, LENGTH, null);
+
+      Assert.assertEquals(mockedBinaryDecoder.constructed().size(), 1, "Verify one BinaryDecoder is created");
+
+      BinaryDecoder createdBinaryDecoder = mockedBinaryDecoder.constructed().get(0);
+
+      Assert.assertEquals(returnedBinaryDecoder, createdBinaryDecoder,
+          "Verify the new created BinaryDecoder is returned");
+
+      //Verify parameters are correctly used when creating the new BinaryDecoder
+      List<Object> parameters = constructorArgs.get(createdBinaryDecoder);
+      Assert.assertEquals(parameters.size(), 3, "Verify the number of parameter is correct");
+      Assert.assertEquals(parameters.get(0), BYTES, "Verify first parameter");
+      Assert.assertEquals(parameters.get(1), OFFSET, "Verify first parameter");
+      Assert.assertEquals(parameters.get(2), LENGTH, "Verify first parameter");
+    }
+  }
+}

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -7,6 +7,7 @@
 plugins {
     id "java-library"
     id "checkstyle"
+    id "jacoco"
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,6 +20,7 @@ apply plugin: 'net.vivin.gradle-semantic-build-versioning'
 //otherwise it defaults to the folder name
 rootProject.name = 'avro-util'
 
+include 'common'
 include 'test-common'
 
 //compatibility helper
@@ -82,4 +83,3 @@ include 'avro-builder:tests:codegen-no-utf8-in-putbyindex'
 include 'avro-builder:tests:tests-allavro'
 
 include 'demos:spotbugs-demo'
-


### PR DESCRIPTION
This is to improve the Jacoco code coverage:
(1) change the generate html report to make it more readable.
(2) include more subprojects to the report.
(3) exclude the generated code from the report.
(4) add unit tests for some zero covered tests.