### PR TITLE
fix fixed literals

### DIFF
--- a/parser/src/main/java/com/linkedin/avroutil1/model/AvroFixedLiteral.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/model/AvroFixedLiteral.java
@@ -6,6 +6,9 @@
 
 package com.linkedin.avroutil1.model;
 
+import java.util.Arrays;
+
+
 public class AvroFixedLiteral extends AvroLiteral {
     private final byte[] value;
 
@@ -34,6 +37,7 @@ public class AvroFixedLiteral extends AvroLiteral {
 
     @Override
     public boolean equals(Object literal) {
-        return literal instanceof AvroFixedLiteral && this.value == ((AvroFixedLiteral) literal).getValue();
+        return literal instanceof AvroFixedLiteral && Arrays.equals(this.value,
+            ((AvroFixedLiteral) literal).getValue());
     }
 }

--- a/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
@@ -119,4 +119,13 @@ public class ConfigurableAvroSchemaComparatorTest {
             SchemaComparisonConfiguration.STRICT.jsonPropNamesToIgnore(jsonPropNamesToIgnore));
     Assert.assertEquals(differences.size(), 0);
   }
+
+  @Test
+  public void testEqualityOfSameRecord() throws IOException {
+    AvroRecordSchema schema1 =
+        (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/TestRecordWithDefaultValues.avsc");
+    AvroRecordSchema schema2 =
+        (AvroRecordSchema) validateAndGetAvroRecordSchema("schemas/TestRecordWithDefaultValues.avsc");
+    Assert.assertTrue(ConfigurableAvroSchemaComparator.equals(schema1, schema2, SchemaComparisonConfiguration.STRICT));
+  }
 }


### PR DESCRIPTION
AvroFixedLiteral equality was broken (before we were doing reference-level equality, not value-level equality).

UT was failing prior to the change in `AvroFixedLiteral`.