### PR TITLE
Updating validate to use AvroCompatHelper to get field default value

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/CompatibleSpecificRecordBuilderBase.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/CompatibleSpecificRecordBuilderBase.java
@@ -48,7 +48,7 @@ public class CompatibleSpecificRecordBuilderBase {
    *                              accept null values.
    */
   protected void validate(Schema.Field field, Object value) {
-    if (!isValidValue(field, value) && field.defaultValue() == null) {
+    if (!isValidValue(field, value) && AvroCompatibilityHelper.getSpecificDefaultValue(field) == null) {
       throw new AvroRuntimeException("Field " + field + " does not accept null values");
     }
   }

--- a/helper/tests/helper-tests-110/build.gradle
+++ b/helper/tests/helper-tests-110/build.gradle
@@ -43,4 +43,7 @@ dependencies {
   testImplementation "org.apache.avro:avro-compiler:1.10.2"
   testImplementation "com.google.guava:guava:28.2-jre"
   testImplementation "org.mockito:mockito-core:3.2.4"
+
+  testImplementation group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.8.10'
+
 }

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CompatibleSpecificRecordBuilderBaseTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CompatibleSpecificRecordBuilderBaseTest.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright 2023 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
 package com.linkedin.avroutil1.compatibility.avro110;
 
 import com.linkedin.avroutil1.compatibility.CompatibleSpecificRecordBuilderBase;

--- a/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CompatibleSpecificRecordBuilderBaseTest.java
+++ b/helper/tests/helper-tests-110/src/test/java/com/linkedin/avroutil1/compatibility/avro110/CompatibleSpecificRecordBuilderBaseTest.java
@@ -1,0 +1,28 @@
+package com.linkedin.avroutil1.compatibility.avro110;
+
+import com.linkedin.avroutil1.compatibility.CompatibleSpecificRecordBuilderBase;
+import java.util.Arrays;
+import org.apache.avro.Schema;
+import org.testng.annotations.Test;
+
+
+public class CompatibleSpecificRecordBuilderBaseTest {
+
+  @Test
+  public void testValidate() {
+    Schema.Field field = new Schema.Field("field1", Schema.create(Schema.Type.STRING), "field doc", "null");
+    Schema myRecord = Schema.createRecord(Arrays.asList(field));
+    new MyBuilderClass(myRecord).testValidate(field, null);
+  }
+
+  class MyBuilderClass extends CompatibleSpecificRecordBuilderBase {
+
+    protected MyBuilderClass(Schema schema) {
+      super(schema);
+    }
+
+    public void testValidate(Schema.Field f, Object o) {
+      validate(f, o);
+    }
+  }
+}


### PR DESCRIPTION
## What
updating validate in Specific record builder base class to use CompatHelper's getDefault field val

## Why
field.defaultValue() is not available in avro > 1.8

## Test
Added Unit test