### PR TITLE
[fastserde] switch jmhCompile to jmhImplementation

### DIFF
--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -108,7 +108,7 @@ dependencies {
 
   testImplementation 'org.testng:testng:6.14.3'
   testImplementation 'org.slf4j:slf4j-simple:1.7.14'
-  jmhCompile "org.openjdk.jmh:jmh-core:1.19"
+  jmhImplementation "org.openjdk.jmh:jmh-core:1.19"
   jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.19"
 
   avro1_4 (AVRO_1_4) {


### PR DESCRIPTION
in response to this build failure
>The jmhCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the jmhImplementation configuration instead. Consult the upgrading guide for further information: 
>https://docs.gradle.org/6.5.1/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations