### PR TITLE
[fast-avro] Added logic to split large method for fast serializer

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -90,7 +90,7 @@ public class FastGenericDeserializerGeneratorTest {
     classLoader = URLClassLoader.newInstance(new URL[]{tempDir.toURI().toURL()},
         FastGenericDeserializerGeneratorTest.class.getClassLoader());
 
-    // In order to test the functionallity of the record split we set an unusually low number
+    // In order to test the functionality of the record split we set an unusually low number
     FastGenericDeserializerGenerator.setFieldsPerPopulationMethod(2);
   }
 

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastSpecificSerializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastSpecificSerializerGeneratorTest.java
@@ -75,6 +75,9 @@ public class FastSpecificSerializerGeneratorTest {
 
     classLoader = URLClassLoader.newInstance(new URL[]{tempDir.toURI().toURL()},
         FastSpecificSerializerGeneratorTest.class.getClassLoader());
+
+    // In order to test the functionality of the record split we set an unusually low number
+    FastGenericSerializerGenerator.setFieldsPerRecordSerializationMethod(2);
   }
 
   @Test(groups = {"serializationTest"})

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
@@ -59,6 +59,9 @@ public class FastStringableTest {
     tempDir = getCodeGenDirectory();
     classLoader = URLClassLoader.newInstance(new URL[]{tempDir.toURI().toURL()},
         FastDeserializerDefaultsTest.class.getClassLoader());
+
+    // In order to test the functionality of the record split we set an unusually low number
+    FastGenericSerializerGenerator.setFieldsPerRecordSerializationMethod(2);
   }
 
   StringableRecord generateRecord(URL exampleURL, URI exampleURI, File exampleFile, BigDecimal exampleBigDecimal,

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -57,7 +57,7 @@ public class FastDeserializerGenerator<T> extends FastDeserializerGeneratorBase<
   private static final Logger LOGGER = LoggerFactory.getLogger(FastDeserializerGenerator.class);
   private static final String DECODER = "decoder";
   private static final String VAR_NAME_FOR_REUSE = "reuse";
-  private static int FIELDS_PER_POPULATION_METHOD = 100;
+  private static int FIELDS_PER_POPULATION_METHOD = 20;
 
   // 65535 is the actual limit, 65K added for safety
   static int MAX_LENGTH_OF_STRING_LITERAL = 65000;


### PR DESCRIPTION
In the past, we updated fast deserializer to support large method splitting, and this code change is leveraging the similar logic to split large method in fast serializer.