### PR TITLE
Adding fail-fast feature to fast-serde

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/avro/fastserdeSimpleRecord.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/fastserdeSimpleRecord.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "SimpleRecord",
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "fields": [
+    {
+      "name": "text",
+      "type": "string",
+      "default": "In vino veritas"
+    }
+  ]
+}

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastSerdeCacheTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastSerdeCacheTest.java
@@ -20,7 +20,7 @@ public class FastSerdeCacheTest {
     supportedSchemaTypes.add(Schema.Type.ARRAY);
 
     Map<Schema.Type, Schema> schemaTypes = new HashMap<>();
-    /**
+    /*
      * Those types could be created by {@link Schema#create(org.apache.avro.Schema.Type)} function.
      */
     schemaTypes.put(Schema.Type.RECORD, Schema.parse("{\"type\": \"record\", \"name\": \"test\", \"fields\":[]}"));

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -52,7 +52,6 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
-import org.apache.avro.specific.SpecificData;
 import org.apache.avro.util.Utf8;
 import org.apache.commons.lang3.StringUtils;
 

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
@@ -87,9 +87,7 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
       fastDeserializer = cachedFastDeserializer.get();
     } else {
       fastDeserializer = getFastDeserializerFromCache(cache, writerSchema, readerSchema, modelData);
-      if (!FastSerdeCache.isFastDeserializer(fastDeserializer)) {
-        // don't cache
-      } else {
+      if (FastSerdeCache.isFastDeserializer(fastDeserializer)) {
         cachedFastDeserializer.compareAndSet(null, fastDeserializer);
         if (LOGGER.isDebugEnabled()) {
           LOGGER.debug("FastGenericDeserializer was generated and cached for reader schema: ["

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeBase.java
@@ -2,15 +2,12 @@ package com.linkedin.avro.fastserde;
 
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelperCommon;
 import com.sun.codemodel.JBlock;
-import com.sun.codemodel.JClass;
 import com.sun.codemodel.JCodeModel;
 import com.sun.codemodel.JConditional;
 import com.sun.codemodel.JDefinedClass;
 import com.sun.codemodel.JExpr;
 import com.sun.codemodel.JExpression;
 import com.sun.codemodel.JFieldRef;
-import com.sun.codemodel.JFieldVar;
-import com.sun.codemodel.JMethod;
 import com.sun.codemodel.JMod;
 import com.sun.codemodel.JVar;
 
@@ -28,7 +25,6 @@ import org.apache.avro.Conversion;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.specific.SpecificData;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
@@ -362,7 +362,7 @@ public final class FastSerdeCache {
    * @see #getFastGenericDeserializerAsync(Schema, Schema, GenericData)
    */
   public CompletableFuture<FastDeserializer<?>> getFastGenericDeserializerAsync(Schema writerSchema, Schema readerSchema) {
-    return getFastGenericDeserializerAsync(writerSchema, readerSchema);
+    return getFastGenericDeserializerAsync(writerSchema, readerSchema, null);
   }
 
   /**
@@ -450,7 +450,7 @@ public final class FastSerdeCache {
     }
 
     return new FastDeserializer<Object>() {
-      private DatumReader datumReader = new SpecificDatumReader<>(writerSchema, readerSchema);
+      private DatumReader datumReader = AvroCompatibilityHelper.newSpecificDatumReader(writerSchema, readerSchema, modelData);
 
       @Override
       public Object deserialize(Object reuse, Decoder d) throws IOException {
@@ -515,7 +515,7 @@ public final class FastSerdeCache {
     }
 
     return new FastDeserializer<Object>() {
-      private DatumReader datumReader = new GenericDatumReader<>(writerSchema, readerSchema, modelData);
+      private DatumReader datumReader = AvroCompatibilityHelper.newGenericDatumReader(writerSchema, readerSchema, modelData);
 
       @Override
       public Object deserialize(Object reuse, Decoder d) throws IOException {

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
@@ -443,10 +443,10 @@ public final class FastSerdeCache {
     try {
       return buildFastSpecificDeserializer(writerSchema, readerSchema, modelData);
     } catch (FastDeserializerGeneratorException e) {
-      LOGGER.warn("Deserializer generation exception when generating specific FastDeserializer for writer schema: "
+      LOGGER.error("Deserializer generation exception when generating specific FastDeserializer for writer schema: "
               + "[\n{}\n] and reader schema: [\n{}\n]", writerSchema.toString(true), readerSchema.toString(true), e);
     } catch (Exception e) {
-      LOGGER.warn("Deserializer class instantiation exception", e);
+      LOGGER.error("Deserializer class instantiation exception", e);
     }
 
     return new FastDeserializer<Object>() {
@@ -508,10 +508,10 @@ public final class FastSerdeCache {
     try {
       return buildFastGenericDeserializer(writerSchema, readerSchema, modelData);
     } catch (FastDeserializerGeneratorException e) {
-      LOGGER.warn("Deserializer generation exception when generating generic FastDeserializer for writer schema: [\n"
+      LOGGER.error("Deserializer generation exception when generating generic FastDeserializer for writer schema: [\n"
           + writerSchema.toString(true) + "\n] and reader schema:[\n" + readerSchema.toString(true) + "\n]", e);
     } catch (Exception e) {
-      LOGGER.warn("Deserializer class instantiation exception:" + e);
+      LOGGER.error("Deserializer class instantiation exception:", e);
     }
 
     return new FastDeserializer<Object>() {
@@ -555,10 +555,10 @@ public final class FastSerdeCache {
       try {
         return buildFastSpecificSerializer(schema, modelData);
       } catch (FastDeserializerGeneratorException e) {
-        LOGGER.warn("Serializer generation exception when generating specific FastSerializer for schema: [\n{}\n]",
+        LOGGER.error("Serializer generation exception when generating specific FastSerializer for schema: [\n{}\n]",
             schema.toString(true), e);
       } catch (Exception e) {
-        LOGGER.warn("Serializer class instantiation exception", e);
+        LOGGER.error("Serializer class instantiation exception", e);
       }
     }
 
@@ -604,10 +604,10 @@ public final class FastSerdeCache {
       try {
         return buildFastGenericSerializer(schema, modelData);
       } catch (FastDeserializerGeneratorException e) {
-        LOGGER.warn("Serializer generation exception when generating generic FastSerializer for schema: [\n{}\n]",
+        LOGGER.error("Serializer generation exception when generating generic FastSerializer for schema: [\n{}\n]",
             schema.toString(true), e);
       } catch (Exception e) {
-        LOGGER.warn("Serializer class instantiation exception", e);
+        LOGGER.error("Serializer class instantiation exception", e);
       }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -87,6 +87,7 @@ include 'demos:spotbugs-demo'
 
 include 'fastserde:avro-fastserde'
 include 'fastserde:avro-fastserde-jmh'
+include 'fastserde:avro-fastserde-tests-common'
 include 'fastserde:avro-fastserde-tests14'
 include 'fastserde:avro-fastserde-tests15'
 include 'fastserde:avro-fastserde-tests16'


### PR DESCRIPTION
This PR aims to add "fail-fast" feature to the fastserde.

Normally when we have datum writer:
```
DatumWriter<T> datumWriter = new FastSpecificDatumWriter<>(schema, specificData);
```
and it's used in a loop as:
```
datumWriter.write(record, binaryEncoder);
```
the `datumWriter` under the hood uses standard avro writer until fast-serializer is generated on the background-thread.

Currently if such generation fails due to any reason we have just one log entry and `datumWriter` still uses standard avro writer.
We found this approach is sometimes too gentle because it hides an issue for a long time. It's easy to miss one WARN log-entry.

That's why we think "fail-fast" approach would be a nice feature. It can be turned on by setting one of system properties
- `avro.fast.serde.failfast`
- `avro.fast.serde.failfast.supplier`

By default it's disabled so that it's backward-compatible.

----

Commits:
1. `Code cleanup`
- `private Optional<String> compileClassPath;` changed to `private String compileClassPath`;
- Resolving `compileClassPath` extracted to helper method (will be re-used for the new system property)
- other minor things
2. `bugfixes`
- `getFastGenericDeserializerAsync` no longer generated StackOverflow (shame on me!)
- Using `AvroCompatibilityHelper` in fallback-serializers to fix an issue with missing c-tor in Avro 1.4.
3. `Generation errors logged on ERROR level.`
- We can discuss here - I'm fine with dropping this commit if you think it should stay as WARN.
4. `[fastserde] Adding fail-fast feature.`
- The main reason why this PR was created.

----

Name "fail-fast" is a kind of industry standard however in this case it may cause confusion with "fast-serde" - we can use another name for this feature (fail-early / force-fastserde / etc.) or give it opposite meaning (e.g. ignore-generation-errors).