### PR TITLE
Address issue with nested arrays

### DIFF
--- a/avro-builder/tests/codegen-19/src/main/avro/vs19/NestedArray.avsc
+++ b/avro-builder/tests/codegen-19/src/main/avro/vs19/NestedArray.avsc
@@ -1,0 +1,27 @@
+{
+    "type": "record",
+    "namespace": "vs19",
+    "name": "Nested Array",
+    "doc": "Nested array example",
+    "fields": [
+        {
+            "name": "NestedArrayItems",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "name": "NestedArrayItem",
+                        "type": "record",
+                        "fields": [
+                            {
+                                "name": "ItemName",
+                                "type": "string"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -140,6 +140,16 @@ public abstract class FastDeserializerGeneratorBase<T> extends FastSerdeBase {
     while (symbolIterator.hasNext()) {
       Symbol symbol = symbolIterator.next();
 
+      if (com.linkedin.testing.avro.fastserde.backport.Symbol.Kind.REPEATER.equals(symbol.kind)
+          && "array-end"
+          .equals(
+              getSymbolPrintName(
+                  ((com.linkedin.testing.avro.fastserde.backport.Symbol.Repeater) symbol)
+                      .end))) {
+        actionIterator = Arrays.asList(reverseSymbolArray(symbol.production)).listIterator();
+        break;
+      }
+
       if (symbol instanceof Symbol.ErrorAction) {
         throw new FastDeserializerGeneratorException(((Symbol.ErrorAction) symbol).msg);
       }


### PR DESCRIPTION
Some schemas with nested arrays ( e.g., NestedArray.avsc ) generate the following error when deserialized with fastserde:

Attempt to process a item-end when a string was expected.

This PR adds a test case and addresses the issue