### PR TITLE
[avro-codegen] Fix underscore issue in getter/setter names

### DIFF
--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -171,6 +172,12 @@ public class SchemaBuilderTest {
     Assert.assertEquals(javaFiles.size(), 2);
   }
 
+  @DataProvider
+  Object[][] testUnderscoreProvider() {
+    return new Object[][]{{true}, {false}};
+  }
+
+  @Test(dataProvider = "testUnderscoreProvider")
   public void testUnderscores(boolean useOwnCodegen) throws Exception {
     File simpleProjectRoot = new File(locateTestProjectsRoot(), "test-underscores");
     File inputFolder = new File(simpleProjectRoot, "input");
@@ -179,30 +186,21 @@ public class SchemaBuilderTest {
       FileUtils.deleteDirectory(outputFolder);
     }
     //run the builder
-    SchemaBuilder.main(new String[] {
-        "--input", inputFolder.getAbsolutePath(),
-        "--output", outputFolder.getAbsolutePath(),
-        "--generator", useOwnCodegen ? CodeGenerator.AVRO_UTIL.name() : CodeGenerator.VANILLA.name()
-    });
+    SchemaBuilder.main(
+        new String[]{"--input", inputFolder.getAbsolutePath(), "--output", outputFolder.getAbsolutePath(),
+            "--generator", useOwnCodegen ? CodeGenerator.AVRO_UTIL.name() : CodeGenerator.VANILLA.name()});
     //see output was generated
     Optional<Path> javaFile = Files.find(outputFolder.toPath(), 5,
-        (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
-    ).collect(Collectors.toList()).stream().findFirst();
+            (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java"))
+        .collect(Collectors.toList())
+        .stream()
+        .findFirst();
     Assert.assertTrue(javaFile.isPresent());
 
     String file = new String(Files.readAllBytes(javaFile.get()));
 
     Assert.assertTrue(file.contains("getFieldWithUnderscores()"));
-  }
-
-  @Test
-  public void testUnderscores_ownCodegen() throws Exception {
-    testUnderscores(true);
-  }
-
-  @Test
-  public void testUnderscores_vanillaCodegen() throws Exception {
-    testUnderscores(false);
+    Assert.assertTrue(file.contains("getFieldWithDoubleUnderscores()"));
   }
 
   @Test

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -12,7 +12,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
@@ -168,6 +170,40 @@ public class SchemaBuilderTest {
         (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
     ).collect(Collectors.toList());
     Assert.assertEquals(javaFiles.size(), 2);
+  }
+
+  public void testUnderscores(boolean useOwnCodegen) throws Exception {
+    File simpleProjectRoot = new File(locateTestProjectsRoot(), "test-underscores");
+    File inputFolder = new File(simpleProjectRoot, "input");
+    File outputFolder = new File(simpleProjectRoot, "output");
+    if (outputFolder.exists()) { //clear output
+      FileUtils.deleteDirectory(outputFolder);
+    }
+    //run the builder
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath(),
+        "--generator", useOwnCodegen ? CodeGenerator.AVRO_UTIL.name() : CodeGenerator.VANILLA.name()
+    });
+    //see output was generated
+    Optional<Path> javaFile = Files.find(outputFolder.toPath(), 5,
+        (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
+    ).collect(Collectors.toList()).stream().findFirst();
+    Assert.assertTrue(javaFile.isPresent());
+
+    String file = new String(Files.readAllBytes(javaFile.get()));
+
+    Assert.assertTrue(file.contains("getFieldWithUnderscores()"));
+  }
+
+  @Test
+  public void testUnderscores_ownCodegen() throws Exception {
+    testUnderscores(true);
+  }
+
+  @Test
+  public void testUnderscores_vanillaCodegen() throws Exception {
+    testUnderscores(false);
   }
 
   @Test

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -12,7 +12,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/avro-builder/builder/src/test/resources/test-projects/test-underscores/input/RecordWithUnderscores.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/test-underscores/input/RecordWithUnderscores.avsc
@@ -5,6 +5,10 @@
     {
       "name": "field_with_underscores_",
       "type": "string"
+    },
+    {
+      "name": "field_with_double__underscores",
+      "type": "string"
     }
   ]
 }

--- a/avro-builder/builder/src/test/resources/test-projects/test-underscores/input/RecordWithUnderscores.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/test-underscores/input/RecordWithUnderscores.avsc
@@ -1,0 +1,10 @@
+{
+  "name": "RecordWithUnderscores",
+  "type": "record",
+  "fields": [
+    {
+      "name": "field_with_underscores",
+      "type": "string"
+    }
+  ]
+}

--- a/avro-builder/builder/src/test/resources/test-projects/test-underscores/input/RecordWithUnderscores.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/test-underscores/input/RecordWithUnderscores.avsc
@@ -3,7 +3,7 @@
   "type": "record",
   "fields": [
     {
-      "name": "field_with_underscores",
+      "name": "field_with_underscores_",
       "type": "string"
     }
   ]

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -942,8 +942,11 @@ public class SpecificRecordClassGenerator {
       throw new IllegalArgumentException("FieldName must be longer than 1");
     }
 
-    return prefix + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1)
-        + getSuffixForFieldName(fieldName);
+    String pascalCasedField = Arrays.stream(fieldName.split("_"))
+        .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
+        .collect(Collectors.joining());
+
+    return prefix + pascalCasedField + getSuffixForFieldName(fieldName);
   }
 
   private void addCustomDecodeMethod(MethodSpec.Builder customDecodeBuilder, AvroRecordSchema recordSchema,

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -942,9 +942,14 @@ public class SpecificRecordClassGenerator {
       throw new IllegalArgumentException("FieldName must be longer than 1");
     }
 
-    String pascalCasedField = Arrays.stream(fieldName.split("_"))
-        .map(s -> s.substring(0, 1).toUpperCase() + s.substring(1))
-        .collect(Collectors.joining());
+    // Converts a snake_case name to a PascalCase name
+    String pascalCasedField = Arrays.stream(fieldName.split("_")).map(s -> {
+      if (s.length() < 1) {
+        return s;
+      } else {
+        return s.substring(0, 1).toUpperCase() + s.substring(1);
+      }
+    }).collect(Collectors.joining());
 
     return prefix + pascalCasedField + getSuffixForFieldName(fieldName);
   }


### PR DESCRIPTION
A record with a field name that includes underscores (i.e. `field_with_underscores_`) has a getter `getFieldWithUnderscores()` in vanilla avro. However, in our custom avro codegen, it was getting generated as `getField_with_underscores_()`. This PR aligns our custom codegen with vanilla avro codegen.

As a note, this is the only non-alphanumeric symbol allowed in Avro field names. The regex for avro field names, according to [the docs](https://avro.apache.org/docs/1.10.2/spec.html), is as follows: `[A-Za-z_][A-Za-z0-9_]*`