### PR TITLE
Implementing util method to compare 2 avro schemas and return list of…

### DIFF
--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifference.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifference.java
@@ -76,7 +76,7 @@ public class AvroSchemaDifference {
    */
   @Override
   public String toString() {
-    return "Type: " + avroSchemaDifferenceType.toString() +
+    return "[" + avroSchemaDifferenceType.toString() + "] " +
         ", SchemaALocation: " + ((schemaALocation != null) ? schemaALocation.toString() : "null") +
         ", SchemaBLocation: " + ((schemaBLocation != null) ? schemaBLocation.toString() : "null") +
         ", DifferenceSummary: " + differenceSummary;

--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifference.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifference.java
@@ -1,0 +1,78 @@
+package com.linkedin.avroutil1.model;
+
+/**
+ * The AvroSchemaDifference class is used to record the differences identified while comparing two Avro schemas. This class
+ * records the code location of the difference identified in schemaA and the corrosponding location in schemaB and records the
+ * summary of difference
+ *  * It supports comparing schemas defined in Avro IDL (.avdl) or Avro schema (.avsc) formats.
+ */
+public class AvroSchemaDifference {
+
+  /**
+   * {@link CodeLocation} of the difference in schemaA
+   */
+  private final CodeLocation schemaALocation;
+
+  /**
+   * {@link CodeLocation} of the difference in schemaB
+   */
+  private final CodeLocation schemaBLocation;
+
+  /**
+   * Enum representing Avro schema difference types.
+   */
+  AvroSchemaDifferenceType avroSchemaDifferenceType;
+
+  /**
+   * Summary of the difference between the schemas
+   */
+  private final String differenceSummary;
+
+  /**
+   * Constructor for creating an AvroSchemaDifference object.
+   *
+   * @param schemaALocation           The {@link CodeLocation} of the difference in schemaA
+   * @param schemaBLocation           The {@link CodeLocation} of the difference in schemaB
+   * @param avroSchemaDifferenceType  The AvroSchemaDifferenceType representing the type of difference
+   * @param differenceSummary         The summary of the difference between the schemas
+   */
+  public AvroSchemaDifference(CodeLocation schemaALocation,
+                              CodeLocation schemaBLocation,
+                              AvroSchemaDifferenceType avroSchemaDifferenceType,
+                              String differenceSummary) {
+    this.schemaALocation = schemaALocation;
+    this.schemaBLocation = schemaBLocation;
+    this.avroSchemaDifferenceType = avroSchemaDifferenceType;
+    this.differenceSummary = differenceSummary;
+  }
+
+  public CodeLocation getSchemaALocation() {
+    return schemaALocation;
+  }
+
+  public CodeLocation getSchemaBLocation() {
+    return schemaBLocation;
+  }
+
+  public AvroSchemaDifferenceType getAvroSchemaDifferenceType() {
+    return avroSchemaDifferenceType;
+  }
+
+  public String getDifferenceSummary() {
+    return differenceSummary;
+  }
+
+  /**
+   * Overrides the default toString() method to return a custom string representation
+   * of the AvroSchemaDifference object.
+   *
+   * @return A string representation of the AvroSchemaDifference object
+   */
+  @Override
+  public String toString() {
+    return "Type: " + avroSchemaDifferenceType.toString() +
+        ", SchemaALocation: " + ((schemaALocation != null) ? schemaALocation.toString() : "null") +
+        ", SchemaBLocation: " + ((schemaBLocation != null) ? schemaBLocation.toString() : "null") +
+        ", DifferenceSummary: " + differenceSummary;
+  }
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifference.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifference.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
 package com.linkedin.avroutil1.model;
 
 /**

--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
@@ -72,11 +72,6 @@ public enum AvroSchemaDifferenceType {
   RECORD_NAME_MISMATCH,
 
   /**
-   * Record field count mismatch between schema A and schema B.
-   */
-  RECORD_FIELD_COUNT_MISMATCH,
-
-  /**
    * Record field name mismatch between schema A and schema B.
    */
   RECORD_FIELD_NAME_MISMATCH,
@@ -87,9 +82,9 @@ public enum AvroSchemaDifferenceType {
   RECORD_DEFAULT_VALUE_MISMATCH,
 
   /**
-   * Default value missing in schema A or schema B.
+   * Default value mismatch in schema A or schema B.
    */
-  DEFAULT_VALUE_MISSING,
+  DEFAULT_VALUE_MISMATCH,
 
   /**
    * Record field position mismatch between schema A and schema B.

--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
@@ -99,11 +99,6 @@ public enum AvroSchemaDifferenceType {
   /**
    * Additional field found in schema A or schema B.
    */
-  ADDITIONAL_FIELD,
-
-  /**
-   * Unknown difference type.
-   */
-  UNKNOWN
+  ADDITIONAL_FIELD
 
 }

--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
 package com.linkedin.avroutil1.model;
 
 /**

--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroSchemaDifferenceType.java
@@ -1,0 +1,103 @@
+package com.linkedin.avroutil1.model;
+
+/**
+ * Enum representing Avro schema difference types.
+ */
+public enum AvroSchemaDifferenceType {
+
+  /**
+   * Null schema provided.
+   */
+  NULL_SCHEMA,
+
+  /**
+   * Schema reference mismatch between schema A and schema B.
+   */
+  SCHEMA_REFERENCE_MISMATCH,
+
+  /**
+   * Type mismatch between schema A and schema B.
+   */
+  TYPE_MISMATCH,
+
+  /**
+   * Aliases mismatch between schema A and schema B.
+   */
+  ALIASES_MISMATCH,
+
+  /**
+   * JSON property count mismatch between schema A and schema B.
+   */
+  JSON_PROPERTY_COUNT_MISMATCH,
+
+  /**
+   * JSON property mismatch between schema A and schema B.
+   */
+  JSON_PROPERTY_MISMATCH,
+
+  /**
+   * Enum name mismatch between schema A and schema B.
+   */
+  ENUM_NAME_MISMATCH,
+
+  /**
+   * Enum symbol mismatch between schema A and schema B.
+   */
+  ENUM_SYMBOL_MISMATCH,
+
+  /**
+   * Fixed name mismatch between schema A and schema B.
+   */
+  FIXED_NAME_MISMATCH,
+
+  /**
+   * Fixed size mismatch between schema A and schema B.
+   */
+  FIXED_SIZE_MISMATCH,
+
+  /**
+   * Union size mismatch between schema A and schema B.
+   */
+  UNION_SIZE_MISMATCH,
+
+  /**
+   * Record name mismatch between schema A and schema B.
+   */
+  RECORD_NAME_MISMATCH,
+
+  /**
+   * Record field count mismatch between schema A and schema B.
+   */
+  RECORD_FIELD_COUNT_MISMATCH,
+
+  /**
+   * Record field name mismatch between schema A and schema B.
+   */
+  RECORD_FIELD_NAME_MISMATCH,
+
+  /**
+   * Record default value mismatch between schema A and schema B.
+   */
+  RECORD_DEFAULT_VALUE_MISMATCH,
+
+  /**
+   * Default value missing in schema A or schema B.
+   */
+  DEFAULT_VALUE_MISSING,
+
+  /**
+   * Record field position mismatch between schema A and schema B.
+   */
+  RECORD_FIELD_POSITION_MISMATCH,
+
+  /**
+   * Additional field found in schema A or schema B.
+   */
+  ADDITIONAL_FIELD,
+
+  /**
+   * Unknown difference type.
+   */
+  UNKNOWN
+
+}

--- a/parser/src/main/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparator.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparator.java
@@ -41,7 +41,7 @@ public class ConfigurableAvroSchemaComparator {
 
   /**
    * Compares two AvroSchema objects for equality using the specified SchemaComparisonConfiguration. This method is high
-   * performant and return on the first found mismatch.
+   * performant and return false on the first found mismatch, and if there is no mismatch, it returns true.
    *
    * @param a The first {@link AvroSchema} to compare.
    * @param b The second {@link AvroSchema} to compare.
@@ -304,14 +304,6 @@ public class ConfigurableAvroSchemaComparator {
 
       List<AvroSchemaField> aFields = a.getFields();
       List<AvroSchemaField> bFields = b.getFields();
-      if (aFields.size() != bFields.size()) {
-        AvroSchemaDifference difference =
-            new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.RECORD_FIELD_COUNT_MISMATCH,
-                String.format("Number of fields %d in %s schemaA does not match with the number of fields %d in %s in schemaB",
-                              aFields.size(), a, bFields.size(), b));
-        differences.add(difference);
-        if (fastFail) return;
-      }
       int numberOfCommonFields = Math.min(aFields.size(), bFields.size());
       for (int i = 0; i < numberOfCommonFields; i++) {
         if (fastFail && !differences.isEmpty()) {
@@ -341,7 +333,7 @@ public class ConfigurableAvroSchemaComparator {
           }
         } else if (aField.hasDefaultValue() || bField.hasDefaultValue()) {
           AvroSchemaDifference difference = new AvroSchemaDifference(aField.getCodeLocation(), bField.getCodeLocation(),
-              AvroSchemaDifferenceType.DEFAULT_VALUE_MISSING,
+              AvroSchemaDifferenceType.DEFAULT_VALUE_MISMATCH,
               String.format("Either field %s in %s in schemaA or field %s in %s in schemaB has missing default value",
                             aField.getName(), a, bField.getName(), b));
           differences.add(difference);

--- a/parser/src/main/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparator.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparator.java
@@ -39,29 +39,44 @@ import java.util.Set;
  */
 public class ConfigurableAvroSchemaComparator {
 
+  /**
+   * Compares two AvroSchema objects for equality using the specified SchemaComparisonConfiguration. This method is high
+   * performant and return on the first found mismatch.
+   *
+   * @param a The first {@link AvroSchema} to compare.
+   * @param b The second {@link AvroSchema} to compare.
+   * @param config The {@link SchemaComparisonConfiguration} that specifies the configuration for the comparison.
+   * @return true if the AvroSchema objects are equal according to the specified comparison configuration, false otherwise.
+   */
   public static boolean equals(AvroSchema a, AvroSchema b, SchemaComparisonConfiguration config) {
-    validateConfig(config);
-    Set<SeenPair> seen = new HashSet<>(3);
-    List<AvroSchemaDifference> differences = new ArrayList<>();
-    try {
-      equals(a, b, config, seen, differences);
-      return differences.isEmpty();
-    } catch (IOException e) {
-      return false;
-    }
+    return equals(a, b, config, true).isEmpty();
   }
 
+  /**
+   * Compares two AvroSchema objects and finds the differences between them using the specified SchemaComparisonConfiguration.
+   * This method will return a list of all the differences while comparing the schemas.
+   *
+   * @param a The first {@link AvroSchema} to compare.
+   * @param b The second {@link AvroSchema} to compare.
+   * @param config The {@link SchemaComparisonConfiguration} that specifies the configuration for the comparison.
+   * @return List of {@link AvroSchemaDifference} objects representing the differences between the two AvroSchema objects
+   */
   public static List<AvroSchemaDifference> findDifference(AvroSchema a, AvroSchema b, SchemaComparisonConfiguration config) {
+    return equals(a, b, config, false);
+  }
+
+  private static List<AvroSchemaDifference> equals(AvroSchema a, AvroSchema b, SchemaComparisonConfiguration config, boolean fastFail) {
     validateConfig(config);
     Set<SeenPair> seen = new HashSet<>(3);
     List<AvroSchemaDifference> differences = new ArrayList<>();
     try {
-      equals(a, b, config, seen, differences);
-    } catch (IOException ignored) {
-      // ignored
+      equals(a, b, config, seen, differences, fastFail);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
     }
     return differences;
   }
+
 
   private static void validateConfig(SchemaComparisonConfiguration config) {
     if (config == null) {
@@ -74,8 +89,12 @@ public class ConfigurableAvroSchemaComparator {
     }
   }
 
-  private static void equals(AvroSchema a, AvroSchema b, SchemaComparisonConfiguration config, Set<SeenPair> seen, List<AvroSchemaDifference> differences)
-      throws IOException {
+  private static void equals(AvroSchema a,
+                             AvroSchema b,
+                             SchemaComparisonConfiguration config,
+                             Set<SeenPair> seen,
+                             List<AvroSchemaDifference> differences,
+                             boolean fastFail) throws IOException {
     if (a == null && b == null) {
       return;
     }
@@ -103,109 +122,63 @@ public class ConfigurableAvroSchemaComparator {
       case STRING:
       case BYTES:
         break;
-
       // named types
       case ENUM:
-        AvroEnumSchema enumA = (AvroEnumSchema) a;
-        AvroEnumSchema enumB = (AvroEnumSchema) b;
-
-        // Compare fullName of enum fields in schemaA and schemaB
-        String enumFullNameA = enumA.getFullName();
-        String enumFullNameB = enumB.getFullName();
-        if (!enumFullNameA.equals(enumFullNameB)) {
-          AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ENUM_NAME_MISMATCH,
-              String.format("Name for Enum field %s in schemaA does not match with name enum field %s in schemaB",
-                  enumFullNameA, enumFullNameB));
-          differences.add(difference);
-        }
-
-        // Compare aliases of enum fields in schemaA and schemaB
-        if (considerAliases && !hasSameAliases(enumA, enumB)) {
-          AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ALIASES_MISMATCH,
-              String.format("Aliases for enum field %s in schemaA does not match with aliases for enum field %s in schemaB",
-                  enumFullNameA, enumFullNameB));
-          differences.add(difference);
-        }
-
-        // Compare symbols of enum fields in schemaA and schemaB
-        if (!enumA.getSymbols().equals(enumB.getSymbols())) {
-          AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ENUM_SYMBOL_MISMATCH,
-              String.format("Symbols %s of enum field %s in schemaA does not match with symbols %s of enum field %s in schemaB",
-                            enumA.getSymbols().toString(), enumFullNameA,
-                            enumB.getSymbols().toString(), enumFullNameB));
-          differences.add(difference);
-        }
+        findEnumSchemaDifferences((AvroEnumSchema) a, (AvroEnumSchema) b, config, seen, differences, fastFail);
         break;
-
       case FIXED:
-        AvroFixedSchema fixedA = (AvroFixedSchema) a;
-        AvroFixedSchema fixedB = (AvroFixedSchema) b;
-
-        // Compare fullName of fixed fields in schemaA and schemaB
-        String fixedFullNameA = fixedA.getFullName();
-        String fixedFullNameB = fixedB.getFullName();
-        if (!fixedFullNameA.equals(fixedFullNameB)) {
-          AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.FIXED_NAME_MISMATCH,
-              String.format("Name for fixed field %s in schemaA does not match with name of fixed field %s in schemaB",
-                            fixedFullNameA, fixedFullNameB));
-          differences.add(difference);
-        }
-
-        // Compare aliases of fixed fields in schemaA and schemaB
-        if (!(!considerAliases || hasSameAliases((AvroFixedSchema) a, (AvroFixedSchema) b))) {
-          AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ALIASES_MISMATCH,
-              String.format("Aliases for fixed field %s in schemaA does not match with the aliases for fixed field %s in schemaB",
-                            fixedFullNameA, fixedFullNameB));
-          differences.add(difference);
-        }
-
-        // Compare size of fixed fields in schemaA and schemaB
-        if ((fixedA.getSize() != fixedB.getSize())) {
-          AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.FIXED_SIZE_MISMATCH,
-              String.format("Size for fixed field %s in schemaA does not match with the size for fixed field %s in schemaB",
-                            fixedFullNameA, fixedFullNameB));
-          differences.add(difference);
-        }
+        findFixedSchemaDifferences((AvroFixedSchema) a, (AvroFixedSchema) b, config, seen, differences, fastFail);
         break;
-
       case RECORD:
-        recordSchemaEquals((AvroRecordSchema) a, (AvroRecordSchema) b, config, seen, differences);
+        recordSchemaEquals((AvroRecordSchema) a, (AvroRecordSchema) b, config, seen, differences, fastFail);
         break;
-
       // collections and union
       case ARRAY:
-        equals(((AvroArraySchema) a).getValueSchema(), ((AvroArraySchema) b).getValueSchema(), config, seen, differences);
+        equals(((AvroArraySchema) a).getValueSchema(), ((AvroArraySchema) b).getValueSchema(), config, seen, differences, fastFail);
         break;
       case MAP:
-        equals(((AvroMapSchema) a).getValueSchema(), ((AvroMapSchema) b).getValueSchema(), config, seen, differences);
+        equals(((AvroMapSchema) a).getValueSchema(), ((AvroMapSchema) b).getValueSchema(), config, seen, differences, fastFail);
         break;
       case UNION:
-        List<SchemaOrRef> aBranches = ((AvroUnionSchema) a).getTypes();
-        List<SchemaOrRef> bBranches = ((AvroUnionSchema) b).getTypes();
-        if (aBranches.size() != bBranches.size()) {
-          AvroSchemaDifference difference =
-              new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.UNION_SIZE_MISMATCH,
-                  String.format("Size for union field %d from schemaA does not match with size for union field %d from schemaB",
-                                aBranches.size(), bBranches.size()));
-          differences.add(difference);
-          return;
-        }
-        // We check for the union branches only if the size is equal
-        for (int i = 0; i < aBranches.size(); i++) {
-          SchemaOrRef aBranch = aBranches.get(i);
-          SchemaOrRef bBranch = bBranches.get(i);
-          equals(aBranch, bBranch, config, seen, differences);
-        }
+        findUnionSchemaDifferences((AvroUnionSchema) a, (AvroUnionSchema) b, config, seen, differences, fastFail);
         break;
       default:
         throw new IllegalStateException("Unhandled type: " + type);
     }
   }
 
