### PR TITLE
Tweaked the fast-avro schema fingerprinting logic

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
@@ -224,34 +224,48 @@ public class FastStringableTest {
     stringMap.put("ddd", "eee");
     record.put("testStringMap", stringMap);
 
-    Decoder decoder = writeWithFastAvro(record, writerSchema, false);
+    Decoder decoder1 = writeWithFastAvro(record, writerSchema, false);
+    Decoder decoder2 = writeWithFastAvro(record, writerSchema, false);
 
-    GenericRecord afterDecoding;
+    GenericRecord afterDecodingWithJavaString, afterDecodingWithoutJavaString;
     if (whetherUseFastDeserializer) {
-      afterDecoding = readWithFastAvro(writerSchema, readerSchema, decoder, false);
+      afterDecodingWithJavaString = readWithFastAvro(writerSchema, readerSchema, decoder1, false);
+      afterDecodingWithoutJavaString = readWithFastAvro(writerSchema, writerSchema, decoder2, false);
     } else {
-      afterDecoding = readWithSlowAvro(writerSchema, readerSchema, decoder, false);
+      afterDecodingWithJavaString = readWithSlowAvro(writerSchema, readerSchema, decoder1, false);
+      afterDecodingWithoutJavaString = readWithSlowAvro(writerSchema, writerSchema, decoder2, false);
     }
 
     if (Utils.isAbleToSupportJavaStrings()){
-      Assert.assertTrue(afterDecoding.get(0) instanceof String, "String is expected, but got: " + afterDecoding.get(0).getClass());
-      Assert.assertTrue(afterDecoding.get(1) instanceof String, "String is expected, but got: " + afterDecoding.get(0).getClass());
-      Assert.assertTrue(((GenericData.Array<Object>) afterDecoding.get(2)).get(0) instanceof String,
-          "String is expected, but got: " + ((GenericData.Array<Object>) afterDecoding.get(2)).get(0).getClass());
-      Assert.assertTrue(((Map<Object, Object>) afterDecoding.get(3)).keySet().iterator().next() instanceof String,
-          "String is expected, but got: " + ((Map<Object, Object>) afterDecoding.get(3)).keySet().iterator().next().getClass());
-      Assert.assertTrue(((Map<Object, Object>) afterDecoding.get(3)).values().iterator().next() instanceof String,
-          "String is expected, but got: " + ((Map<Object, Object>) afterDecoding.get(3)).values().iterator().next().getClass());
+      Assert.assertTrue(afterDecodingWithJavaString.get(0) instanceof String, "String is expected, but got: " + afterDecodingWithJavaString.get(0).getClass());
+      Assert.assertTrue(afterDecodingWithJavaString.get(1) instanceof String, "String is expected, but got: " + afterDecodingWithJavaString.get(0).getClass());
+      Assert.assertTrue(((GenericData.Array<Object>) afterDecodingWithJavaString.get(2)).get(0) instanceof String,
+          "String is expected, but got: " + ((GenericData.Array<Object>) afterDecodingWithJavaString.get(2)).get(0).getClass());
+      Assert.assertTrue(((Map<Object, Object>) afterDecodingWithJavaString.get(3)).keySet().iterator().next() instanceof String,
+          "String is expected, but got: " + ((Map<Object, Object>) afterDecodingWithJavaString.get(3)).keySet().iterator().next().getClass());
+      Assert.assertTrue(((Map<Object, Object>) afterDecodingWithJavaString.get(3)).values().iterator().next() instanceof String,
+          "String is expected, but got: " + ((Map<Object, Object>) afterDecodingWithJavaString.get(3)).values().iterator().next().getClass());
     }  else {
-      Assert.assertTrue(afterDecoding.get(0) instanceof Utf8, "Utf8 is expected, but got: " + afterDecoding.get(0).getClass());
-      Assert.assertTrue(afterDecoding.get(1) instanceof Utf8, "Utf8 is expected, but got: " + afterDecoding.get(0).getClass());
-      Assert.assertTrue(((GenericData.Array<Object>) afterDecoding.get(2)).get(0) instanceof Utf8,
-          "Utf8 is expected, but got: " + ((GenericData.Array<Object>) afterDecoding.get(2)).get(0).getClass());
-      Assert.assertTrue(((Map<Object, Object>) afterDecoding.get(3)).keySet().iterator().next() instanceof Utf8,
-          "Utf8 is expected, but got: " + ((Map<Object, Object>) afterDecoding.get(3)).keySet().iterator().next().getClass());
-      Assert.assertTrue(((Map<Object, Object>) afterDecoding.get(3)).values().iterator().next() instanceof Utf8,
-          "Utf8 is expected, but got: " + ((Map<Object, Object>) afterDecoding.get(3)).values().iterator().next().getClass());
+      Assert.assertTrue(afterDecodingWithJavaString.get(0) instanceof Utf8, "Utf8 is expected, but got: " + afterDecodingWithJavaString.get(0).getClass());
+      Assert.assertTrue(afterDecodingWithJavaString.get(1) instanceof Utf8, "Utf8 is expected, but got: " + afterDecodingWithJavaString.get(0).getClass());
+      Assert.assertTrue(((GenericData.Array<Object>) afterDecodingWithJavaString.get(2)).get(0) instanceof Utf8,
+          "Utf8 is expected, but got: " + ((GenericData.Array<Object>) afterDecodingWithJavaString.get(2)).get(0).getClass());
+      Assert.assertTrue(((Map<Object, Object>) afterDecodingWithJavaString.get(3)).keySet().iterator().next() instanceof Utf8,
+          "Utf8 is expected, but got: " + ((Map<Object, Object>) afterDecodingWithJavaString.get(3)).keySet().iterator().next().getClass());
+      Assert.assertTrue(((Map<Object, Object>) afterDecodingWithJavaString.get(3)).values().iterator().next() instanceof Utf8,
+          "Utf8 is expected, but got: " + ((Map<Object, Object>) afterDecodingWithJavaString.get(3)).values().iterator().next().getClass());
     }
+
+    // Regardless of the above, we should also be able to decode to Utf8 within the same JVM that already decoded Java Strings
+    Assert.assertTrue(afterDecodingWithoutJavaString.get(0) instanceof Utf8, "Utf8 is expected, but got: " + afterDecodingWithoutJavaString.get(0).getClass());
+    Assert.assertTrue(afterDecodingWithoutJavaString.get(1) instanceof Utf8, "Utf8 is expected, but got: " + afterDecodingWithoutJavaString.get(0).getClass());
+    Assert.assertTrue(((GenericData.Array<Object>) afterDecodingWithoutJavaString.get(2)).get(0) instanceof Utf8,
+        "Utf8 is expected, but got: " + ((GenericData.Array<Object>) afterDecodingWithoutJavaString.get(2)).get(0).getClass());
+    Assert.assertTrue(((Map<Object, Object>) afterDecodingWithoutJavaString.get(3)).keySet().iterator().next() instanceof Utf8,
+        "Utf8 is expected, but got: " + ((Map<Object, Object>) afterDecodingWithoutJavaString.get(3)).keySet().iterator().next().getClass());
+    Assert.assertTrue(((Map<Object, Object>) afterDecodingWithoutJavaString.get(3)).values().iterator().next() instanceof Utf8,
+        "Utf8 is expected, but got: " + ((Map<Object, Object>) afterDecodingWithoutJavaString.get(3)).values().iterator().next().getClass());
+
   }
 
 

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorBase.java
@@ -37,8 +37,8 @@ public abstract class FastDeserializerGeneratorBase<T> extends FastSerdeBase {
   }
 
   public static String getClassName(Schema writerSchema, Schema readerSchema, String description) {
-    Long writerSchemaId = Math.abs(Utils.getSchemaFingerprint(writerSchema));
-    Long readerSchemaId = Math.abs(Utils.getSchemaFingerprint(readerSchema));
+    int writerSchemaId = Math.abs(Utils.getSchemaFingerprint(writerSchema));
+    int readerSchemaId = Math.abs(Utils.getSchemaFingerprint(readerSchema));
     String typeName = SchemaAssistant.getTypeName(readerSchema);
     return typeName + SEP + description + "Deserializer" + SEP + writerSchemaId + SEP + readerSchemaId;
   }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
