### PR TITLE
[builder] continue throwing non-JsonProcessingExceptions

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/FileSystemSchemaSetProvider.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/FileSystemSchemaSetProvider.java
@@ -320,6 +320,8 @@ public class FileSystemSchemaSetProvider implements SchemaSetProvider {
       if (e.getClass().getName().equals("com.fasterxml.jackson.core.JsonProcessingException")) {
         LOGGER.error("exception parsing avro file {}", f.getAbsolutePath(), e);
         throw new IllegalArgumentException("exception parsing avro file " + f.getAbsolutePath(), e);
+      } else {
+        throw e;
       }
     }
   }

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -38,7 +38,7 @@ public class SchemaBuilderTest {
     List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
         (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
     ).collect(Collectors.toList());
-    Assert.assertEquals(javaFiles.size(), 1);
+    Assert.assertEquals(javaFiles.size(), 2);
   }
 
   @Test


### PR DESCRIPTION
This is a follow up to https://github.com/linkedin/avro-util/pull/442. Non-`JsonProcessingException`s should still be thrown 