### PR TITLE
Fix test case and code for nested arrays

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastNestedArrayTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastNestedArrayTest.java
@@ -4,7 +4,6 @@ import com.linkedin.avro.fastserde.generated.avro.NestedArrayItem;
 import com.linkedin.avro.fastserde.generated.avro.NestedArrayTest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.avro.io.Decoder;
 import org.testng.Assert;
@@ -16,12 +15,17 @@ public class FastNestedArrayTest {
   @Test
   public void testExample() throws Exception {
 
-     NestedArrayTest nestedArrayTest = new NestedArrayTest();
+    NestedArrayTest nestedArrayTest = new NestedArrayTest();
 
-    List<NestedArrayItem> items = new ArrayList<>();
     NestedArrayItem item = new NestedArrayItem();
     FastSerdeTestsSupport.setField(item, "ItemName", "itemName");
-    FastSerdeTestsSupport.setField(nestedArrayTest, "NestedArrayItems", Collections.singletonList(items));
+
+    List<NestedArrayItem> nestedArrayItem = new ArrayList<>();
+    nestedArrayItem.add(item);
+    List<List<NestedArrayItem>> nestedArrayItems = new ArrayList<>();
+    nestedArrayItems.add(nestedArrayItem);
+
+    FastSerdeTestsSupport.setField(nestedArrayTest, "NestedArrayItems", nestedArrayItems);
 
     Decoder decoder = FastSerdeTestsSupport.specificDataAsDecoder(nestedArrayTest, NestedArrayTest.SCHEMA$);
 
@@ -32,6 +36,10 @@ public class FastNestedArrayTest {
 
     NestedArrayTest actual = fastDeserializer.deserialize(decoder);
 
-    Assert.assertEquals(actual, nestedArrayTest);
+    List<List<NestedArrayItem>> actualNestedArrayItems =
+        (List<List<NestedArrayItem>>) FastSerdeTestsSupport.getField(actual,"NestedArrayItems");
+    Assert.assertEquals(1, actualNestedArrayItems.size());
+    Assert.assertEquals(1, actualNestedArrayItems.get(0).size());
+    Assert.assertEquals("itemName", String.valueOf(FastSerdeTestsSupport.getField(actualNestedArrayItems.get(0).get(0),"ItemName")));
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -97,10 +97,7 @@ public abstract class FastDeserializerGeneratorBase<T> extends FastSerdeBase {
     while (actionIterator.hasNext()) {
       Symbol symbol = actionIterator.next();
 
-      if (Symbol.Kind.REPEATER.equals(symbol.kind)  &&
-          Symbol.Kind.TERMINAL.equals(((Symbol.Repeater)symbol).end)
-          && "array-end"
-          .equals(((Symbol.Repeater)symbol).end.toString())) {
+      if(Symbol.Kind.REPEATER.equals(symbol.kind) && "array-end".equals(((Symbol.Repeater)symbol).end.toString())) {
         actionIterator = Arrays.asList(reverseSymbolArray(symbol.production)).listIterator();
         break;
       }


### PR DESCRIPTION
The test for nested arrays was incorrect.  Update the tests in `FastNestedArrayTest.java` to correctly validate the test.

Fix bug processing nested array discovered by updating test.