@@ -34,7 +34,7 @@ public class FastSerializerGenerator<T> extends FastSerdeBase {
   /**
    * Enum schema mapping for Avro-1.4 to record schema id and corresponding schema JVar.
    */
-  private final Map<Long, JVar> enumSchemaVarMap = new HashMap<>();
+  private final Map<Integer, JVar> enumSchemaVarMap = new HashMap<>();
 
 
   public FastSerializerGenerator(boolean useGenericTypes, Schema schema, File destination, ClassLoader classLoader,
@@ -44,7 +44,7 @@ public class FastSerializerGenerator<T> extends FastSerdeBase {
   }
 
   public static String getClassName(Schema schema, String description) {
-    Long schemaId = Math.abs(Utils.getSchemaFingerprint(schema));
+    int schemaId = Math.abs(Utils.getSchemaFingerprint(schema));
     String typeName = SchemaAssistant.getTypeName(schema);
     return typeName + SEP + description + "Serializer" + SEP + schemaId;
   }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
@@ -2,7 +2,6 @@ package com.linkedin.avro.fastserde;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroVersion;
-import com.linkedin.avroutil1.compatibility.SchemaNormalization;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -39,7 +38,7 @@ public class Utils {
   }
 
   // Cache the mapping between Schema and the corresponding fingerprint
-  private static final Map<Schema, Long> SCHEMA_IDS_CACHE = new ConcurrentHashMap<>();
+  private static final Map<Schema, Integer> SCHEMA_IDS_CACHE = new ConcurrentHashMap<>();
 
   private Utils() {
   }
@@ -108,13 +107,14 @@ public class Utils {
   }
   /**
    * This function will produce a fingerprint for the provided schema.
+   *
    * @param schema a schema
    * @return fingerprint for the given schema
    */
-  public static Long getSchemaFingerprint(Schema schema) {
-    Long schemaId = SCHEMA_IDS_CACHE.get(schema);
+  public static int getSchemaFingerprint(Schema schema) {
+    Integer schemaId = SCHEMA_IDS_CACHE.get(schema);
     if (schemaId == null) {
-      schemaId = SchemaNormalization.parsingFingerprint64(schema);
+      schemaId = schema.toString().hashCode();
       SCHEMA_IDS_CACHE.put(schema, schemaId);
     }
 


### PR DESCRIPTION
It used to leverage the Avro fingerprinting, which is based on the "parsing canonical form" of the schema, but this ignores properties such as which class to use for String deserialization. This is a problem in cases where we wish to deserialize the same schema both with and without Java Strings, since the cache will return the same deserializer for both, ultimately leading to class cast issues.

The new approach is to simply take the hash code of the full string of the schema.