### PR TITLE
Disable annotation processing in the runtime compiler

### DIFF
--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
@@ -134,7 +134,7 @@ public abstract class FastSerdeBase {
        */
       LOGGER.info("Starting compilation for the generated source file: {} ", filePath);
       LOGGER.debug("The inferred compile class path for file: {} : {}", filePath, compileClassPathForCurrentFile);
-      compileResult = compiler.run(null, null, null, "-cp", compileClassPathForCurrentFile, filePath, "-XDuseUnsharedTable");
+      compileResult = compiler.run(null, null, null, "-cp", compileClassPathForCurrentFile, "-XDuseUnsharedTable", "-proc:none", filePath);
     } catch (Exception e) {
       throw new FastSerdeGeneratorException("Unable to compile:" + className + " from source file: " + filePath, e);
     }


### PR DESCRIPTION
In one of our use-cases, we noticed this compilation failure:
```
FastSerdeBase [INFO] Starting compilation for the generated source file: <redacted>/MultiGetResponseRecordV1_GenericDeserializer_1339531883776153861_1339531883776153861.java 
warning: Supported source version 'RELEASE_6' from annotation processor 'org.antlr.v4.runtime.misc.NullUsageProcessor' less than -source '1.8'
error: Bad service configuration file, or exception thrown while constructing Processor object: javax.annotation.processing.Processor: Provider lombok.launch.AnnotationProcessorHider$AnnotationProcessor not found
...
Caused by: com.linkedin.venice.exceptions.VeniceException: Failed to generate fast generic de-serializer for Avro schema: {"type":"record","name":"MultiGetResponseRecordV1","namespace":"com.linkedin.venice.read.protocol.response","doc":"This field will store all the related info for one record","fields":[{"name":"keyIndex","type":"int","doc":"The corresponding key index for each record. Venice Client/Router is maintaining a mapping between a unique index and the corresponding key, so that Venice backend doesn't need to return the full key bytes to reduce network overhead"},{"name":"value","type":"bytes","doc":"Avro serialized value"},{"name":"schemaId","type":"int","doc":"Schema id of current store being used when serializing this record"}]}
	at com.linkedin.venice.serializer.FastSerializerDeserializerFactory.verifyWhetherFastGenericDeserializerWorks(FastSerializerDeserializerFactory.java:78) ~[venice-client-common-0.4.111.jar:?]
...
```

It turned out that the user had excluded `lombok` from all configurations and hence, the annotation processor was not found in the classpath. Although this can be attributed as a user error, since fast-avro doesn't use annotations, we can disable annotation processing completely. It could potentially speed up the compilation a bit too since the compiler won't search through the classpath to find all annotation processors.