### PR TITLE
Fix bug for empty field in schema

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
@@ -261,7 +261,7 @@ public abstract class AbstractSchemaBuilder implements SchemaBuilder {
             case RECORD:
                 validateNames();
                 result = Schema.createRecord(_name, _doc, _namespace, _isError);
-                if (_fields != null && !_fields.isEmpty()) {
+                if (_fields != null) {
                     List<Schema.Field> fields = _fields.stream()
                         .map(field -> _adapter.newFieldBuilder(field)
                             .setSchema(inheritNamespace(field.schema()))

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SchemaBuilderTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SchemaBuilderTest.java
@@ -159,4 +159,20 @@ public class SchemaBuilderTest {
         AvroCompatibilityHelper.newSchema(null).setType(Schema.Type.UNION)
             .setUnionBranches(Arrays.asList(recordSchema1, recordSchema2)).build();
     }
+
+    @DataProvider
+    private Object[][] TestSchemeBuildWithNamespaceInheritProvider() {
+        return new Object[][]{
+            {"allavro/RecordWithEmptyFieldList.avsc"},
+            {"allavro/RecordWithEmptyFieldListInNestedField.avsc"}
+        };
+    }
+
+    @Test(dataProvider = "TestSchemeBuildWithNamespaceInheritProvider")
+    public void testSchemaBuilderWithNamespaceInherit(String originalAvscFile) throws Exception {
+        String originalAvsc = TestUtil.load(originalAvscFile);
+        Schema originalSchema = AvroCompatibilityHelper.parse(originalAvsc);
+        Schema newSchema = AvroCompatibilityHelper.newSchema(originalSchema).setType(Schema.Type.RECORD).build();
+        Assert.assertEquals(newSchema, originalSchema);
+    }
 }

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldList.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldList.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "record",
+  "namespace": "allavro",
+  "name": "RecordWithEmptyFieldList",
+  "fields": []
+}

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyListInNestedField.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyListInNestedField.avsc
@@ -1,0 +1,47 @@
+{
+  "type": "record",
+  "namespace": "allavro",
+  "name": "RecordWithEmptyFieldListInNestedField",
+  "fields": [
+    {
+      "name":"unionRecordWithArray",
+      "type":[
+        "null",
+        {
+          "type":"array",
+          "items":
+          {
+            "type":"record",
+            "name":"testRecord1",
+            "fields":[]
+          }
+        }
+      ]
+    },
+    {
+      "name": "unionRecordWithRecord",
+      "type": [
+        "null",
+        {
+          "fields": [],
+          "name": "testRecord2",
+          "type": "record"
+        }
+      ]
+    },
+    {
+      "name": "unionRecordWithMap",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "record",
+            "name": "testRecord3",
+            "fields": []
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
AvroCompatibilityHelper.newSchema(schemaA) API ignores empty field list. For example:
when the schema has empty field like
SchemaA:
{"type":"record","name":"StatsTransaction","fields":[],"schemaType":"DocumentSchema","version":1}
Then call the AvroCompatibilityHelper.newSchema(SchemaA).setType(Type.RECORD).build();
will return:
{"type":"record","name":"StatsTransaction","schemaType":"DocumentSchema","version":1}

This also ignore field for empty nexted subrecords field.

This PR is to fix this issue by allowing empty field list in record