### PR TITLE
[builder] fix exception handling

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/FileSystemSchemaSetProvider.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/FileSystemSchemaSetProvider.java
@@ -316,8 +316,11 @@ public class FileSystemSchemaSetProvider implements SchemaSetProvider {
     } catch (Exception e) {
       //this catches json processing exceptions (from jackson 1.* or 2.*, as different versions of avro use either)
       //this DOES NOT catch avro exceptions (that may happen after json parsing is done) as they are handled by the caller
-      LOGGER.error("exception parsing avro file {}", f.getAbsolutePath(), e);
-      throw new IllegalArgumentException("exception parsing avro file " + f.getAbsolutePath(), e);
+      // We check the name by its String value not its class value in order to not directly depend on a specific version of Jackson.
+      if (e.getClass().getName().equals("com.fasterxml.jackson.core.JsonProcessingException")) {
+        LOGGER.error("exception parsing avro file {}", f.getAbsolutePath(), e);
+        throw new IllegalArgumentException("exception parsing avro file " + f.getAbsolutePath(), e);
+      }
     }
   }
 

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -80,7 +80,7 @@ public class SchemaBuilderTest {
     List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
         (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
     ).collect(Collectors.toList());
-    Assert.assertEquals(javaFiles.size(), 1);
+    Assert.assertEquals(javaFiles.size(), 2);
   }
 
   @Test(expectedExceptions = java.lang.RuntimeException.class)

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -30,7 +30,10 @@ public class SchemaBuilderTest {
       FileUtils.deleteDirectory(outputFolder);
     }
     //run the builder
-    SchemaBuilder.main(new String[] {"--input", inputFolder.getAbsolutePath(), "--output", outputFolder.getAbsolutePath()});
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath()
+    });
     //see output was generated
     List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
         (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")

--- a/avro-builder/builder/src/test/resources/test-projects/simple-project/input/NestedRecord.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/simple-project/input/NestedRecord.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "record",
+  "namespace": "simpleproject",
+  "name": "NestedRecord",
+  "fields": [
+    {
+      "name": "j",
+      "type": "int"
+    }
+  ]
+}

--- a/avro-builder/builder/src/test/resources/test-projects/simple-project/input/SimpleRecord.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/simple-project/input/SimpleRecord.avsc
@@ -3,6 +3,13 @@
   "namespace": "simpleproject",
   "name": "SimpleRecord",
   "fields": [
-    {"name": "f", "type": "int"}
+    {
+      "name": "f",
+      "type": "int"
+    },
+    {
+      "name": "s",
+      "type": "simpleproject.NestedRecord"
+    }
   ]
 }


### PR DESCRIPTION
In https://github.com/linkedin/avro-util/pull/370's `FileSystemSchemaSetProvider.java`, we switched from `catch`ing `JsonProcessingException` to catching all `Exception`s. This meant that `SchemaParseException`s up above were getting thrown on instead of retried. This change fixes that bug.