### PR TITLE
JDK11 specific VarHandle based implementation of PrimitiveList plus MR jar

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,8 +6,8 @@ on:
       - '*'
 
 jobs:
-  gradle-java8:
-    name: Java 8 release
+  gradle-java11:
+    name: Java 11 release
     runs-on: ubuntu-latest
     steps:
     - name: checkout code
@@ -16,12 +16,13 @@ jobs:
         # bring in all history because the gradle versions plugin needs to "walk back" to the closest ancestor tag
         # to figure out what version this is. optimizing this is left as a challenge to future committers
         fetch-depth: 0
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Gradle
         # add --info or --debug below for more details when trying to understand issues
+        # We have to use JDK11 to support multi-release jar, however standard classes are compiled with --release 1.8
       run: ./gradlew clean build javadoc --stacktrace --warning-mode all --no-daemon
     - name: Branch tag
       id: branch_tag

--- a/avro-fastserde/build.gradle
+++ b/avro-fastserde/build.gradle
@@ -3,10 +3,9 @@
  * Licensed under the BSD 2-Clause License (the "License").
  * See License in the project root for license information.
  */
-
 plugins {
   id "java-library"
-  id "me.champeau.gradle.jmh" version "0.5.0"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 configurations {
@@ -68,11 +67,8 @@ if (USE_AVRO_1_4) {
   USE_AVRO_1_10 = false
 }
 
-
-
 jmh {
   profilers = ['gc', 'pauses']
-  duplicateClassesStrategy = 'warn'
   clean {
     delete "$buildDir/jmh-generated-classes"
     delete "$buildDir/jmh-generated-sources"
@@ -86,8 +82,36 @@ sourceSets {
     compileClasspath += test.output
     runtimeClasspath += test.output
   }
+  //This block is only supported and required when building with JDK11
+  if (JavaVersion.current() == JavaVersion.VERSION_11) {
+    java11 {
+      java {
+        srcDirs = ['src/main/java11']
+      }
+    }
+  }
 }
 
+//This block is only supported and required when building with JDK11
+if (JavaVersion.current() == JavaVersion.VERSION_11) {
+  compileJava11Java {
+    sourceCompatibility = 11
+    targetCompatibility = 11
+    options.compilerArgs.addAll(['--release', '11'])
+  }
+  jar {
+    into('META-INF/versions/11') {
+      from sourceSets.java11.output
+    }
+
+    manifest {
+      attributes(
+          "Manifest-Version": "1.0",
+          "Multi-Release": true
+      )
+    }
+  }
+}
 dependencies {
   implementation project(":helper:helper")
 
@@ -108,8 +132,8 @@ dependencies {
 
   testImplementation 'org.testng:testng:6.14.3'
   testImplementation 'org.slf4j:slf4j-simple:1.7.14'
-  jmhImplementation "org.openjdk.jmh:jmh-core:1.19"
-  jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.19"
+  jmhImplementation "org.openjdk.jmh:jmh-core:1.34"
+  jmhAnnotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:1.34"
 
   avro1_4 (AVRO_1_4) {
     exclude group: "org.mortbay.jetty"
@@ -145,6 +169,11 @@ dependencies {
     exclude group: "org.slf4j"
   }
   codegenCompile project(":avro-fastserde")
+  if (JavaVersion.current() == JavaVersion.VERSION_11) {
+    java11Implementation files(sourceSets.main.output.classesDirs)
+    java11Implementation AVRO_LIB
+    java11Implementation "org.apache.commons:commons-lang3:3.4"
+  }
 }
 
 compileJmhJava {
@@ -164,10 +193,17 @@ for (String avroVersion : avroVersions) {
     testLogging {
       events "passed", "skipped", "failed"
     }
-
-    classpath = project.sourceSets.test.runtimeClasspath.filter {
-      File file -> !(file.name.contains("avro") && !file.name.contains("helper"))
-    }.plus (configurations."avro${avroVersion}")
+    //Classpath override for JDK11 build, we add JDK11 classes in front of other entities
+    //so unit tests will use platform specific classes
+    if (JavaVersion.current() == JavaVersion.VERSION_11) {
+      classpath = project.sourceSets.java11.output.classesDirs + project.sourceSets.test.runtimeClasspath.filter {
+        File file -> !(file.name.contains("avro") && !file.name.contains("helper"))
+      }.plus(configurations."avro${avroVersion}")
+    } else {
+      classpath = project.sourceSets.test.runtimeClasspath.filter {
+        File file -> !(file.name.contains("avro") && !file.name.contains("helper"))
+      }.plus(configurations."avro${avroVersion}")
+    }
 
     def gradleIsFun = avroVersion
 
@@ -258,37 +294,45 @@ compileTestJava.dependsOn whetherToCompileAvroClasses1_10
 // Need to create several similar tasks since gradle will only run the same task at most once,
 // but we need to clean up and re-compile for each Avro version since the avro classes will be
 // generated with every Avro version.
+
+//Clean task deletes JDK11 classes, so for JDK11 build we need to generate them again before each test
+def gradleCommand = []
+if (JavaVersion.current() == JavaVersion.VERSION_11) {
+  gradleCommand = ['./gradlew', 'avro-fastserde:clean', ':avro-fastserde:java11Classes', 'avro-fastserde:testClasses']
+} else {
+  gradleCommand = ['./gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses']
+}
 task cleanupAndRebuildTestsForAvro1_4(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_4'
+  commandLine gradleCommand + '-PUSE_AVRO_1_4'
 }
 task cleanupAndRebuildTestsForAvro1_5(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_5'
+  commandLine gradleCommand + '-PUSE_AVRO_1_5'
 }
 task cleanupAndRebuildTestsForAvro1_6(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_6'
+  commandLine gradleCommand + '-PUSE_AVRO_1_6'
 }
 task cleanupAndRebuildTestsForAvro1_7(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_7'
+  commandLine gradleCommand + '-PUSE_AVRO_1_7'
 }
 task cleanupAndRebuildTestsForAvro1_8(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_8'
+  commandLine gradleCommand + '-PUSE_AVRO_1_8'
 }
 task cleanupAndRebuildTestsForAvro1_9(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_9'
+  commandLine gradleCommand + '-PUSE_AVRO_1_9'
 }
 task cleanupAndRebuildTestsForAvro1_10(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_10'
+  commandLine gradleCommand + '-PUSE_AVRO_1_10'
 }
 task cleanupAndRebuildTestsForAvro1_11(type:Exec) {
   workingDir '../'
-  commandLine './gradlew', 'avro-fastserde:clean', 'avro-fastserde:testClasses', '-PUSE_AVRO_1_11'
+  commandLine gradleCommand + '-PUSE_AVRO_1_11'
 }
 cleanupAndRebuildTestsForAvro1_4.dependsOn generateAvroClasses1_4
 cleanupAndRebuildTestsForAvro1_5.dependsOn generateAvroClasses1_5

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_10;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_10/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_4;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_4/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_5;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_5/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_6;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_6/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_7;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_7/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_8;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_8/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_FLOAT_GenericDeserializer_7282396011446356583_7282396011446356583.java
@@ -4,7 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_9;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -23,7 +23,7 @@ public class Array_of_FLOAT_GenericDeserializer_7282396011446356583_728239601144
         throws IOException
     {
         PrimitiveFloatList array0 = null;
-        array0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
+        array0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray((reuse), (decoder)));
         return array0;
     }
 

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_TestRecord_SpecificDeserializer_6709200327098145888_6709200327098145888.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -928,7 +928,7 @@ public class Array_of_TestRecord_SpecificDeserializer_6709200327098145888_670920
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101031552.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -938,7 +938,7 @@ public class Array_of_UNION_SpecificDeserializer_735161557101031552_735161557101
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_TestRecord_SpecificDeserializer_3436583053015536530_3436583053015536530.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -933,7 +933,7 @@ public class Map_of_TestRecord_SpecificDeserializer_3436583053015536530_34365830
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604109790.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -943,7 +943,7 @@ public class Map_of_UNION_SpecificDeserializer_1942337358604109790_1942337358604
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen19 = (decoder.readArrayStart());

--- a/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
+++ b/avro-fastserde/src/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_9/TestRecord_SpecificDeserializer_4584175291925934544_4584175291925934544.java
@@ -12,7 +12,7 @@ import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
-import com.linkedin.avro.fastserde.ByteBufferBackedPrimitiveFloatList;
+import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
@@ -910,7 +910,7 @@ public class TestRecord_SpecificDeserializer_4584175291925934544_458417529192593
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
-        floatArray0 = ((PrimitiveFloatList) ByteBufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
+        floatArray0 = ((PrimitiveFloatList) BufferBackedPrimitiveFloatList.readPrimitiveFloatArray(TestRecord.get(35), (decoder)));
         TestRecord.put(35, floatArray0);
         PrimitiveIntList intArray0 = null;
         long chunkLen18 = (decoder.readArrayStart());

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/BufferBackedPrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/BufferBackedPrimitiveFloatList.java
@@ -34,7 +34,7 @@ import org.apache.avro.io.Decoder;
  *
  *   TODO: Provide arrays for other primitive types.
  */
-public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
+public class BufferBackedPrimitiveFloatList extends AbstractList<Float>
     implements GenericArray<Float>, Comparable<GenericArray<Float>>, PrimitiveFloatList {
   private static final float[] EMPTY = new float[0];
   private static final int FLOAT_SIZE = Float.BYTES;
@@ -45,7 +45,7 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
   private boolean isCached = false;
   private CompositeByteBuffer byteBuffer;
 
-  public ByteBufferBackedPrimitiveFloatList(int capacity) {
+  public BufferBackedPrimitiveFloatList(int capacity) {
     if (capacity != 0) {
       elements = new float[capacity];
     }
@@ -53,7 +53,7 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
     byteBuffer = new CompositeByteBuffer(capacity != 0);
   }
 
-  public ByteBufferBackedPrimitiveFloatList(Collection<Float> c) {
+  public BufferBackedPrimitiveFloatList(Collection<Float> c) {
     if (c != null) {
       elements = new float[c.size()];
       addAll(c);
@@ -62,13 +62,13 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
   }
 
   /**
-   * Instantiate (or re-use) and populate a {@link ByteBufferBackedPrimitiveFloatList} from a {@link org.apache.avro.io.Decoder}.
+   * Instantiate (or re-use) and populate a {@link BufferBackedPrimitiveFloatList} from a {@link org.apache.avro.io.Decoder}.
    *
    * N.B.: the caller must ensure the data is of the appropriate type by calling {@link #isFloatArray(Schema)}.
    *
-   * @param old old {@link ByteBufferBackedPrimitiveFloatList} to reuse
+   * @param old old {@link BufferBackedPrimitiveFloatList} to reuse
    * @param in {@link org.apache.avro.io.Decoder} to read new list from
-   * @return a {@link ByteBufferBackedPrimitiveFloatList} with data, possibly the old argument reused
+   * @return a {@link BufferBackedPrimitiveFloatList} with data, possibly the old argument reused
    * @throws IOException on io errors
    */
   public static Object readPrimitiveFloatArray(Object old, Decoder in) throws IOException {
@@ -76,7 +76,7 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
     long totalLength = 0;
 
     if (length > 0) {
-      ByteBufferBackedPrimitiveFloatList array = (ByteBufferBackedPrimitiveFloatList) newPrimitiveFloatArray(old);
+      BufferBackedPrimitiveFloatList array = (BufferBackedPrimitiveFloatList) newPrimitiveFloatArray(old);
       int index = 0;
 
       do {
@@ -91,7 +91,7 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
       array.size = (int) totalLength;
       return array;
     } else {
-      return new ByteBufferBackedPrimitiveFloatList(0);
+      return new BufferBackedPrimitiveFloatList(0);
     }
   }
 
@@ -101,7 +101,7 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
    * @param list
    * @param totalSize
    */
-  private static void setupElements(ByteBufferBackedPrimitiveFloatList list, int totalSize) {
+  private static void setupElements(BufferBackedPrimitiveFloatList list, int totalSize) {
     if (list.elements.length != 0) {
       if (totalSize <= list.getCapacity()) {
         // reuse the float array directly
@@ -118,7 +118,7 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
 
   /**
      * @param expected {@link Schema} to inspect
-     * @return true if the {@code expected} SCHEMA is of the right type to decode as a {@link ByteBufferBackedPrimitiveFloatList}
+     * @return true if the {@code expected} SCHEMA is of the right type to decode as a {@link BufferBackedPrimitiveFloatList}
      *         false otherwise
      */
   public static boolean isFloatArray(Schema expected) {
@@ -127,15 +127,15 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
   }
 
   private static Object newPrimitiveFloatArray(Object old) {
-    if (old instanceof ByteBufferBackedPrimitiveFloatList) {
-      ByteBufferBackedPrimitiveFloatList oldFloatList = (ByteBufferBackedPrimitiveFloatList) old;
+    if (old instanceof BufferBackedPrimitiveFloatList) {
+      BufferBackedPrimitiveFloatList oldFloatList = (BufferBackedPrimitiveFloatList) old;
       oldFloatList.byteBuffer.clear();
       oldFloatList.isCached = false;
       oldFloatList.size = 0;
       return oldFloatList;
     } else {
       // Just a place holder, will set up the elements later.
-      return new ByteBufferBackedPrimitiveFloatList(0);
+      return new BufferBackedPrimitiveFloatList(0);
     }
   }
 
@@ -297,8 +297,8 @@ public class ByteBufferBackedPrimitiveFloatList extends AbstractList<Float>
   @Override
   public int compareTo(GenericArray<Float> that) {
     cacheFromByteBuffer();
-    if (that instanceof ByteBufferBackedPrimitiveFloatList) {
-      ByteBufferBackedPrimitiveFloatList thatPrimitiveList = (ByteBufferBackedPrimitiveFloatList) that;
+    if (that instanceof BufferBackedPrimitiveFloatList) {
+      BufferBackedPrimitiveFloatList thatPrimitiveList = (BufferBackedPrimitiveFloatList) that;
       if (this.size == thatPrimitiveList.size) {
         for (int i = 0; i < this.size; i++) {
           int compare = Float.compare(this.elements[i], thatPrimitiveList.elements[i]);

--- a/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -754,12 +754,12 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
 
     final JVar arrayVar = action.getShouldRead() ? declareValueVar(name, effectiveArrayReaderSchema, parentBody, true, false, true) : null;
     /**
-     * Special optimization for float array by leveraging {@link ByteBufferBackedPrimitiveFloatList}.
+     * Special optimization for float array by leveraging {@link BufferBackedPrimitiveFloatList}.
      *
      * TODO: Handle other primitive element types here.
      */
     if (action.getShouldRead() && arraySchema.getElementType().getType().equals(Schema.Type.FLOAT)) {
-      JClass primitiveFloatList = codeModel.ref(ByteBufferBackedPrimitiveFloatList.class);
+      JClass primitiveFloatList = codeModel.ref(BufferBackedPrimitiveFloatList.class);
       JExpression readPrimitiveFloatArrayInvocation = primitiveFloatList.staticInvoke("readPrimitiveFloatArray").
           arg(reuseSupplier.get()).arg(JExpr.direct(DECODER));
       JExpression castedResult =

--- a/avro-fastserde/src/main/java11/com/linkedin/avro/fastserde/BufferBackedPrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java11/com/linkedin/avro/fastserde/BufferBackedPrimitiveFloatList.java
@@ -352,8 +352,8 @@ public class BufferBackedPrimitiveFloatList extends AbstractList<Float>
     StringBuilder buffer = new StringBuilder();
     buffer.append("[");
     int count = 0;
-    for (Float e : this) {
-      buffer.append(e == null ? "null" : e.toString());
+    for (int i = 0; i < size; i++) {
+      buffer.append(getPrimitive(i));
       if (++count < size()) {
         buffer.append(", ");
       }

--- a/avro-fastserde/src/main/java11/com/linkedin/avro/fastserde/BufferBackedPrimitiveFloatList.java
+++ b/avro-fastserde/src/main/java11/com/linkedin/avro/fastserde/BufferBackedPrimitiveFloatList.java
@@ -1,0 +1,384 @@
+package com.linkedin.avro.fastserde;
+
+import com.linkedin.avro.api.PrimitiveFloatList;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.io.Decoder;
+import org.apache.commons.lang3.ArrayUtils;
+
+
+/**
+ * This is a re-implementation of Avro's {@link GenericData.Array} class.
+
+ * Compared to the Avro implementation, it offers the following GC-related optimizations:
+ * - It does not, by default, box primitive floats into Object Floats, though it will still do so if the
+ *   regular functions are called (e.g.: {@link #get(int)}, for compatibility purposes. In order to avoid
+ *   boxing, the {@link #getPrimitive(int)} function can be used instead.
+
+ * - It does not maintain a reference to a {@link Schema} instance, since that schema would always be the
+ *   same. Instead, it defines a static {@link #SCHEMA} which is used by all instances.
+
+ * - It re-implements {@link #compareTo(GenericArray)}, {@link #equals(Object)} and {@link #hashCode()}
+ *   in order to leverage the primitive types, rather than causing unintended boxing.
+
+ *   Using VarHandle(JDK9+ API) to speed up float-array deserialization: We allocate byte array to store the raw bytes
+ *   from BinaryDecoder and deserialize them only during array element access. We cache the results into the elements
+ *   array after the first get access of the array so that sub-sequent array access are fast.
+ *   TODO: Provide arrays for other primitive types.
+ */
+public class BufferBackedPrimitiveFloatList extends AbstractList<Float>
+    implements GenericArray<Float>, Comparable<GenericArray<Float>>, PrimitiveFloatList {
+  private static final float[] EMPTY = new float[0];
+  private static final int FLOAT_SIZE = Float.BYTES;
+  private static final Schema FLOAT_SCHEMA = Schema.create(Schema.Type.FLOAT);
+  private static final Schema SCHEMA = Schema.createArray(FLOAT_SCHEMA);
+  private int size;
+  private float[] elements = EMPTY;
+  private boolean isCached = false;
+  private byte[] byteBuffer;
+
+  private static final VarHandle VH = MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.LITTLE_ENDIAN);
+
+  public BufferBackedPrimitiveFloatList(int capacity) {
+    if (capacity != 0) {
+      elements = new float[capacity];
+    }
+  }
+
+  public BufferBackedPrimitiveFloatList(Collection<Float> c) {
+    if (c != null) {
+      elements = new float[c.size()];
+      addAll(c);
+    }
+  }
+
+  /**
+   * Instantiate (or re-use) and populate a {@link BufferBackedPrimitiveFloatList} from a {@link Decoder}.
+
+   * N.B.: the caller must ensure the data is of the appropriate type by calling {@link #isFloatArray(Schema)}.
+   *
+   * @param old old {@link BufferBackedPrimitiveFloatList} to reuse
+   * @param in {@link Decoder} to read new list from
+   * @return a {@link BufferBackedPrimitiveFloatList} with data, possibly the old argument reused
+   * @throws IOException on io errors
+   */
+  public static Object readPrimitiveFloatArray(Object old, Decoder in) throws IOException {
+    long length = in.readArrayStart();
+    long totalLength = 0;
+
+    if (length > 0) {
+      BufferBackedPrimitiveFloatList array = (BufferBackedPrimitiveFloatList) newPrimitiveFloatArray(old);
+
+      do {
+        long byteSize = length * FLOAT_SIZE;
+        byte[] buffer = new byte[(int)byteSize];
+        in.readFixed(buffer, 0, (int)byteSize);
+        totalLength += length;
+        length = in.arrayNext();
+        /*
+        This implies memory copy when there is more than one float array
+        However, another option will be to keep the list of byte arrays
+        and track positions similar to {@link CompositeByteBuffer}
+         */
+        array.byteBuffer = merge(array.byteBuffer, buffer);
+      } while (length > 0);
+
+      array.size = (int) totalLength;
+      return array;
+    } else {
+      return new BufferBackedPrimitiveFloatList(0);
+    }
+  }
+
+  private static byte[] merge(byte[] a, byte[] b) {
+    if (a == null) {
+      return b;
+    } else {
+      return ArrayUtils.addAll(a, b);
+    }
+  }
+
+  /**
+   *  The primitive float array `elements` will only be used when the interface user calls a mutating operation.
+   *  eg add/remove else for read-only use case this will not be called.
+   * @param list
+   * @param totalSize
+   */
+  private static void setupElements(BufferBackedPrimitiveFloatList list, int totalSize) {
+    if (list.elements.length != 0) {
+      if (totalSize <= list.getCapacity()) {
+        // reuse the float array directly
+        list.clear();
+      } else {
+        list.resizeAndClear(totalSize);
+      }
+      list.size = totalSize;
+      return;
+    }
+    list.elements = new float[totalSize];
+    list.size = totalSize;
+  }
+
+  /**
+     * @param expected {@link Schema} to inspect
+     * @return true if the {@code expected} SCHEMA is of the right type to decode as a {@link BufferBackedPrimitiveFloatList}
+     *         false otherwise
+     */
+  public static boolean isFloatArray(Schema expected) {
+    return expected != null && Schema.Type.ARRAY.equals(expected.getType()) && FLOAT_SCHEMA.equals(
+        expected.getElementType());
+  }
+
+  private static Object newPrimitiveFloatArray(Object old) {
+    if (old instanceof BufferBackedPrimitiveFloatList) {
+      BufferBackedPrimitiveFloatList oldFloatList = (BufferBackedPrimitiveFloatList) old;
+      oldFloatList.byteBuffer = null;
+      oldFloatList.isCached = false;
+      oldFloatList.size = 0;
+      return oldFloatList;
+    } else {
+      // Just a place holder, will set up the elements later.
+      return new BufferBackedPrimitiveFloatList(0);
+    }
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  public int size() {
+    return size;
+  }
+
+  @Override
+  public void clear() {
+    size = 0;
+  }
+
+  private int getCapacity() {
+    return elements.length;
+  }
+
+  private void resizeAndClear(int newSize) {
+    elements = new float[newSize];
+    clear();
+  }
+
+  @Override
+  public Iterator<Float> iterator() {
+    return new Iterator<Float>() {
+      private int position = 0;
+
+      @Override
+      public boolean hasNext() {
+        return position < size;
+      }
+
+      @Override
+      public Float next() {
+        float f = getPrimitive(position);
+        position++;
+        return f;
+      }
+
+      @Override
+      public void remove() {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  public float getPrimitive(int i) {
+    if (i >= size) {
+      throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
+    }
+    if (isCached) {
+      return elements[i];
+    }
+    return (float)VH.get(byteBuffer, i * FLOAT_SIZE);
+  }
+
+  @Override
+  public Float get(int i) {
+    return getPrimitive(i);
+  }
+
+  /**
+   * Add a primitive float inside the list, without boxing.
+
+   * TODO: verify if it's enough to simply store the data as primitives in order to benefit from the GC optimization.
+   * @param o new float to add
+   * @return true?
+   */
+  public boolean addPrimitive(float o) {
+    cacheFromByteBuffer();
+    if (size == elements.length) {
+      float[] newElements = new float[(size * 3) / 2 + 1];
+      System.arraycopy(elements, 0, newElements, 0, size);
+      elements = newElements;
+    }
+    elements[size++] = o;
+    return true;
+  }
+
+  @Override
+  public boolean add(Float o) {
+    return addPrimitive(o);
+  }
+
+  @Override
+  public void add(int location, Float o) {
+    if (location > size || location < 0) {
+      throw new IndexOutOfBoundsException("Index " + location + " out of bounds.");
+    }
+    cacheFromByteBuffer();
+    if (size == elements.length) {
+      float[] newElements = new float[(size * 3) / 2 + 1];
+      System.arraycopy(elements, 0, newElements, 0, size);
+      elements = newElements;
+    }
+    System.arraycopy(elements, location, elements, location + 1, size - location);
+    elements[location] = o;
+    size++;
+  }
+
+  @Override
+  public Float set(int i, Float o) {
+    return set(i, o);
+  }
+
+  @Override
+  public float setPrimitive(int i, float o) {
+    if (i >= size) {
+      throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
+    }
+    cacheFromByteBuffer();
+    float response = elements[i];
+    elements[i] = o;
+
+    return response;
+  }
+
+  @Override
+  public Float remove(int i) {
+    if (i >= size) {
+      throw new IndexOutOfBoundsException("Index " + i + " out of bounds.");
+    }
+    cacheFromByteBuffer();
+    Float result = elements[i];
+    --size;
+    System.arraycopy(elements, i + 1, elements, i, (size - i));
+    elements[size] = 0;
+    return result;
+  }
+
+  private void cacheFromByteBuffer() {
+    if (isCached) {
+      return;
+    }
+    synchronized (this) {
+      if (!isCached) {
+        setupElements(this, this.size);
+        for (int i = 0; i < size; i++) {
+          elements[i] = (float)VH.get(byteBuffer, i);
+        }
+        isCached = true;
+      }
+    }
+  }
+
+  public float peekPrimitive() {
+    cacheFromByteBuffer();
+    return (size < elements.length) ? elements[size] : null;
+  }
+
+  @Override
+  public Float peek() {
+    return peekPrimitive();
+  }
+
+  @Override
+  public int compareTo(GenericArray<Float> that) {
+    cacheFromByteBuffer();
+    if (that instanceof BufferBackedPrimitiveFloatList) {
+      BufferBackedPrimitiveFloatList thatPrimitiveList = (BufferBackedPrimitiveFloatList) that;
+      if (this.size == thatPrimitiveList.size) {
+        for (int i = 0; i < this.size; i++) {
+          int compare = Float.compare(this.elements[i], thatPrimitiveList.elements[i]);
+          if (compare != 0) {
+            return compare;
+          }
+        }
+        return 0;
+      } else if (this.size > thatPrimitiveList.size) {
+        return 1;
+      } else {
+        return -1;
+      }
+    } else {
+      // Not our own type of primitive list, so we will delegate to the regular implementation, which will do boxing
+      return GenericData.get().compare(this, that, this.getSchema());
+    }
+  }
+
+  @Override
+  public void reverse() {
+    cacheFromByteBuffer();
+    int left = 0;
+    int right = elements.length - 1;
+
+    while (left < right) {
+      float tmp = elements[left];
+      elements[left] = elements[right];
+      elements[right] = tmp;
+
+      left++;
+      right--;
+    }
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder buffer = new StringBuilder();
+    buffer.append("[");
+    int count = 0;
+    for (Float e : this) {
+      buffer.append(e == null ? "null" : e.toString());
+      if (++count < size()) {
+        buffer.append(", ");
+      }
+    }
+    buffer.append("]");
+    return buffer.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    cacheFromByteBuffer();
+    if (o instanceof GenericArray) {
+      return compareTo((GenericArray) o) == 0;
+    } else {
+      return super.equals(o);
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    cacheFromByteBuffer();
+    int hashCode = 1;
+    for (int i = 0; i < this.size; i++) {
+      hashCode = 31 * hashCode + Float.hashCode(elements[i]);
+    }
+    return hashCode;
+  }
+}

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
@@ -90,7 +90,7 @@ public class FastDeserializerDefaultsTest {
     long startTime = System.currentTimeMillis();
 
     for (int i = 0; i < iteration; i++) {
-      ByteBufferBackedPrimitiveFloatList list = new ByteBufferBackedPrimitiveFloatList(array_size);
+      BufferBackedPrimitiveFloatList list = new BufferBackedPrimitiveFloatList(array_size);
 
       for (int l = 0; l < array_size; l++) {
         list.addPrimitive((float) l);

--- a/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/JDKVersionTest.java
+++ b/avro-fastserde/src/test/java/com/linkedin/avro/fastserde/JDKVersionTest.java
@@ -1,0 +1,16 @@
+package com.linkedin.avro.fastserde;
+
+import org.testng.annotations.Test;
+
+
+public class JDKVersionTest {
+  @Test
+  public void jdkVersionTest() {
+    try {
+      Class<?> cl = Class.forName("com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList");
+      System.out.println(cl.getProtectionDomain());
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,10 @@ subprojects {
     compileJava {
       sourceCompatibility = '1.8'
       targetCompatibility = '1.8'
+      //This flag is only supported and required when building with JDK11
+      if (JavaVersion.current() == JavaVersion.VERSION_11) {
+        options.compilerArgs.addAll(['--release', '8'])
+      }
     }
 
     test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/helper/tests/helper-tests-110/build.gradle
+++ b/helper/tests/helper-tests-110/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-111/build.gradle
+++ b/helper/tests/helper-tests-111/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-111_0/build.gradle
+++ b/helper/tests/helper-tests-111_0/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id "java-library"
     id "jacoco"
     id "checkstyle"
-    id "me.champeau.gradle.jmh" version "0.5.3"
+    id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-14/build.gradle
+++ b/helper/tests/helper-tests-14/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-15/build.gradle
+++ b/helper/tests/helper-tests-15/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-16/build.gradle
+++ b/helper/tests/helper-tests-16/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-17/build.gradle
+++ b/helper/tests/helper-tests-17/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-18/build.gradle
+++ b/helper/tests/helper-tests-18/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {

--- a/helper/tests/helper-tests-19/build.gradle
+++ b/helper/tests/helper-tests-19/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id "java-library"
   id "jacoco"
   id "checkstyle"
-  id "me.champeau.gradle.jmh" version "0.5.3"
+  id "me.champeau.jmh" version "0.6.6"
 }
 
 dependencies {


### PR DESCRIPTION
This PR adds:
- Multi-release jar to incorporate JDK11 only classes, (I tried to upgrade build to Gradle 7 to use MrJar plugin, but G7 changes the order of tasks causing multiple issues with avro-fastserde module)
- ByteBufferBackedPrimitiveFloatList renamed to BufferBackedPrimitiveFloatList and added JDK11 only version which uses VarHandles to do byte conversion
- Upgraded JMH plugin and JMH version
- Added simple test to print out version of PrimitiveList class being used by unit tests 
- Tag build switched to JDK11, added release compiler options to maintain backward compatibility