-  private static void equals(SchemaOrRef aBranch, SchemaOrRef bBranch, SchemaComparisonConfiguration config, Set<SeenPair> seen, List<AvroSchemaDifference> differences)
-      throws IOException {
+  private static void findUnionSchemaDifferences(AvroUnionSchema a,
+                                                 AvroUnionSchema b,
+                                                 SchemaComparisonConfiguration config,
+                                                 Set<SeenPair> seen,
+                                                 List<AvroSchemaDifference> differences,
+                                                 boolean fastFail) throws IOException {
+    List<SchemaOrRef> aBranches = a.getTypes();
+    List<SchemaOrRef> bBranches = b.getTypes();
+    if (aBranches.size() != bBranches.size()) {
+      AvroSchemaDifference difference =
+          new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.UNION_SIZE_MISMATCH,
+              String.format("Size for union field %d from schemaA does not match with size for union field %d from schemaB",
+                  aBranches.size(), bBranches.size()));
+      differences.add(difference);
+      return;
+    }
+    // We check for the union branches only if the size is equal
+    for (int i = 0; i < aBranches.size(); i++) {
+      SchemaOrRef aBranch = aBranches.get(i);
+      SchemaOrRef bBranch = bBranches.get(i);
+      equals(aBranch, bBranch, config, seen, differences, fastFail);
+    }
+  }
+
+  private static void equals(SchemaOrRef aBranch,
+                             SchemaOrRef bBranch,
+                             SchemaComparisonConfiguration config,
+                             Set<SeenPair> seen,
+                             List<AvroSchemaDifference> differences,
+                             boolean fastFail) throws IOException {
     if (aBranch.getSchema() != null) {
-      equals(aBranch.getSchema(), bBranch.getSchema(), config, seen, differences);
+      equals(aBranch.getSchema(), bBranch.getSchema(), config, seen, differences, fastFail);
     }
     if (aBranch.getRef() != null && !aBranch.getRef().equals(bBranch.getRef())) {
       AvroSchemaDifference difference =
@@ -216,16 +189,89 @@ public class ConfigurableAvroSchemaComparator {
     }
   }
 
+  private static void findEnumSchemaDifferences(AvroEnumSchema a,
+                                                AvroEnumSchema b,
+                                                SchemaComparisonConfiguration config,
+                                                Set<SeenPair> seen,
+                                                List<AvroSchemaDifference> differences,
+                                                boolean fastFail) {
+    // Compare fullName of enum fields in schemaA and schemaB
+    String enumFullNameA = a.getFullName();
+    String enumFullNameB = b.getFullName();
+    if (!enumFullNameA.equals(enumFullNameB)) {
+      AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ENUM_NAME_MISMATCH,
+          String.format("Name for Enum field %s in schemaA does not match with name enum field %s in schemaB",
+              enumFullNameA, enumFullNameB));
+      differences.add(difference);
+      if (fastFail) return;
+    }
+
+    // Compare aliases of enum fields in schemaA and schemaB
+    if (config.isCompareAliases() && !hasSameAliases(a, b)) {
+      AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ALIASES_MISMATCH,
+          String.format("Aliases for enum field %s in schemaA does not match with aliases for enum field %s in schemaB",
+              enumFullNameA, enumFullNameB));
+      differences.add(difference);
+      if (fastFail) return;
+    }
+
+    // Compare symbols of enum fields in schemaA and schemaB
+    if (!a.getSymbols().equals(b.getSymbols())) {
+      AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ENUM_SYMBOL_MISMATCH,
+          String.format("Symbols %s of enum field %s in schemaA does not match with symbols %s of enum field %s in schemaB",
+              a.getSymbols().toString(), enumFullNameA,
+              b.getSymbols().toString(), enumFullNameB));
+      differences.add(difference);
+    }
+  }
+
+  private static void findFixedSchemaDifferences(AvroFixedSchema a,
+                                                 AvroFixedSchema b,
+                                                 SchemaComparisonConfiguration config,
+                                                 Set<SeenPair> seen,
+                                                 List<AvroSchemaDifference>differences,
+                                                 boolean fastFail) {
+    // Compare fullName of fixed fields in schemaA and schemaB
+    String fixedFullNameA = a.getFullName();
+    String fixedFullNameB = b.getFullName();
+    if (!fixedFullNameA.equals(fixedFullNameB)) {
+      AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.FIXED_NAME_MISMATCH,
+          String.format("Name for fixed field %s in schemaA does not match with name of fixed field %s in schemaB",
+              fixedFullNameA, fixedFullNameB));
+      differences.add(difference);
+      if (fastFail) return;
+    }
+
+    // Compare aliases of fixed fields in schemaA and schemaB
+    if (config.isCompareAliases() && !hasSameAliases(a, b)) {
+      AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ALIASES_MISMATCH,
+          String.format("Aliases for fixed field %s in schemaA does not match with the aliases for fixed field %s in schemaB",
+              fixedFullNameA, fixedFullNameB));
+      differences.add(difference);
+      if (fastFail) return;
+    }
+
+    // Compare size of fixed fields in schemaA and schemaB
+    if ((a.getSize() != b.getSize())) {
+      AvroSchemaDifference difference = new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.FIXED_SIZE_MISMATCH,
+          String.format("Size for fixed field %s in schemaA does not match with the size for fixed field %s in schemaB",
+              fixedFullNameA, fixedFullNameB));
+      differences.add(difference);
+    }
+  }
+
   private static void recordSchemaEquals(AvroRecordSchema a,
-      AvroRecordSchema b,
-      SchemaComparisonConfiguration config,
-      Set<SeenPair> seen,
-      List<AvroSchemaDifference> differences) throws IOException {
+                                         AvroRecordSchema b,
+                                         SchemaComparisonConfiguration config,
+                                         Set<SeenPair> seen,
+                                         List<AvroSchemaDifference> differences,
+                                         boolean fastFail) throws IOException {
     if (!a.getFullName().equals(b.getFullName())) {
       AvroSchemaDifference difference =
           new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.RECORD_NAME_MISMATCH,
               String.format("Name of the %s in schemaA does not match with name of the %s in schemaB", a, b));
       differences.add(difference);
+      if (fastFail) return;
     }
     // loop protection for self-referencing schemas
     SeenPair pair = new SeenPair(a, b);
