### PR TITLE
Updated build to exclude explicit dependency on Avro from FastSerde build

### DIFF
--- a/fastserde/avro-fastserde/build.gradle
+++ b/fastserde/avro-fastserde/build.gradle
@@ -134,6 +134,10 @@ publishing {
           if ("$project.group" == o.groupId[0].text() && "helper" == o.artifactId[0].text()) {
             toRemove.add(o)
           }
+          //Also remove explicit dependency on Avro, as FaastSerde is version independent
+          if ("org.apache.avro" == o.groupId[0].text() && "avro" == o.artifactId[0].text()) {
+            toRemove.add(o)
+          }
         }
 
         for (Node o : toRemove) {


### PR DESCRIPTION
- FastSerde module is Avro version independent, but still require Avro library to compile
- Default version is 1.10 and due to build changes this version leaked to POM file causing dependency issues
- This change removes explicit dependency on Avro from POM file