### PR TITLE
AvscWriter plugin support in legacy writer

### DIFF
--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -16,6 +16,7 @@ import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -129,16 +130,20 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     }
 
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen) throws IOException {
-        Map<String, Object> props = schema.getObjectProps();
+    protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, Object> props = new HashMap<>(schema.getObjectProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
         }
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
-        Map<String, Object> props = field.getObjectProps();
+    protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, Object> props = new HashMap<>(field.getObjectProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
         }

--- a/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
+++ b/helper/impls/helper-impl-110/src/main/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriter.java
@@ -16,7 +16,7 @@ import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -132,7 +132,7 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
         throws IOException {
-        Map<String, Object> props = new HashMap<>(schema.getObjectProps());
+        Map<String, Object> props = new LinkedHashMap<>(schema.getObjectProps());
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
@@ -142,7 +142,7 @@ public class Avro110AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
         throws IOException {
-        Map<String, Object> props = new HashMap<>(field.getObjectProps());
+        Map<String, Object> props = new LinkedHashMap<>(field.getObjectProps());
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -16,7 +16,7 @@ import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -131,7 +131,7 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
         throws IOException {
-        Map<String, Object> props = new HashMap<>(schema.getObjectProps());
+        Map<String, Object> props = new LinkedHashMap<>(schema.getObjectProps());
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
@@ -141,7 +141,7 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     @Override
     protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
         throws IOException {
-        Map<String, Object> props = new HashMap<>(field.getObjectProps());
+        Map<String, Object> props = new LinkedHashMap<>(field.getObjectProps());
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);

--- a/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
+++ b/helper/impls/helper-impl-111/src/main/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriter.java
@@ -16,6 +16,7 @@ import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,16 +129,20 @@ public class Avro111AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> 
     }
 
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen) throws IOException {
-        Map<String, Object> props = schema.getObjectProps();
+    protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, Object> props = new HashMap<>(schema.getObjectProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
         }
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
-        Map<String, Object> props = field.getObjectProps();
+    protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, Object> props = new HashMap<>(field.getObjectProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
         }

--- a/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
+++ b/helper/impls/helper-impl-14/src/main/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriter.java
@@ -186,8 +186,10 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         }
     }
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
         Map<String, String> props = getProps(schema);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
             writeProps(props, gen, s -> !"default".equals(s));
@@ -197,8 +199,10 @@ public class Avro14AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
         Map<String, String> props = getProps(field);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         writeProps(props, gen);
     }
 }

--- a/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
+++ b/helper/impls/helper-impl-15/src/main/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriter.java
@@ -186,8 +186,10 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
         Map<String, String> props = getProps(schema);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
             writeProps(props, gen, s -> !"default".equals(s));
@@ -197,8 +199,10 @@ public class Avro15AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
         Map<String, String> props = getProps(field);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         writeProps(props, gen);
     }
 }

--- a/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
+++ b/helper/impls/helper-impl-16/src/main/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriter.java
@@ -12,6 +12,7 @@ import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -144,8 +145,10 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen) throws IOException {
-        Map<String, String> props = schema.getProps();
+    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, String> props = new HashMap<>(schema.getProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
             writeProps(props, gen, s -> !"default".equals(s));
@@ -155,8 +158,10 @@ public class Avro16AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
-        Map<String, String> props = field.props();
+    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, String> props = new HashMap<>(field.props());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         writeProps(props, gen);
     }
 }

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -12,7 +12,7 @@ import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -154,7 +154,7 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         if (props == null || props.isEmpty()) {
             return;
         }
-        props = new HashMap<>(props);
+        props = new LinkedHashMap<>(props);
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
@@ -170,7 +170,7 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         if(props == null) {
             return;
         }
