### PR TITLE
Adding @deprecate javadoc for public fields in codegen

### DIFF
--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGenerator.java
@@ -467,6 +467,7 @@ public class SpecificRecordClassGenerator {
         FieldSpec.Builder fieldBuilder = getFieldSpecBuilder(field, config).addModifiers(accessModifier);
         if(config.hasPublicFields()) {
           fieldBuilder.addAnnotation(Deprecated.class);
+          fieldBuilder.addJavadoc("@deprecated public fields are deprecated. Please use setters/getters.");
         }
         classBuilder.addField(fieldBuilder.build());
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/StringUtils.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/StringUtils.java
@@ -12,6 +12,7 @@ import org.apache.commons.text.StringEscapeUtils;
 public class StringUtils {
 
   public static final String EMPTY_STRING = "";
+  public static final int INDEX_NOT_FOUND = -1;
 
   private StringUtils() {
     // Util class; should not be instantiated.
@@ -50,5 +51,28 @@ public class StringUtils {
       processed = StringEscapeUtils.unescapeJson(processed);
     }
     return processed;
+  }
+
+  /***
+   * from https://commons.apache.org/proper/commons-lang/javadocs/api-2.6/src-html/org/apache/commons/lang/StringUtils.html#line.5318
+   * @param str
+   * @param sub
+   * @return
+   */
+  public static int countMatches(String str, String sub) {
+    if (isEmpty(str) || isEmpty(sub)) {
+      return 0;
+    }
+    int count = 0;
+    int idx = 0;
+    while ((idx = str.indexOf(sub, idx)) != INDEX_NOT_FOUND) {
+      count++;
+      idx += sub.length();
+    }
+    return count;
+  }
+
+  public static boolean isEmpty(String str) {
+    return str == null || str.length() == 0;
   }
 }


### PR DESCRIPTION
** What**
Adding @deprecated javadoc to public fields in codegen

**Why**
adding [@deprecated in javadoc ](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html#@deprecated)  
```
The @deprecated description in the first sentence should at least tell the user when the API was deprecated and what to use as a replacement. 
Only the first sentence will appear in the summary section and index. 
```

**Testing**
Added UT