### PR TITLE
AvroCodecUtil#serializeJson() - add method with `bool oneline` option

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCodecUtil.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCodecUtil.java
@@ -48,16 +48,19 @@ public class AvroCodecUtil {
         return os.toByteArray();
     }
 
+   /**
+    * serializes an IndexedRecord to a json string in Avro's json encoding format (pretty-printed).
+    */
     public static String serializeJson(IndexedRecord record, AvroVersion format) throws IOException {
         return serializeJson(record, format, false);
     }
 
-  /**
-   * Serialize an IndexedRecord (Generic Record or Specific Record) to json string
-   * @param record the record to serialize
-   * @param format the version of avro to use
-   * @param oneline whether to output the json in one line or pretty printed.
-   */
+   /**
+    * Serialize an IndexedRecord (Generic Record or Specific Record) to json string (in Avro's json encoding format).
+    * @param record the record to serialize
+    * @param format the version of avro to use
+    * @param oneline whether to output the json in one line or pretty printed.
+    */
     public static String serializeJson(IndexedRecord record, AvroVersion format, boolean oneline) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         Encoder encoder = AvroCompatibilityHelper.newJsonEncoder(record.getSchema(), os, !oneline, format);

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCodecUtil.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/AvroCodecUtil.java
@@ -49,8 +49,18 @@ public class AvroCodecUtil {
     }
 
     public static String serializeJson(IndexedRecord record, AvroVersion format) throws IOException {
+        return serializeJson(record, format, false);
+    }
+
+  /**
+   * Serialize an IndexedRecord (Generic Record or Specific Record) to json string
+   * @param record the record to serialize
+   * @param format the version of avro to use
+   * @param oneline whether to output the json in one line or pretty printed.
+   */
+    public static String serializeJson(IndexedRecord record, AvroVersion format, boolean oneline) throws IOException {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        Encoder encoder = AvroCompatibilityHelper.newJsonEncoder(record.getSchema(), os, true, format);
+        Encoder encoder = AvroCompatibilityHelper.newJsonEncoder(record.getSchema(), os, !oneline, format);
         DatumWriter<IndexedRecord> writer = AvroCompatibilityHelper.isSpecificRecord(record) ?
                 new SpecificDatumWriter<>(record.getSchema())
                 : new GenericDatumWriter<>(record.getSchema());


### PR DESCRIPTION
## What
Adding a method to get one-line serialized schemas.

## Why
Users want to get one-line serialized schemas


## Test