-        props = new HashMap<>(props);
+        props = new LinkedHashMap<>(props);
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (!props.isEmpty()) {
             writeProps(props, gen);

--- a/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
+++ b/helper/impls/helper-impl-17/src/main/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriter.java
@@ -12,6 +12,7 @@ import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -148,11 +149,13 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen, Set<String> propNames) throws IOException {
         Map<String, JsonNode> props = Avro17Utils.getProps(schema);
         if (props == null || props.isEmpty()) {
             return;
         }
+        props = new HashMap<>(props);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
             writeProps(props, gen, s -> !"default".equals(s));
@@ -162,9 +165,14 @@ public class Avro17AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen, Set<String> propNames) throws IOException {
         Map<String, JsonNode> props = Avro17Utils.getProps(field);
-        if (props != null && !props.isEmpty()) {
+        if(props == null) {
+            return;
+        }
+        props = new HashMap<>(props);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
+        if (!props.isEmpty()) {
             writeProps(props, gen);
         }
     }

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -12,7 +12,7 @@ import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -154,7 +154,7 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         if (props == null || props.isEmpty()) {
             return;
         }
-        props = new HashMap<>(props);
+        props = new LinkedHashMap<>(props);
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
@@ -170,7 +170,7 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
         if (props == null) {
             return;
         }
-        props = new HashMap<>(props);
+        props = new LinkedHashMap<>(props);
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (!props.isEmpty()) {
             writeProps(props, gen);

--- a/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
+++ b/helper/impls/helper-impl-18/src/main/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriter.java
@@ -12,6 +12,7 @@ import com.linkedin.avroutil1.compatibility.Jackson1Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -148,11 +149,13 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema schema, Jackson1JsonGeneratorWrapper gen, Set<String> propNames) throws IOException {
         Map<String, JsonNode> props = schema.getJsonProps();
         if (props == null || props.isEmpty()) {
             return;
         }
+        props = new HashMap<>(props);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         //write all props except "default" for enums
         if (schema.getType() == Schema.Type.ENUM) {
             writeProps(props, gen, s -> !"default".equals(s));
@@ -162,9 +165,14 @@ public class Avro18AvscWriter extends AvscWriter<Jackson1JsonGeneratorWrapper> {
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen) throws IOException {
+    protected void writePropsLegacy(Schema.Field field, Jackson1JsonGeneratorWrapper gen, Set<String> propNames) throws IOException {
         Map<String, JsonNode> props = field.getJsonProps();
-        if (props != null && !props.isEmpty()) {
+        if (props == null) {
+            return;
+        }
+        props = new HashMap<>(props);
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
+        if (!props.isEmpty()) {
             writeProps(props, gen);
         }
     }

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -16,7 +16,7 @@ import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -131,7 +131,7 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     @Override
     protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
         throws IOException {
-        Map<String, Object> props = new HashMap<>(schema.getObjectProps());
+        Map<String, Object> props = new LinkedHashMap<>(schema.getObjectProps());
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
@@ -141,7 +141,7 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
     @Override
     protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
         throws IOException {
-        Map<String, Object> props = new HashMap<>(field.getObjectProps());
+        Map<String, Object> props = new LinkedHashMap<>(field.getObjectProps());
         props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);

--- a/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
+++ b/helper/impls/helper-impl-19/src/main/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriter.java
@@ -16,6 +16,7 @@ import com.linkedin.avroutil1.compatibility.Jackson2Utils;
 import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -128,16 +129,20 @@ public class Avro19AvscWriter extends AvscWriter<Jackson2JsonGeneratorWrapper> {
         }
     }
     @Override
-    protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen) throws IOException {
-        Map<String, Object> props = schema.getObjectProps();
+    protected void writePropsLegacy(Schema schema, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, Object> props = new HashMap<>(schema.getObjectProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
         }
     }
 
     @Override
-    protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen) throws IOException {
-        Map<String, Object> props = field.getObjectProps();
+    protected void writePropsLegacy(Schema.Field field, Jackson2JsonGeneratorWrapper gen, Set<String> propNames)
+        throws IOException {
+        Map<String, Object> props = new HashMap<>(field.getObjectProps());
+        props.entrySet().removeIf(e -> !propNames.contains(e.getKey()));
         if (props != null && !props.isEmpty()) {
             writeProps(props, gen);
         }

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriterTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriterTest.java
@@ -22,11 +22,16 @@ import org.testng.annotations.Test;
 
 
 public class Avro110AvscWriterTest {
-
+  @Test
+  public void testVanilla() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.VANILLA_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, schema.toString());
+  }
   @Test
   public void testLegacyOneLine() throws IOException {
     // Avro 1.10 gets all props including int, null, boolean, object, string etc
-    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"},\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
     Assert.assertEquals(serialized, expected);
@@ -35,13 +40,13 @@ public class Avro110AvscWriterTest {
   @Test
   public void testLegacyOneLineWithFieldPlugin() throws IOException {
     // Avro 1.10 gets all props including int, null, boolean, object, string etc
-    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // field's objectProp before stringProp as objectProp is being handled by plugin.
     // schema's schemaNestedJsonProp before other props as it is handled by plugin
     String expected =
-        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
-            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+            Arrays.asList(new FieldLevelPlugin("objectProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
         .toAvsc(schema);
     Assert.assertEquals(serialized, expected);
   }

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriterTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/Avro110AvscWriterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro110;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.apache.avro.util.internal.JacksonUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro110AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Avro 1.10 gets all props including int, null, boolean, object, string etc
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithFieldPlugin() throws IOException {
+    // Avro 1.10 gets all props including int, null, boolean, object, string etc
+    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // schema's schemaNestedJsonProp before other props as it is handled by plugin
+    String expected =
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson2JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, JacksonUtils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      if (schema.hasProps()) {
+        String prop = schema.getProp(PROP_NAME);
+        if(prop == null) {
+          return null;
+        }
+        writeProp(PROP_NAME, prop, (Jackson2JsonGeneratorWrapper) gen);
+      }
+      return PROP_NAME;
+    }
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson2JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, JacksonUtils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      if (field.hasProps()) {
+        Object prop = field.getObjectProp(PROP_NAME);
+        if(prop == null) {
+          return null;
+        }
+        writeProp(PROP_NAME, prop, (Jackson2JsonGeneratorWrapper) gen);
+      }
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriterTest.java
+++ b/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriterTest.java
@@ -24,9 +24,15 @@ import org.testng.annotations.Test;
 public class Avro111AvscWriterTest {
 
   @Test
+  public void testVanilla() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.VANILLA_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, schema.toString());
+  }
+  @Test
   public void testLegacyOneLine() throws IOException {
     // Avro 1.11 gets all props including int, null, boolean, object, string etc
-    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"},\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
     Assert.assertEquals(serialized, expected);
@@ -35,13 +41,13 @@ public class Avro111AvscWriterTest {
   @Test
   public void testLegacyOneLineWithFieldPlugin() throws IOException {
     // Avro 1.11 gets all props including int, null, boolean, object, string etc
-    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // field's objectProp before stringProp as objectProp is being handled by plugin.
     // schema's schemaNestedJsonProp before other props as it is handled by plugin
     String expected =
-        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
-            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+            Arrays.asList(new FieldLevelPlugin("objectProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
         .toAvsc(schema);
     Assert.assertEquals(serialized, expected);
   }

--- a/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriterTest.java
+++ b/helper/tests/helper-tests-111/src/test/java/com/linkedin/avroutil1/compatibility/avro111/Avro111AvscWriterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro111;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.apache.avro.util.internal.JacksonUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro111AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Avro 1.11 gets all props including int, null, boolean, object, string etc
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithFieldPlugin() throws IOException {
+    // Avro 1.11 gets all props including int, null, boolean, object, string etc
+    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // schema's schemaNestedJsonProp before other props as it is handled by plugin
+    String expected =
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson2JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, JacksonUtils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      if (schema.hasProps()) {
+        String prop = schema.getProp(PROP_NAME);
+        if(prop == null) {
+          return null;
+        }
+        writeProp(PROP_NAME, prop, (Jackson2JsonGeneratorWrapper) gen);
+      }
+      return PROP_NAME;
+    }
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson2JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, JacksonUtils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      if (field.hasProps()) {
+        Object prop = field.getObjectProp(PROP_NAME);
+        if(prop == null) {
+          return null;
+        }
+        writeProp(PROP_NAME, prop, (Jackson2JsonGeneratorWrapper) gen);
+      }
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriterTest.java
+++ b/helper/tests/helper-tests-14/src/test/java/com/linkedin/avroutil1/compatibility/avro14/Avro14AvscWriterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro14;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro14AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Only string and serialized json props retained in avro 1.4
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithPlugins() throws IOException {
+    // Only string and serialized json props retained in avro 1.6
+    // fields stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\"}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(
+                new FieldLevelPlugin("stringProp"),
+                new SchemaLevelPlugin("schemaNestedJsonProp")
+            ))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      Object prop = field.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen) {
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      String prop = schema.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriterTest.java
+++ b/helper/tests/helper-tests-15/src/test/java/com/linkedin/avroutil1/compatibility/avro15/Avro15AvscWriterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro15;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro15AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Only string and serialized json props retained in avro 1.5
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithPlugins() throws IOException {
+    // Only string and serialized json props retained in avro 1.6
+    // fields stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\"}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(
+                new FieldLevelPlugin("stringProp"),
+                new SchemaLevelPlugin("schemaNestedJsonProp")
+            ))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      Object prop = field.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen) {
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      String prop = schema.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriterTest.java
+++ b/helper/tests/helper-tests-16/src/test/java/com/linkedin/avroutil1/compatibility/avro16/Avro16AvscWriterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro16;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro16AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Only string and serialized json props retained in avro 1.6
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithPlugins() throws IOException {
+    // Only string and serialized json props retained in avro 1.6
+    // fields stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\"}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(
+                new FieldLevelPlugin("stringProp"),
+                new SchemaLevelPlugin("schemaNestedJsonProp")
+            ))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      Object prop = field.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen) {
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      String prop = schema.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriterTest.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro17;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro17AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Avro 1.7 gets all props including int, null, boolean, object, string etc
+    String expected =
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithPlugins() throws IOException {
+    // Avro 1.7 gets all props including int, null, boolean, object, string etc
+    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // schema's schemaNestedJsonProp before other props as it is handled by plugin
+    String expected =
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen) {
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      String prop = schema.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen) {
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      Object prop = field.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriterTest.java
+++ b/helper/tests/helper-tests-17/src/test/java/com/linkedin/avroutil1/compatibility/avro17/Avro17AvscWriterTest.java
@@ -22,12 +22,16 @@ import org.testng.annotations.Test;
 
 
 public class Avro17AvscWriterTest {
-
+  @Test
+  public void testVanilla() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.VANILLA_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, schema.toString());
+  }
   @Test
   public void testLegacyOneLine() throws IOException {
     // Avro 1.7 gets all props including int, null, boolean, object, string etc
-    String expected =
-        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"},\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
     Assert.assertEquals(serialized, expected);
@@ -36,13 +40,13 @@ public class Avro17AvscWriterTest {
   @Test
   public void testLegacyOneLineWithPlugins() throws IOException {
     // Avro 1.7 gets all props including int, null, boolean, object, string etc
-    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // field's objectProp before stringProp as objectProp is being handled by plugin.
     // schema's schemaNestedJsonProp before other props as it is handled by plugin
     String expected =
-        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
-            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+            Arrays.asList(new FieldLevelPlugin("objectProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
         .toAvsc(schema);
     Assert.assertEquals(serialized, expected);
   }
@@ -89,7 +93,7 @@ public class Avro17AvscWriterTest {
 
     @Override
     public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
-      Object prop = field.getProp(PROP_NAME);
+      Object prop = field.getJsonProp(PROP_NAME);
       if (prop == null) {
         return null;
       }

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriterTest.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro18;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson1JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.Jackson1Utils;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.codehaus.jackson.JsonGenerator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro18AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Avro 1.8 gets all props including int, null, boolean, object, string etc
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithFieldPlugin() throws IOException {
+    // Avro 1.8 gets all props including int, null, boolean, object, string etc
+    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // schema's schemaNestedJsonProp before other props as it is handled by plugin
+    String expected =
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen) {
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      String prop = schema.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson1JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, Jackson1Utils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      Object prop = field.getProp(PROP_NAME);
+      if (prop == null) {
+        return null;
+      }
+      writeProp(PROP_NAME, prop, (Jackson1JsonGeneratorWrapper) gen);
+      return PROP_NAME;
+    }
+  }
+}

--- a/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriterTest.java
+++ b/helper/tests/helper-tests-18/src/test/java/com/linkedin/avroutil1/compatibility/avro18/Avro18AvscWriterTest.java
@@ -22,11 +22,16 @@ import org.testng.annotations.Test;
 
 
 public class Avro18AvscWriterTest {
-
+  @Test
+  public void testVanilla() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.VANILLA_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, schema.toString());
+  }
   @Test
   public void testLegacyOneLine() throws IOException {
     // Avro 1.8 gets all props including int, null, boolean, object, string etc
-    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"},\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
     Assert.assertEquals(serialized, expected);
@@ -35,13 +40,13 @@ public class Avro18AvscWriterTest {
   @Test
   public void testLegacyOneLineWithFieldPlugin() throws IOException {
     // Avro 1.8 gets all props including int, null, boolean, object, string etc
-    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // field's objectProp before stringProp as objectProp is being handled by plugin.
     // schema's schemaNestedJsonProp before other props as it is handled by plugin
     String expected =
-        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
-            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+            Arrays.asList(new FieldLevelPlugin("objectProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
         .toAvsc(schema);
     Assert.assertEquals(serialized, expected);
   }
@@ -88,7 +93,7 @@ public class Avro18AvscWriterTest {
 
     @Override
     public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
-      Object prop = field.getProp(PROP_NAME);
+      Object prop = field.getObjectProps().get(PROP_NAME);
       if (prop == null) {
         return null;
       }

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriterTest.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriterTest.java
@@ -24,9 +24,16 @@ import org.testng.annotations.Test;
 public class Avro19AvscWriterTest {
 
   @Test
+  public void testVanilla() throws IOException {
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.VANILLA_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, schema.toString());
+  }
+
+  @Test
   public void testLegacyOneLine() throws IOException {
     // Avro 1.9 gets all props including int, null, boolean, object, string etc
-    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"},\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
     Assert.assertEquals(serialized, expected);
@@ -35,13 +42,13 @@ public class Avro19AvscWriterTest {
   @Test
   public void testLegacyOneLineWithFieldPlugin() throws IOException {
     // Avro 1.9 gets all props including int, null, boolean, object, string etc
-    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // field's objectProp before stringProp as objectProp is being handled by plugin.
     // schema's schemaNestedJsonProp before other props as it is handled by plugin
     String expected =
-        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"stringProp\":\"stringValue\",\"intProp\":42,\"floatProp\":42.42,\"nullProp\":null,\"boolProp\":true,\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
     Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
     String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
-            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+            Arrays.asList(new FieldLevelPlugin("objectProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
         .toAvsc(schema);
     Assert.assertEquals(serialized, expected);
   }

--- a/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriterTest.java
+++ b/helper/tests/helper-tests-19/src/test/java/com/linkedin/avroutil1/compatibility/avro19/Avro19AvscWriterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.compatibility.avro19;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
+import com.linkedin.avroutil1.compatibility.Jackson2JsonGeneratorWrapper;
+import com.linkedin.avroutil1.compatibility.JsonGeneratorWrapper;
+import com.linkedin.avroutil1.normalization.AvscWriterPlugin;
+import com.linkedin.avroutil1.testcommon.TestUtil;
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.apache.avro.util.internal.JacksonUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class Avro19AvscWriterTest {
+
+  @Test
+  public void testLegacyOneLine() throws IOException {
+    // Avro 1.9 gets all props including int, null, boolean, object, string etc
+    String expected = "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42,\"stringProp\":\"stringValue\"},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}";
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE, null).toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  @Test
+  public void testLegacyOneLineWithFieldPlugin() throws IOException {
+    // Avro 1.9 gets all props including int, null, boolean, object, string etc
+    // field's stringProp before nestedJsonProp as stringProp is being handled by plugin.
+    // schema's schemaNestedJsonProp before other props as it is handled by plugin
+    String expected =
+        "{\"type\":\"record\",\"name\":\"RecordWithFieldProps\",\"namespace\":\"com.acme\",\"doc\":\"A perfectly normal record with field props\",\"fields\":[{\"name\":\"stringField\",\"type\":\"string\",\"stringProp\":\"stringValue\",\"nestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"boolProp\":true,\"nullProp\":null,\"objectProp\":{\"a\":\"b\",\"c\":\"d\"},\"floatProp\":42.42,\"intProp\":42},{\"name\":\"intField\",\"type\":\"int\"}],\"schemaNestedJsonProp\":\"{\\\"innerKey\\\" : \\\"innerValue\\\"}\",\"schemaStringProp\":\"stringyMcStringface\",\"schemaNullProp\":null,\"schemaBoolProp\":false,\"schemaIntProp\":24,\"schemaFloatProp\":1.2,\"schemaObjectProp\":{\"e\":\"f\",\"g\":\"h\"}}" ;
+    Schema schema = Schema.parse(TestUtil.load("RecordWithFieldProps.avsc"));
+    String serialized = AvroCompatibilityHelper.getAvscWriter(AvscGenerationConfig.LEGACY_ONELINE,
+            Arrays.asList(new FieldLevelPlugin("stringProp"), new SchemaLevelPlugin("schemaNestedJsonProp")))
+        .toAvsc(schema);
+    Assert.assertEquals(serialized, expected);
+  }
+
+  private class SchemaLevelPlugin extends AvscWriterPlugin {
+    public SchemaLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson2JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, JacksonUtils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+
+    }
+
+    @Override
+    public String execute(Schema schema, JsonGeneratorWrapper gen) {
+      if (schema.hasProps()) {
+        String prop = schema.getProp(PROP_NAME);
+        if(prop == null) {
+          return null;
+        }
+        writeProp(PROP_NAME, prop, (Jackson2JsonGeneratorWrapper) gen);
+      }
+      return PROP_NAME;
+    }
+  }
+
+  private class FieldLevelPlugin extends AvscWriterPlugin {
+
+    public FieldLevelPlugin(String prop_name) {
+      super(prop_name);
+    }
+
+    private void writeProp(String propName, Object prop, Jackson2JsonGeneratorWrapper gen){
+      JsonGenerator delegate = gen.getDelegate();
+      try {
+        delegate.writeObjectField(propName, JacksonUtils.toJsonNode(prop));
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+
+    @Override
+    public String execute(Schema.Field field, JsonGeneratorWrapper gen) {
+      if (field.hasProps()) {
+        Object prop = field.getObjectProp(PROP_NAME);
+        if(prop == null) {
+          return null;
+        }
+        writeProp(PROP_NAME, prop, (Jackson2JsonGeneratorWrapper) gen);
+      }
+      return PROP_NAME;
+    }
+  }
+}


### PR DESCRIPTION
## What
legacy writer support was added in 0.3.3.
Adding plugin support for special handling of json props for legacy use cases as well.

## Test
build, 
Unit tests

avro-schemas scan : https://lva1-app63607.corp.linkedin.com/s/eteghjt2aq5s6
