### PR TITLE
fix empty union codegen & skip option

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -209,9 +209,9 @@ public class SchemaBuilder {
       handleUtf8EncodingInPutByIndex = Boolean.TRUE.equals(Boolean.parseBoolean(value));
     }
 
-    boolean skipCodegenIfSchemaOnClasspath = true;
+    boolean skipCodegenIfSchemaOnClasspath = false;
     if (options.has(skipCodegenIfSchemaOnClasspathOpt)) {
-      String value = options.valueOf(enableUtf8EncodingInPutByIndex);
+      String value = options.valueOf(skipCodegenIfSchemaOnClasspathOpt);
       skipCodegenIfSchemaOnClasspath = Boolean.TRUE.equals(Boolean.parseBoolean(value));
     }
 

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -297,10 +297,7 @@ public class AvroUtilCodeGenOp implements Operation {
             }
           }
         } catch (Exception e) {
-          errorCount++;
-          //TODO - error-out
-          LOGGER.error(
-              "failed to generate class for " + fullname, e);
+          throw new InternalError("failed to generate class for " + fullname, e);
         }
       }
       writeJavaFilesToDisk(generatedSpecificClasses, config.getOutputSpecificRecordClassesRoot());

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenOp.java
@@ -297,7 +297,7 @@ public class AvroUtilCodeGenOp implements Operation {
             }
           }
         } catch (Exception e) {
-          throw new InternalError("failed to generate class for " + fullname, e);
+          throw new RuntimeException("failed to generate class for " + fullname, e);
         }
       }
       writeJavaFilesToDisk(generatedSpecificClasses, config.getOutputSpecificRecordClassesRoot());

--- a/avro-codegen/build.gradle
+++ b/avro-codegen/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation "com.squareup:javapoet:1.13.0"
     implementation "commons-io:commons-io:2.6"
     implementation "org.apache.logging.log4j:log4j-api:2.17.1"
+    implementation "org.slf4j:slf4j-api:1.7.14"
     implementation "com.beust:jcommander:1.78"
     implementation "org.apache.ant:ant:1.10.7"
     testImplementation "com.fasterxml.jackson.core:jackson-core:2.10.2"

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.StringJoiner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 import javax.lang.model.element.Modifier;
 import javax.tools.JavaFileObject;
@@ -59,6 +61,7 @@ import javax.tools.JavaFileObject;
  * generates java classes out of avro schemas.
  */
 public class SpecificRecordClassGenerator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpecificRecordClassGenerator.class);
 
   private int sizeValCounter = -1;
 
@@ -1159,6 +1162,9 @@ public class SpecificRecordClassGenerator {
               .endControlFlow();
 
           serializedCodeBlock = codeBlockBuilder.build().toString();
+        } else {
+          LOGGER.warn("Unions with Zero types are not recommended and poorly supported. "
+              + "Please consider using a nullable field instead. Field name: " + fieldName);
         }
         break;
       case RECORD:

--- a/avro-codegen/src/test/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGeneratorTest.java
+++ b/avro-codegen/src/test/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGeneratorTest.java
@@ -190,6 +190,5 @@ public class SpecificRecordClassGeneratorTest {
     JavaFileObject javaFileObject =
         generator.generateSpecificClass(schema, SpecificRecordGenerationConfig.BROAD_COMPATIBILITY);
     CompilerHelper.assertCompiles(javaFileObject);
-
   }
 }

--- a/avro-codegen/src/test/resources/schemas/TestProblematicRecord.avsc
+++ b/avro-codegen/src/test/resources/schemas/TestProblematicRecord.avsc
@@ -14,6 +14,10 @@
     {
       "name": "field",
       "type": "string"
+    },
+    {
+      "name": "fieldOfEmptyUnion",
+        "type": [ ]
     }
   ]
 }


### PR DESCRIPTION
Changes 3 things:
1. fixes skipCodegenIfSchemaOnClasspath. It was poorly configured
2. avro-util codegen was silently failing when a file wasn't generated. We now loudly fail.
3. fixes an issue with codegen'ing empty unions

@li-ukumar PTAL at the empty union codegen. It naively skips any union codegen branches if there's an empty union. Not sure if more is needed.