### PR TITLE
Fix schema creation when original schema's record has empty field list

### DIFF
--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
@@ -149,7 +149,7 @@ public abstract class AbstractSchemaBuilder implements SchemaBuilder {
 
     @Override
     public SchemaBuilder removeField(String fieldName) {
-        if (fieldName == null || fieldName.isEmpty()) {
+        if (fieldName == null) {
             throw new IllegalArgumentException("argument cannot be null or empty");
         }
         int index = fieldPositionByName(fieldName, false);

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
@@ -261,7 +261,7 @@ public abstract class AbstractSchemaBuilder implements SchemaBuilder {
             case RECORD:
                 validateNames();
                 result = Schema.createRecord(_name, _doc, _namespace, _isError);
-                if (_fields != null && !_fields.isEmpty()) {
+                if (_fields != null) {
                     List<Schema.Field> fields = _fields.stream()
                         .map(field -> _adapter.newFieldBuilder(field)
                             .setSchema(inheritNamespace(field.schema()))

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/AbstractSchemaBuilder.java
@@ -149,7 +149,7 @@ public abstract class AbstractSchemaBuilder implements SchemaBuilder {
 
     @Override
     public SchemaBuilder removeField(String fieldName) {
-        if (fieldName == null) {
+        if (fieldName == null || fieldName.isEmpty()) {
             throw new IllegalArgumentException("argument cannot be null or empty");
         }
         int index = fieldPositionByName(fieldName, false);

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SchemaBuilderTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/SchemaBuilderTest.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class SchemaBuilderTest {
@@ -158,5 +159,21 @@ public class SchemaBuilderTest {
         //this is fine
         AvroCompatibilityHelper.newSchema(null).setType(Schema.Type.UNION)
             .setUnionBranches(Arrays.asList(recordSchema1, recordSchema2)).build();
+    }
+
+    @DataProvider
+    private Object[][] TestSchemeBuildWithEmptyFieldProvider() {
+        return new Object[][]{
+            {"allavro/RecordWithEmptyFieldList.avsc"},
+            {"allavro/RecordWithEmptyFieldListInNestedField.avsc"}
+        };
+    }
+
+    @Test(dataProvider = "TestSchemeBuildWithEmptyFieldProvider")
+    public void testSchemaBuilderWithEmptyField(String originalAvscFile) throws Exception {
+        String originalAvsc = TestUtil.load(originalAvscFile);
+        Schema originalSchema = AvroCompatibilityHelper.parse(originalAvsc);
+        Schema newSchema = AvroCompatibilityHelper.newSchema(originalSchema).setType(Schema.Type.RECORD).build();
+        Assert.assertEquals(newSchema, originalSchema);
     }
 }

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldList.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldList.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "record",
+  "namespace": "allavro",
+  "name": "RecordWithEmptyFieldList",
+  "fields": []
+}

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldListInNestedField.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldListInNestedField.avsc
@@ -1,0 +1,58 @@
+{
+  "type": "record",
+  "namespace": "allavro",
+  "name": "RecordWithEmptyFieldListInNestedField",
+  "fields": [
+    {
+      "name":"unionWithArray",
+      "type":[
+        "null",
+        {
+          "type":"array",
+          "items":
+          {
+            "type":"record",
+            "name":"testRecord1",
+            "fields":[]
+          }
+        }
+      ]
+    },
+    {
+      "name": "unionWithRecord",
+      "type": [
+        "null",
+        {
+          "fields": [],
+          "name": "testRecord2",
+          "type": "record"
+        }
+      ]
+    },
+    {
+      "name": "unionWithMap",
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "record",
+            "name": "testRecord3",
+            "fields": []
+          }
+        }
+      ]
+    },
+    {
+      "name": "unionWithMapRecord",
+      "type": {
+        "type":"map",
+        "values": {
+          "name": "testRecord4",
+          "type": "record",
+          "fields": []
+        }
+      }
+    }
+  ]
+}

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldListInNestedField.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/RecordWithEmptyFieldListInNestedField.avsc
@@ -44,15 +44,33 @@
       ]
     },
     {
-      "name": "unionWithMapRecord",
-      "type": {
-        "type":"map",
-        "values": {
-          "name": "testRecord4",
+      "name": "unionWithNestedField",
+      "type": [
+        "null",
+        {
           "type": "record",
-          "fields": []
+          "name": "testRecord4",
+          "fields": [
+            {
+              "name": "testUnion",
+              "type": [
+                "null",
+                {
+                  "type": "map",
+                  "values": {
+                    "type": "array",
+                    "items": {
+                      "type": "record",
+                      "name": "testRecord5",
+                      "fields": []
+                    }
+                  }
+                }
+              ]
+            }
+          ]
         }
-      }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fix schema parsing when record has empty field list.
AvroCompatibilityHelper.newSchema(schemaA) API ignores empty field list. For example:
when the schema has empty field like
SchemaA:
{"type":"record","name":"StatsTransaction","fields":[],"schemaType":"DocumentSchema","version":1}
Then call the AvroCompatibilityHelper.newSchema(SchemaA).setType(Type.RECORD).build();
will return:
{"type":"record","name":"StatsTransaction","schemaType":"DocumentSchema","version":1}

This also ignore field for empty nexted subrecords field.

This PR is to fix this issue by allowing empty field list in record