### PR TITLE
[codegen] reference class fields using 'this.'

### DIFF
--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -1548,7 +1548,7 @@ public class SpecificRecordClassGenerator {
       if (SpecificRecordGeneratorUtil.isNullUnionOf(AvroType.STRING, field.getSchema())) {
         Class<?> fieldClass = SpecificRecordGeneratorUtil.getJavaClassForAvroTypeIfApplicable(AvroType.STRING,
             config.getDefaultMethodStringRepresentation(), false);
-        switchBuilder.addStatement("case $L: return com.linkedin.avroutil1.compatibility.StringConverterUtil.get$L($L)", fieldIndex++, fieldClass.getSimpleName(), escapedFieldName);
+        switchBuilder.addStatement("case $L: return com.linkedin.avroutil1.compatibility.StringConverterUtil.get$L(this.$L)", fieldIndex++, fieldClass.getSimpleName(), escapedFieldName);
       } else if (SpecificRecordGeneratorUtil.isListTransformerApplicableForSchema(field.getSchema())) {
         switchBuilder.addStatement(
             "case $L: return com.linkedin.avroutil1.compatibility.collectiontransformer.ListTransformer.get$LList(this.$L)",

--- a/avro-codegen/src/test/resources/schemas/TestProblematicRecord.avsc
+++ b/avro-codegen/src/test/resources/schemas/TestProblematicRecord.avsc
@@ -10,6 +10,10 @@
           "values": "float"
         }
       ]
+    },
+    {
+      "name": "field",
+      "type": "string"
     }
   ]
 }


### PR DESCRIPTION
In the generated `get(int field)` method, if the field name was `field`, the local method argument was referenced, not the class field. Prefixing thos lookups with `this.` fixes this issue.

Alternatively, we could consider postfixing all method arguments with `$` or in some way that there would never be a conflict (I imagine this is why `SCHEMA$` is used).

Before
![Screen Shot 2023-02-26 at 7 14 32 PM](https://user-images.githubusercontent.com/101298964/221464607-cd8f250e-2e8b-40e1-8baa-fd752159dd22.png)

After
![Screen Shot 2023-02-26 at 7 18 08 PM](https://user-images.githubusercontent.com/101298964/221465000-11d572ab-5567-4197-abcd-5868215f56f8.png)

