### PR TITLE
[fast-avro] Added a few serde optimization

### DIFF
--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/CompositeByteBuffer.java
@@ -43,6 +43,14 @@ public class CompositeByteBuffer {
     byteBufferCount = count;
   }
 
+  int getByteBufferCount() {
+    return this.byteBufferCount;
+  }
+
+  List<ByteBuffer> getByteBuffers() {
+    return this.byteBuffers;
+  }
+
   public float getElement(int i) {
     int index = i * 4;
     // most common case:


### PR DESCRIPTION
Serializer:
This code change will try to reuse the backed bytes if the float list is 'BufferBackedPrimitiveFloatList' when writing float list. If an instance of `BufferBackedPrimitiveFloatList` is changed after deserialization: `readPrimitiveFloatArray`, Fast Serializer won't use the backed bytes because of the divergence.

Deserializer:
Use `reset` instead of `clear` when reusing `GenericArray` since `reset` is cheaper than `clear` and the behavior difference is that `reset` won't nullify the elements in current array, but just resize the array length to be 0.