### PR TITLE
Updating Unit tests to expect correct order of avsc writer

### DIFF
--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordInherit.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordInherit.avsc
@@ -1,7 +1,7 @@
 {
-  "type" : "record",
   "name" : "ComplexRecord",
   "namespace" : "TopNamespace",
+  "type" : "record",
   "fields" : [ {
     "name" : "longField",
     "type" : "long",
@@ -9,8 +9,8 @@
   }, {
     "name" : "fixedField",
     "type" : {
-      "type" : "fixed",
       "name" : "FixedSchema",
+      "type" : "fixed",
       "size" : 100
     },
     "doc" : "fixed type"
@@ -19,16 +19,16 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : {
-        "type" : "record",
         "name" : "innerRecord",
+        "type" : "record",
         "fields" : [ {
           "name" : "stringField",
           "type" : "string"
         }, {
           "name" : "unionWithEnum",
           "type" : [ "null", "int", {
-            "type" : "enum",
             "name" : "enumField",
+            "type" : "enum",
             "symbols" : [ "A", "B" ]
           } ]
         }, {
@@ -36,8 +36,8 @@
           "type" : {
             "type" : "map",
             "values" : {
-              "type" : "record",
               "name" : "mapUnionRecord",
+              "type" : "record",
               "fields" : [ {
                 "name" : "stringField",
                 "type" : [ "null", "string" ],

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordInnerNamespaceInherit.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordInnerNamespaceInherit.avsc
@@ -1,7 +1,7 @@
 {
-  "type" : "record",
   "name" : "ComplexRecord",
   "namespace" : "TopNamespace",
+  "type" : "record",
   "fields" : [ {
     "name" : "longField",
     "type" : "long",
@@ -9,8 +9,8 @@
   }, {
     "name" : "fixedField",
     "type" : {
-      "type" : "fixed",
       "name" : "FixedSchema",
+      "type" : "fixed",
       "size" : 100
     },
     "doc" : "fixed type"
@@ -19,17 +19,17 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : {
-        "type" : "record",
         "name" : "innerRecord",
         "namespace" : "InnerNamespace",
+        "type" : "record",
         "fields" : [ {
           "name" : "stringField",
           "type" : "string"
         }, {
           "name" : "unionWithEnum",
           "type" : [ "null", "int", {
-            "type" : "enum",
             "name" : "enumField",
+            "type" : "enum",
             "symbols" : [ "A", "B" ]
           } ]
         }, {
@@ -37,8 +37,8 @@
           "type" : {
             "type" : "map",
             "values" : {
-              "type" : "record",
               "name" : "mapUnionRecord",
+              "type" : "record",
               "fields" : [ {
                 "name" : "stringField",
                 "type" : [ "null", "string" ],

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordInnerNamespaceNoInherit.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordInnerNamespaceNoInherit.avsc
@@ -1,7 +1,7 @@
 {
-  "type" : "record",
   "name" : "ComplexRecord",
   "namespace" : "TopNamespace",
+  "type" : "record",
   "fields" : [ {
     "name" : "longField",
     "type" : "long",
@@ -9,9 +9,9 @@
   }, {
     "name" : "fixedField",
     "type" : {
-      "type" : "fixed",
       "name" : "FixedSchema",
       "namespace" : "",
+      "type" : "fixed",
       "size" : 100
     },
     "doc" : "fixed type"
@@ -20,17 +20,17 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : {
-        "type" : "record",
         "name" : "innerRecord",
         "namespace" : "InnerNamespace",
+        "type" : "record",
         "fields" : [ {
           "name" : "stringField",
           "type" : "string"
         }, {
           "name" : "unionWithEnum",
           "type" : [ "null", "int", {
-            "type" : "enum",
             "name" : "enumField",
+            "type" : "enum",
             "symbols" : [ "A", "B" ]
           } ]
         }, {
@@ -38,8 +38,8 @@
           "type" : {
             "type" : "map",
             "values" : {
-              "type" : "record",
               "name" : "mapUnionRecord",
+              "type" : "record",
               "fields" : [ {
                 "name" : "stringField",
                 "type" : [ "null", "string" ],

--- a/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordNoInherit.avsc
+++ b/helper/tests/helper-tests-allavro/src/test/resources/allavro/ComplexRecordNoInherit.avsc
@@ -1,7 +1,7 @@
 {
-  "type" : "record",
   "name" : "ComplexRecord",
   "namespace" : "TopNamespace",
+  "type" : "record",
   "fields" : [ {
     "name" : "longField",
     "type" : "long",
@@ -9,9 +9,9 @@
   }, {
     "name" : "fixedField",
     "type" : {
-      "type" : "fixed",
       "name" : "FixedSchema",
       "namespace" : "",
+      "type" : "fixed",
       "size" : 100
     },
     "doc" : "fixed type"
@@ -20,17 +20,17 @@
     "type" : [ "null", {
       "type" : "array",
       "items" : {
-        "type" : "record",
         "name" : "innerRecord",
         "namespace" : "",
+        "type" : "record",
         "fields" : [ {
           "name" : "stringField",
           "type" : "string"
         }, {
           "name" : "unionWithEnum",
           "type" : [ "null", "int", {
-            "type" : "enum",
             "name" : "enumField",
+            "type" : "enum",
             "symbols" : [ "A", "B" ]
           } ]
         }, {
@@ -38,8 +38,8 @@
           "type" : {
             "type" : "map",
             "values" : {
-              "type" : "record",
               "name" : "mapUnionRecord",
+              "type" : "record",
               "fields" : [ {
                 "name" : "stringField",
                 "type" : [ "null", "string" ],


### PR DESCRIPTION
commit #446 added support for canonical form of avro files, which updated AvscWriter to follow a defined order of keys while writing avsc, where 'type' is after 'name' and 'namespace'

Updating Unit tests to expect the same