@@ -245,6 +291,7 @@ public class ConfigurableAvroSchemaComparator {
             new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.ALIASES_MISMATCH,
                 String.format("Aliases for %s in schemaA does not match with the aliases for %s in schemaB", a, b));
         differences.add(difference);
+        if (fastFail) return;
       }
 
       if (considerJsonProps && !hasSameObjectProps(a, b, considerJsonStringProps, considerJsonNonStringProps)) {
@@ -252,6 +299,7 @@ public class ConfigurableAvroSchemaComparator {
             new AvroSchemaDifference(a.getCodeLocation(), b.getCodeLocation(), AvroSchemaDifferenceType.JSON_PROPERTY_MISMATCH,
                 String.format("Json properties of %s in schemaA does not match with the json properties of %s in schemaB", a, b));
         differences.add(difference);
+        if (fastFail) return;
       }
 
       List<AvroSchemaField> aFields = a.getFields();
@@ -262,20 +310,24 @@ public class ConfigurableAvroSchemaComparator {
                 String.format("Number of fields %d in %s schemaA does not match with the number of fields %d in %s in schemaB",
                               aFields.size(), a, bFields.size(), b));
         differences.add(difference);
+        if (fastFail) return;
       }
       int numberOfCommonFields = Math.min(aFields.size(), bFields.size());
       for (int i = 0; i < numberOfCommonFields; i++) {
+        if (fastFail && !differences.isEmpty()) {
+          return;
+        }
         AvroSchemaField aField = aFields.get(i);
         AvroSchemaField bField = bFields.get(i);
-
         if (!aField.getName().equals(bField.getName())) {
           AvroSchemaDifference difference = new AvroSchemaDifference(aField.getCodeLocation(), bField.getCodeLocation(),
               AvroSchemaDifferenceType.RECORD_FIELD_NAME_MISMATCH,
               String.format("Name for field %s in %s in schemaA does not match with field %s in %s in schemaB",
                             aField.getName(), a, bField.getName(), b));
           differences.add(difference);
+          if (fastFail) return;
         }
-        equals(aField.getSchema(), bField.getSchema(), config, seen, differences);
+        equals(aField.getSchema(), bField.getSchema(), config, seen, differences, fastFail);
 
         if (aField.hasDefaultValue() && bField.hasDefaultValue()) {
           if (!aField.getDefaultValue().equals(bField.getDefaultValue())) {
@@ -285,6 +337,7 @@ public class ConfigurableAvroSchemaComparator {
                     aField.getDefaultValue(), aField.getName(), a,
                     bField.getDefaultValue(), bField.getName(), b));
             differences.add(difference);
+            if (fastFail) return;
           }
         } else if (aField.hasDefaultValue() || bField.hasDefaultValue()) {
           AvroSchemaDifference difference = new AvroSchemaDifference(aField.getCodeLocation(), bField.getCodeLocation(),
@@ -292,6 +345,7 @@ public class ConfigurableAvroSchemaComparator {
               String.format("Either field %s in %s in schemaA or field %s in %s in schemaB has missing default value",
                             aField.getName(), a, bField.getName(), b));
           differences.add(difference);
+          if (fastFail) return;
         }
         if (!Objects.equals(aField.getPosition(), bField.getPosition())) {
           AvroSchemaDifference difference = new AvroSchemaDifference(aField.getCodeLocation(), bField.getCodeLocation(),
@@ -299,18 +353,21 @@ public class ConfigurableAvroSchemaComparator {
               String.format("Position %d for field %s in %s in schemaA does not match with position %d field %s in %s in schemaB",
                   aField.getPosition(), aField.getName(), a, bField.getPosition(), bField.getName(), b));
           differences.add(difference);
+          if (fastFail) return;
         }
         if (considerJsonProps && !hasSameObjectProps(aField, bField, considerJsonStringProps, considerJsonNonStringProps)) {
           AvroSchemaDifference difference = new AvroSchemaDifference(aField.getCodeLocation(), bField.getCodeLocation(),
               AvroSchemaDifferenceType.JSON_PROPERTY_MISMATCH,
               String.format("Json properties of %s in schemaA does not match with the json properties of %s in schemaB", a, b));
           differences.add(difference);
+          if (fastFail) return;
         }
         if (considerAliases && !hasSameAliases(aField, bField)) {
           AvroSchemaDifference difference = new AvroSchemaDifference(aField.getCodeLocation(), bField.getCodeLocation(),
               AvroSchemaDifferenceType.ALIASES_MISMATCH,
               String.format("Aliases for %s in schemaA does not match with the aliases for %s in schemaB", a, b));
           differences.add(difference);
+          if (fastFail) return;
         }
       }
       // If there is size mismatch between the schemas, we add the additional fields in the differences
@@ -320,6 +377,7 @@ public class ConfigurableAvroSchemaComparator {
             AvroSchemaDifferenceType.ADDITIONAL_FIELD,
             String.format("Additional field %s found in schemaA", aField.getName()));
         differences.add(difference);
+        if (fastFail) return;
       }
       for (int i = numberOfCommonFields; i < bFields.size(); i++) {
         AvroSchemaField bField = bFields.get(i);
@@ -327,6 +385,7 @@ public class ConfigurableAvroSchemaComparator {
             AvroSchemaDifferenceType.ADDITIONAL_FIELD,
             String.format("Additional field %s found in schemaB", bField.getName()));
         differences.add(difference);
+        if (fastFail) return;
       }
     } finally {
       seen.remove(pair);

--- a/parser/src/main/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparator.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparator.java
@@ -58,6 +58,7 @@ public class ConfigurableAvroSchemaComparator {
     try {
       equals(a, b, config, seen, differences);
     } catch (IOException ignored) {
+      // ignored
     }
     return differences;
   }

--- a/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
@@ -7,11 +7,16 @@
 package com.linkedin.avroutil1.util;
 
 import com.linkedin.avroutil1.compatibility.SchemaComparisonConfiguration;
+import com.linkedin.avroutil1.model.AvroEnumSchema;
 import com.linkedin.avroutil1.model.AvroRecordSchema;
+import com.linkedin.avroutil1.model.AvroSchema;
+import com.linkedin.avroutil1.model.AvroSchemaDifference;
+import com.linkedin.avroutil1.model.AvroSchemaDifferenceType;
 import com.linkedin.avroutil1.parser.avsc.AvscParseResult;
 import com.linkedin.avroutil1.parser.avsc.AvscParser;
 import com.linkedin.avroutil1.testcommon.TestUtil;
 import java.io.IOException;
+import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -22,23 +27,89 @@ public class ConfigurableAvroSchemaComparatorTest {
   @DataProvider
   private Object[][] testEqualsProvider() {
     return new Object[][] {
-        {"schemas/TestRecord.avsc", "schemas/TestRecord.avsc", true}
+        {"schemas/TestRecord.avsc", "schemas/TestRecord.avsc"}
     };
   }
 
-  @Test(dataProvider = "testEqualsProvider")
-  public void testEquals(String path1, String path2, boolean isEqual) throws IOException {
+  private static AvroSchema validateAndGetAvroRecordSchema(String path) throws IOException {
     AvscParser parser = new AvscParser();
-    String avsc1 = TestUtil.load(path1);
-    String avsc2 = TestUtil.load(path2);
-    AvscParseResult result1 = parser.parse(avsc1);
-    AvscParseResult result2 = parser.parse(avsc2);
-    Assert.assertNull(result1.getParseError());
-    Assert.assertNull(result2.getParseError());
-    AvroRecordSchema recordSchema1 = (AvroRecordSchema) result1.getTopLevelSchema();
-    AvroRecordSchema recordSchema2 = (AvroRecordSchema) result2.getTopLevelSchema();
-    Assert.assertTrue(
-        ConfigurableAvroSchemaComparator.equals(recordSchema1, recordSchema2, SchemaComparisonConfiguration.PRE_1_7_3));
+    String avsc = TestUtil.load(path);
+    AvscParseResult result = parser.parse(avsc);
+    Assert.assertNull(result.getParseError());
+    return result.getTopLevelSchema();
+  }
+
+  @Test(dataProvider = "testEqualsProvider")
+  public void testEquals(String path1, String path2) throws IOException {
+    AvroRecordSchema recordSchema1 = (AvroRecordSchema) validateAndGetAvroRecordSchema(path1);
+    AvroRecordSchema recordSchema2 = (AvroRecordSchema) validateAndGetAvroRecordSchema(path2);
+    Assert.assertTrue(ConfigurableAvroSchemaComparator.equals(recordSchema1, recordSchema2, SchemaComparisonConfiguration.PRE_1_7_3));
+  }
+
+  @Test
+  public void testNotEquals() throws IOException {
+    AvroRecordSchema schema1 = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester1.avsc");
+    AvroRecordSchema schema2 = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester2.avsc");
+    Assert.assertFalse(ConfigurableAvroSchemaComparator.equals(schema1, schema2, SchemaComparisonConfiguration.PRE_1_7_3));
+  }
+
+  // FindDifference testing
+  @Test
+  public void testSimilarSchema() throws IOException {
+    // Load the schema, move this code to a separate method
+    AvroRecordSchema schema = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester1.avsc");
+    List<AvroSchemaDifference> differences = ConfigurableAvroSchemaComparator.findDifference(schema, schema, SchemaComparisonConfiguration.PRE_1_7_3);
+    Assert.assertEquals(differences.size(), 0);
+  }
+
+  @Test
+  public void testNullSchema() throws IOException {
+    // Load the schema, move this code to a separate method
+    AvroRecordSchema schema = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester1.avsc");
+    List<AvroSchemaDifference> differences = ConfigurableAvroSchemaComparator.findDifference(schema, null, SchemaComparisonConfiguration.PRE_1_7_3);
+    Assert.assertEquals(differences.size(), 1);
+  }
+
+  @Test
+  public void testSchemaWithTypeMismatch() throws IOException  {
+    AvroRecordSchema schema1 = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester1.avsc");
+    AvroEnumSchema schema2 = (AvroEnumSchema) validateAndGetAvroRecordSchema("schemas/TestEnum.avsc");
+    List<AvroSchemaDifference> differences =  ConfigurableAvroSchemaComparator.findDifference(schema1, schema2, SchemaComparisonConfiguration.PRE_1_7_3);
+    Assert.assertEquals(differences.size(), 1);
+  }
+
+  @Test
+  public void testSchemaWithDifferences() throws IOException {
+
+    AvroRecordSchema schema1 = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester1.avsc");
+    AvroRecordSchema schema2 = (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/UtilTester2.avsc");
+    List<AvroSchemaDifference> differences = ConfigurableAvroSchemaComparator.findDifference(schema1, schema2, SchemaComparisonConfiguration.STRICT);
+    int expectedDifferences = 18;
+    AvroSchemaDifferenceType[] expectedDifferenceTypes = {
+        AvroSchemaDifferenceType.RECORD_NAME_MISMATCH,
+        AvroSchemaDifferenceType.ALIASES_MISMATCH,
+        AvroSchemaDifferenceType.RECORD_FIELD_COUNT_MISMATCH,
+        AvroSchemaDifferenceType.TYPE_MISMATCH,
+        AvroSchemaDifferenceType.RECORD_DEFAULT_VALUE_MISMATCH,
+        AvroSchemaDifferenceType.ALIASES_MISMATCH,
+        AvroSchemaDifferenceType.ALIASES_MISMATCH,
+        AvroSchemaDifferenceType.ENUM_SYMBOL_MISMATCH,
+        AvroSchemaDifferenceType.ALIASES_MISMATCH,
+        AvroSchemaDifferenceType.FIXED_SIZE_MISMATCH,
+        AvroSchemaDifferenceType.TYPE_MISMATCH,
+        AvroSchemaDifferenceType.TYPE_MISMATCH,
+        AvroSchemaDifferenceType.TYPE_MISMATCH,
+        AvroSchemaDifferenceType.UNION_SIZE_MISMATCH,
+        AvroSchemaDifferenceType.ALIASES_MISMATCH,
+        AvroSchemaDifferenceType.FIXED_SIZE_MISMATCH,
+        AvroSchemaDifferenceType.RECORD_FIELD_NAME_MISMATCH,
+        AvroSchemaDifferenceType.ADDITIONAL_FIELD
+    };
+
+    Assert.assertEquals(differences.size(), expectedDifferences);
+    for (int i = 0; i < expectedDifferences; i++) {
+      Assert.assertEquals(differences.get(i).getAvroSchemaDifferenceType(), expectedDifferenceTypes[i]);
+    }
   }
 
 }

--- a/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
@@ -35,8 +35,8 @@ public class ConfigurableAvroSchemaComparatorTest {
     return new Object[][] {
         {"schemas/UtilTester1.avsc", "schemas/UtilTester1.avsc", SchemaComparisonConfiguration.PRE_1_7_3, 0},
         {"schemas/UtilTester1.avsc", null, SchemaComparisonConfiguration.PRE_1_7_3, 1},
-        {"schemas/UtilTester1.avsc", "schemas/UtilTester2.avsc", SchemaComparisonConfiguration.PRE_1_7_3, 13},
-        {"schemas/UtilTester1.avsc", "schemas/UtilTester2.avsc", SchemaComparisonConfiguration.STRICT, 18}
+        {"schemas/UtilTester1.avsc", "schemas/UtilTester2.avsc", SchemaComparisonConfiguration.PRE_1_7_3, 12},
+        {"schemas/UtilTester1.avsc", "schemas/UtilTester2.avsc", SchemaComparisonConfiguration.STRICT, 17}
     };
   }
 

--- a/parser/src/test/resources/schemas/UtilTester1.avsc
+++ b/parser/src/test/resources/schemas/UtilTester1.avsc
@@ -1,0 +1,120 @@
+{
+  "type": "record",
+  "namespace": "vs14",
+  "name": "UtilTester1",
+  "fields": [
+    {
+      "name": "primitiveTypeMismatch",
+      "type": "float",
+      "default": 2,
+      "aliases": ["aliasMismatch"]
+    },
+    {
+      "name": "enumMismatch",
+      "type": {
+        "name": "enumMismatch",
+        "type": "enum",
+        "symbols": [
+          "A", "B", "C"
+        ],
+        "aliases": ["enumAliases"]
+      }
+    },
+    {
+      "name": "fixedMismatch",
+      "type": {
+        "name": "fixedMismatch",
+        "type": "fixed",
+        "size": 1,
+        "aliases": ["fixedAliases_schemaA"]
+      }
+    },
+    {
+      "name": "arrayMismatch",
+      "type": {
+        "type": "array",
+        "items": "float"
+      }
+    },
+    {
+      "name": "mapMismatch",
+      "type": {
+        "type": "map",
+        "values": "float"
+      }
+    },
+    {
+      "name": "unionMismatch",
+      "type": ["null", "int", "float"]
+    },
+    {
+      "name": "unionSizeMismatch",
+      "type": ["null", "int", "float"]
+    },
+    {
+      "name" : "min",
+      "doc" : "Minimum value",
+      "type" : {
+        "type" : "record",
+        "name" : "Amount",
+        "namespace" : "vs14",
+        "doc" : "Represents an amount of money",
+        "fields" : [ {
+          "name" : "currencyCode",
+          "type" : "string",
+          "doc" : "Currency code v$"
+        }, {
+          "name" : "amount",
+          "type" : "string",
+          "doc" : "The amount of money as a real number string, See https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#BigDecimal-java.lang.String-"
+        } ],
+        "aliases": [
+          "vs14.MoneyAmount"
+        ]
+      }
+    },
+    {
+      "name": "arrayOfRecord",
+      "type": {
+        "type": "array",
+        "items": "vs14.Amount"
+      }
+    },
+    {
+      "name": "mapOfRecord",
+      "type": {
+        "type": "map",
+        "values": "vs14.Amount"
+      }
+    },
+    {
+      "name": "wierdUnion",
+      "type": ["null", "int", "long", "string", "vs14.Amount", "vs14.fixedMismatch", {
+        "type": "array",
+        "items": "string"
+      }]
+    },
+    {
+      "name": "unionOfArray",
+      "type": ["null", {
+        "type": "array",
+        "items": "string"
+      }
+      ]
+    },
+    {
+      "name": "unionOfString",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "intField",
+      "type": "int"
+    },
+    {
+      "name": "extraField",
+      "type": "bytes"
+    }
+
+  ],
+  "aliases": ["UtilTesterAlias"]
+}

--- a/parser/src/test/resources/schemas/UtilTester2.avsc
+++ b/parser/src/test/resources/schemas/UtilTester2.avsc
@@ -1,0 +1,112 @@
+{
+  "type": "record",
+  "namespace": "vs14",
+  "name": "UtilTester2",
+  "fields": [
+    {
+      "name": "primitiveTypeMismatch",
+      "type": "double",
+      "default": 1
+    },
+    {
+      "name": "enumMismatch",
+      "type": {
+        "name": "enumMismatch",
+        "type": "enum",
+        "symbols": [
+          "A", "B", "C", "D"
+        ]
+      }
+    },
+    {
+      "name": "fixedMismatch",
+      "type": {
+        "name": "fixedMismatch",
+        "type": "fixed",
+        "size": 2,
+        "aliases": ["fixedAliases_schemaB"]
+      }
+    },
+    {
+      "name": "arrayMismatch",
+      "type": {
+        "type": "array",
+        "items": "double"
+      }
+    },
+    {
+      "name": "mapMismatch",
+      "type": {
+        "type": "map",
+        "values": "double"
+      }
+    },
+    {
+      "name": "unionMismatch",
+      "type": ["null", "int", "double"]
+    },
+    {
+      "name": "unionSizeMismatch",
+      "type": ["null", "int", "float", "string"]
+    },
+    {
+      "name" : "min",
+      "doc" : "Minimum value",
+      "type" : {
+        "type" : "record",
+        "name" : "Amount",
+        "namespace" : "vs14",
+        "doc" : "Represents an amount of money",
+        "fields" : [ {
+          "name" : "currencyCode",
+          "type" : "string",
+          "doc" : "Currency code v$"
+        }, {
+          "name" : "amount",
+          "type" : "string",
+          "doc" : "The amount of money as a real number string, See https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#BigDecimal-java.lang.String-"
+        } ],
+        "aliases": [
+          "vs14.MoneyAmount"
+        ]
+      }
+    },
+    {
+      "name": "arrayOfRecord",
+      "type": {
+        "type": "array",
+        "items": "vs14.Amount"
+      }
+    },
+    {
+      "name": "mapOfRecord",
+      "type": {
+        "type": "map",
+        "values": "vs14.Amount"
+      }
+    },
+    {
+      "name": "wierdUnion",
+      "type": ["null", "int", "long", "string", "vs14.Amount", "vs14.fixedMismatch", {
+        "type": "array",
+        "items": "string"
+      }]
+    },
+    {
+      "name": "unionOfArray",
+      "type": ["null", {
+        "type": "array",
+        "items": "string"
+      }
+      ]
+    },
+    {
+      "name": "unionOfString",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "intFieldNameChanged",
+      "type": "int"
+    }
+  ]
+}


### PR DESCRIPTION
### Description:
Implementing `findDifference` method in `ConfigurableAvroSchemaComparator` which can be used to compare two Avro schema and return a `List<AvroSchemaDifference>` containing a collection of exact location, type, and summary of differences in schemaA, schemaB (the schema being compared). This can be achieved by updating the existing `equals` implementation to update the `List<AvroSchemaDifference>` instead of returning a boolean. 

**Code Changes:**
- Added `findDifference` method in `ConfigurableAvroSchemaComparator`
- Updated the `equals` method to update the differences instead of returning a boolean 
- Minor bug fixes: 
    - Record schema additional field checks
    - Union branches reference check
- Unit testing the util

**As a reviewer, please help with looking for potential issues for :**
 - Testing that has been done and more testing that can be done 
 - Coding conventions, code reuse and sound logic
 - Performance and scalability

### Testing Done
- New Tests: Added new avsc schemas `UtilTester1` and `UtilTester2` which contained multiple differences. Added unit test to findDifference between these avsc's. 
- Existing Tests: Existing tests passed. 
- Manual Tests: Debugging the changes and fix bugs.
