### PR TITLE
[parser] fix default parsing of record field's of type union

### DIFF
--- a/parser/src/test/java/com/linkedin/avroutil1/parser/avsc/AvscParserTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/parser/avsc/AvscParserTest.java
@@ -17,6 +17,7 @@ import com.linkedin.avroutil1.model.AvroLogicalType;
 import com.linkedin.avroutil1.model.AvroMapLiteral;
 import com.linkedin.avroutil1.model.AvroMapSchema;
 import com.linkedin.avroutil1.model.AvroPrimitiveSchema;
+import com.linkedin.avroutil1.model.AvroRecordLiteral;
 import com.linkedin.avroutil1.model.AvroRecordSchema;
 import com.linkedin.avroutil1.model.AvroSchema;
 import com.linkedin.avroutil1.model.AvroSchemaField;
@@ -74,14 +75,14 @@ public class AvscParserTest {
 
     @Test
     public void testRecordDefaults() throws Exception {
-        String avsc = TestUtil.load("schemas/RecordDefault.avsc");
-//        AvscParser parser = new AvscParser();
-//        AvscParseResult result = parser.parse(avsc);
-//        Schema schema = new Schema.Parser().parse(avsc);
-//        Assert.assertNull(result.getParseError());
-//        Assert.assertTrue(result.getParseError() instanceof AvroSyntaxException);
+        String avsc = TestUtil.load("schemas/RecordDefaultWithUnionField.avsc");
+        AvscParser parser = new AvscParser();
+        AvscParseResult result = parser.parse(avsc);
+        Assert.assertNull(result.getParseError());
+        AvroRecordLiteral defaultFieldValue =
+            (AvroRecordLiteral) ((AvroRecordSchema) result.getTopLevelSchema()).getFields().get(0).getDefaultValue();
+        Assert.assertEquals(defaultFieldValue.getValue().toString(), "{f2=null, f3=Enum1, f1=someString}");
     }
-
     @Test
     public void testParseInvalidDoc() throws Exception {
         String avsc = TestUtil.load("schemas/TestInvalidDocRecord.avsc");

--- a/parser/src/test/java/com/linkedin/avroutil1/parser/avsc/AvscParserTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/parser/avsc/AvscParserTest.java
@@ -73,6 +73,16 @@ public class AvscParserTest {
     }
 
     @Test
+    public void testRecordDefaults() throws Exception {
+        String avsc = TestUtil.load("schemas/RecordDefault.avsc");
+//        AvscParser parser = new AvscParser();
+//        AvscParseResult result = parser.parse(avsc);
+//        Schema schema = new Schema.Parser().parse(avsc);
+//        Assert.assertNull(result.getParseError());
+//        Assert.assertTrue(result.getParseError() instanceof AvroSyntaxException);
+    }
+
+    @Test
     public void testParseInvalidDoc() throws Exception {
         String avsc = TestUtil.load("schemas/TestInvalidDocRecord.avsc");
         AvscParser parser = new AvscParser();

--- a/parser/src/test/resources/schemas/RecordDefault.avsc
+++ b/parser/src/test/resources/schemas/RecordDefault.avsc
@@ -1,0 +1,55 @@
+{
+  "type": "record",
+  "name": "SchemaWithRecordDefault",
+  "fields": [
+    {
+      "name": "mainField",
+      "type": {
+        "type": "record",
+        "name": "InnerRecord",
+        "fields": [
+          {
+            "name": "f1",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "name": "f2",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "name": "f3",
+            "type": {
+              "type": "enum",
+              "name": "MyEnum",
+              "symbols": [
+                "Enum1",
+                "Enum2"
+              ]
+            }
+          },
+          {
+            "name": "f4",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
+      },
+      "default": {
+        "f1": "someString",
+        "f2": null,
+        "f3": "Enum1",
+        "f4": {
+          "string": "someString"
+        }
+      }
+    }
+  ]
+}

--- a/parser/src/test/resources/schemas/RecordDefaultWithUnionField.avsc
+++ b/parser/src/test/resources/schemas/RecordDefaultWithUnionField.avsc
@@ -32,23 +32,13 @@
                 "Enum2"
               ]
             }
-          },
-          {
-            "name": "f4",
-            "type": [
-              "null",
-              "string"
-            ]
           }
         ]
       },
       "default": {
         "f1": "someString",
         "f2": null,
-        "f3": "Enum1",
-        "f4": {
-          "string": "someString"
-        }
+        "f3": "Enum1"
       }
     }
   ]

--- a/parser/src/test/resources/schemas/TestTreeNode.avsc
+++ b/parser/src/test/resources/schemas/TestTreeNode.avsc
@@ -13,8 +13,9 @@
         "null"
       ],
       "default": [
-        {"children" : {"array": []}},
-        {"children" : null}
+        {
+          "children": []
+        }
       ]
     }
   ]


### PR DESCRIPTION
aligns AvscParser with Avro behavior outlined in #486 