### PR TITLE
Added serde customization support in Fast-Avro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #gradle artifacts
 .gradle/
+
 **/build/*
 !**/avro-fastserde-tests111/build/codegen
 

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDatumWriterTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDatumWriterTest.java
@@ -1,13 +1,18 @@
 package com.linkedin.avro.fastserde;
 
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestRecord;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.util.Utf8;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -79,5 +84,41 @@ public class FastDatumWriterTest {
     fastGenericDatumWriter.write(record, AvroCompatibilityHelper.newBinaryEncoder(new ByteArrayOutputStream(), true, null));
     Assert.assertTrue(fastGenericDatumWriter.isFastSerializerUsed(), "FastGenericDatumWriter should be using"
         + " Fast Serializer when the fast deserializer generation is done.");
+  }
+
+  @Test(groups = {"serializationTest"})
+  @SuppressWarnings("unchecked")
+  public void writeWithCustomizationCheck() throws IOException {
+    Schema recordSchema = createRecord("TestSchema",
+        createField("testInt", Schema.create(Schema.Type.INT)),
+        createMapFieldSchema("testMap", Schema.create(Schema.Type.STRING)));
+    /**
+     * Check whether the map type is a {@link java.util.LinkedHashMap} or not.
+     */
+    DatumWriterCustomization customization = new DatumWriterCustomization.Builder()
+        .setCheckMapTypeFunction( o -> {
+          if (o == null) {
+            return;
+          }
+          if (! (o instanceof LinkedHashMap)) {
+            throw new IllegalArgumentException("The map type should be 'LinkedHashMap'");
+          }
+        }).build();
+    // Check cold datum Writer
+    GenericRecord record = new GenericData.Record(recordSchema);
+    record.put("testInt", new Integer(100));
+    Map<Utf8, Utf8> testMap = new HashMap<>();
+    testMap.put(new Utf8("key1"), new Utf8("value1"));
+    testMap.put(new Utf8("key2"), new Utf8("value2"));
+    record.put("testMap", testMap);
+    FastGenericDatumWriter<GenericRecord> fastGenericDatumWriterWithoutCustomization = new FastGenericDatumWriter<>(recordSchema, null, cache, null);
+    // No exception
+    fastGenericDatumWriterWithoutCustomization.write(record, AvroCompatibilityHelper.newBinaryEncoder(new ByteArrayOutputStream(), true, null));
+
+    FastGenericDatumWriter<GenericRecord> fastGenericDatumWriterWithCustomization = new FastGenericDatumWriter<>(recordSchema, null, cache, customization);
+    Assert.expectThrows(IllegalArgumentException.class,
+        () -> fastGenericDatumWriterWithCustomization.write(record, AvroCompatibilityHelper.newBinaryEncoder(new ByteArrayOutputStream(), true, null)));
+
+
   }
 }

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -1592,7 +1592,7 @@ public class FastGenericDeserializerGeneratorTest {
 
   private static <T> T decodeRecordColdFast(Schema writerSchema, Schema readerSchema, Decoder decoder) {
     FastDeserializer<T> deserializer =
-        new FastSerdeCache.FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, GenericData.get());
+        new FastSerdeUtils.FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, GenericData.get(), false);
 
     return decodeRecordFast(deserializer, decoder);
   }

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/logical/types/LogicalTypesTestBase.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/logical/types/LogicalTypesTestBase.java
@@ -2,6 +2,7 @@ package com.linkedin.avro.fastserde.logical.types;
 
 import static com.linkedin.avro.fastserde.FastSerdeTestsSupport.getCodeGenDirectory;
 
+import com.linkedin.avro.fastserde.FastSerdeUtils;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -136,11 +137,11 @@ public abstract class LogicalTypesTestBase {
                 schema, classesDir, classLoader, null, specificData)
                 .generateSerializer();
 
-        FastSerdeCache.FastSerializerWithAvroGenericImpl<T> fastSerializerWithAvroGeneric =
-                new FastSerdeCache.FastSerializerWithAvroGenericImpl<>(schema, genericData);
+        FastSerdeUtils.FastSerializerWithAvroGenericImpl<T> fastSerializerWithAvroGeneric =
+                new FastSerdeUtils.FastSerializerWithAvroGenericImpl<>(schema, genericData, null, false);
 
-        FastSerdeCache.FastSerializerWithAvroSpecificImpl<T> fastSerializerWithAvroSpecific =
-                new FastSerdeCache.FastSerializerWithAvroSpecificImpl<>(schema, specificData);
+        FastSerdeUtils.FastSerializerWithAvroSpecificImpl<T> fastSerializerWithAvroSpecific =
+                new FastSerdeUtils.FastSerializerWithAvroSpecificImpl<>(schema, specificData, null, false);
 
         GenericDatumWriter<T> genericDatumWriter = new GenericDatumWriter<>(
                 schema, genericData);
@@ -188,11 +189,11 @@ public abstract class LogicalTypesTestBase {
                 schema, schema, classesDir, classLoader, null, specificData)
                 .generateDeserializer();
 
-        FastSerdeCache.FastDeserializerWithAvroGenericImpl<GenericData.Record> fastDeserializerWithAvroGeneric =
-                new FastSerdeCache.FastDeserializerWithAvroGenericImpl<>(schema, schema, genericData);
+        FastSerdeUtils.FastDeserializerWithAvroGenericImpl<GenericData.Record> fastDeserializerWithAvroGeneric =
+                new FastSerdeUtils.FastDeserializerWithAvroGenericImpl<>(schema, schema, genericData, false);
 
-        FastSerdeCache.FastDeserializerWithAvroSpecificImpl<T> fastDeserializerWithAvroSpecific =
-                new FastSerdeCache.FastDeserializerWithAvroSpecificImpl<>(schema, schema, specificData);
+        FastSerdeUtils.FastDeserializerWithAvroSpecificImpl<T> fastDeserializerWithAvroSpecific =
+                new FastSerdeUtils.FastDeserializerWithAvroSpecificImpl<>(schema, schema, specificData, false);
 
         GenericDatumReader<GenericData.Record> genericDatumReader = new GenericDatumReader<>(schema, schema, genericData);
 

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_BOOLEAN_GenericDeserializer_869749973_869749973.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_BOOLEAN_GenericDeserializer_869749973_869749973.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveBooleanList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -19,7 +20,7 @@ public class Array_of_BOOLEAN_GenericDeserializer_869749973_869749973
         this.readerSchema = readerSchema;
     }
 
-    public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder)
+    public List<Boolean> deserialize(List<Boolean> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         PrimitiveBooleanList array0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_DOUBLE_GenericDeserializer_18760307_18760307.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_DOUBLE_GenericDeserializer_18760307_18760307.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveDoubleArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -19,7 +20,7 @@ public class Array_of_DOUBLE_GenericDeserializer_18760307_18760307
         this.readerSchema = readerSchema;
     }
 
-    public List<Double> deserialize(List<Double> reuse, Decoder decoder)
+    public List<Double> deserialize(List<Double> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         PrimitiveDoubleList array0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_FLOAT_GenericDeserializer_1012670397_1012670397.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_FLOAT_GenericDeserializer_1012670397_1012670397.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 
@@ -19,7 +20,7 @@ public class Array_of_FLOAT_GenericDeserializer_1012670397_1012670397
         this.readerSchema = readerSchema;
     }
 
-    public List<Float> deserialize(List<Float> reuse, Decoder decoder)
+    public List<Float> deserialize(List<Float> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         PrimitiveFloatList array0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_INT_GenericDeserializer_1012089072_1012089072.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_INT_GenericDeserializer_1012089072_1012089072.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -19,7 +20,7 @@ public class Array_of_INT_GenericDeserializer_1012089072_1012089072
         this.readerSchema = readerSchema;
     }
 
-    public List<Integer> deserialize(List<Integer> reuse, Decoder decoder)
+    public List<Integer> deserialize(List<Integer> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         PrimitiveIntList array0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_LONG_GenericDeserializer_325099267_325099267.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_LONG_GenericDeserializer_325099267_325099267.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -19,7 +20,7 @@ public class Array_of_LONG_GenericDeserializer_325099267_325099267
         this.readerSchema = readerSchema;
     }
 
-    public List<Long> deserialize(List<Long> reuse, Decoder decoder)
+    public List<Long> deserialize(List<Long> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         PrimitiveLongList array0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243.java
@@ -4,7 +4,6 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveBooleanList;
@@ -14,6 +13,7 @@ import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
@@ -37,7 +37,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         this.readerSchema = readerSchema;
     }
 
-    public List<com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(List<com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder)
+    public List<com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(List<com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         List<com.linkedin.avro.fastserde.generated.avro.TestRecord> array0 = null;
@@ -58,14 +58,14 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 if ((reuse) instanceof GenericArray) {
                     arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                 }
-                array0 .add(deserializeTestRecord0(arrayArrayElementReuseVar0, (decoder)));
+                array0 .add(deserializeTestRecord0(arrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -75,29 +75,29 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
-        populate_TestRecord17((TestRecord), (decoder));
-        populate_TestRecord18((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
+        populate_TestRecord17((TestRecord), (customization), (decoder));
+        populate_TestRecord18((TestRecord), (customization), (decoder));
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -114,7 +114,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -131,7 +131,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -148,7 +148,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -165,7 +165,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -189,7 +189,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -220,7 +220,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -254,7 +254,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(14, testFixed1);
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex7 = (decoder.readIndex());
@@ -314,7 +314,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(16, testFixedArray0);
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray0 = null;
@@ -364,7 +364,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(18, Enums.getConstant(TestEnum.class, (decoder.readEnum())));
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex9 = (decoder.readIndex());
@@ -400,7 +400,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(20, testEnumArray0);
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumUnionArray0 = null;
@@ -443,14 +443,14 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
             TestRecord.put(22, null);
         } else {
             if (unionIndex11 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex11));
             }
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -477,11 +477,11 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex12));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex13 = (decoder.readIndex());
@@ -504,10 +504,10 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         }
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
         long chunkLen5 = (decoder.readArrayStart());
         Object oldArray4 = TestRecord.get(24);
@@ -527,39 +527,29 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen5 = (decoder.arrayNext());
         }
         TestRecord.put(24, recordsArray0);
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen6 = (decoder.readMapStart());
         if (chunkLen6 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen6 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen6)));
             do {
                 for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen6 = (decoder.mapNext());
             } while (chunkLen6 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
         int unionIndex14 = (decoder.readIndex());
@@ -593,7 +583,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex15 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex15));
                             }
@@ -608,7 +598,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         }
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex16 = (decoder.readIndex());
@@ -620,17 +610,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen8 = (decoder.readMapStart());
                 if (chunkLen8 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen8 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen8)));
                     do {
                         for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
                             Utf8 key1 = (decoder.readString(null));
@@ -640,7 +620,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                                 recordsMapUnionOption0 .put(key1, null);
                             } else {
                                 if (unionIndex17 == 1) {
-                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex17));
                                 }
@@ -649,7 +629,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                         chunkLen8 = (decoder.mapNext());
                     } while (chunkLen8 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -678,16 +658,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen10 = (decoder.readMapStart());
                 if (chunkLen10 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen10)));
                     do {
                         for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -697,7 +668,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                                 recordsArrayMapElem0 .put(key2, null);
                             } else {
                                 if (unionIndex18 == 1) {
-                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex18));
                                 }
@@ -706,7 +677,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                         chunkLen10 = (decoder.mapNext());
                     } while (chunkLen10 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -715,23 +686,13 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(28, recordsArrayMap0);
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen11 = (decoder.readMapStart());
         if (chunkLen11 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen11 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen11)));
             do {
                 for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
                     Utf8 key3 = (decoder.readString(null));
@@ -759,7 +720,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex19));
                                 }
@@ -772,7 +733,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 chunkLen11 = (decoder.mapNext());
             } while (chunkLen11 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
         int unionIndex20 = (decoder.readIndex());
@@ -803,16 +764,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen14 = (decoder.readMapStart());
                         if (chunkLen14 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen14)));
                             do {
                                 for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                                     Utf8 key4 = (decoder.readString(null));
@@ -822,7 +774,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                                         recordsArrayMapUnionOptionElem0 .put(key4, null);
                                     } else {
                                         if (unionIndex21 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex21));
                                         }
@@ -831,7 +783,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                                 chunkLen14 = (decoder.mapNext());
                             } while (chunkLen14 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -844,7 +796,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         }
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex22 = (decoder.readIndex());
@@ -856,17 +808,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen15 = (decoder.readMapStart());
                 if (chunkLen15 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen15 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen15)));
                     do {
                         for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
                             Utf8 key5 = (decoder.readString(null));
@@ -894,7 +836,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex23 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex23));
                                         }
@@ -907,7 +849,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
                         chunkLen15 = (decoder.mapNext());
                     } while (chunkLen15 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -920,7 +862,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
             TestRecord.put(32, null);
         } else {
             if (unionIndex24 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex24 == 2) {
                     Utf8 charSequence4;
@@ -942,7 +884,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveBooleanList booleanArray0 = null;
@@ -979,7 +921,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(34, doubleArray0);
     }
 
-    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
@@ -1003,7 +945,7 @@ public class Array_of_TestRecord_SpecificDeserializer_1088113243_1088113243
         TestRecord.put(36, intArray0);
     }
 
-    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveLongList longArray0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_UNION_GenericDeserializer_777827233_777827233.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_UNION_GenericDeserializer_777827233_777827233.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -26,7 +27,7 @@ public class Array_of_UNION_GenericDeserializer_777827233_777827233
         this.field0 = arrayElemOptionSchema0 .getField("field").schema();
     }
 
-    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         List<IndexedRecord> array0 = null;
@@ -53,7 +54,7 @@ public class Array_of_UNION_GenericDeserializer_777827233_777827233
                     array0 .add(null);
                 } else {
                     if (unionIndex0 == 1) {
-                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+                        array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder), (customization)));
                     } else {
                         throw new RuntimeException(("Illegal union index for 'arrayElem': "+ unionIndex0));
                     }
@@ -64,7 +65,7 @@ public class Array_of_UNION_GenericDeserializer_777827233_777827233
         return array0;
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_UNION_SpecificDeserializer_1277939469_1277939469.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_UNION_SpecificDeserializer_1277939469_1277939469.java
@@ -4,7 +4,6 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveBooleanList;
@@ -14,6 +13,7 @@ import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
@@ -37,7 +37,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         this.readerSchema = readerSchema;
     }
 
-    public List<com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(List<com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder)
+    public List<com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(List<com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         List<com.linkedin.avro.fastserde.generated.avro.TestRecord> array0 = null;
@@ -64,7 +64,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                     array0 .add(null);
                 } else {
                     if (unionIndex0 == 1) {
-                        array0 .add(deserializeTestRecord0(arrayArrayElementReuseVar0, (decoder)));
+                        array0 .add(deserializeTestRecord0(arrayArrayElementReuseVar0, (decoder), (customization)));
                     } else {
                         throw new RuntimeException(("Illegal union index for 'arrayElem': "+ unionIndex0));
                     }
@@ -75,7 +75,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         return array0;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -85,29 +85,29 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
-        populate_TestRecord17((TestRecord), (decoder));
-        populate_TestRecord18((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
+        populate_TestRecord17((TestRecord), (customization), (decoder));
+        populate_TestRecord18((TestRecord), (customization), (decoder));
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -124,7 +124,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -141,7 +141,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -158,7 +158,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -175,7 +175,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -199,7 +199,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -230,7 +230,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex7 = (decoder.readIndex());
@@ -264,7 +264,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(14, testFixed1);
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex8 = (decoder.readIndex());
@@ -324,7 +324,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(16, testFixedArray0);
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray0 = null;
@@ -374,7 +374,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(18, Enums.getConstant(TestEnum.class, (decoder.readEnum())));
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex10 = (decoder.readIndex());
@@ -410,7 +410,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(20, testEnumArray0);
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumUnionArray0 = null;
@@ -453,14 +453,14 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
             TestRecord.put(22, null);
         } else {
             if (unionIndex12 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex12));
             }
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -487,11 +487,11 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex13));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex14 = (decoder.readIndex());
@@ -514,10 +514,10 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         }
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
         long chunkLen5 = (decoder.readArrayStart());
         Object oldArray4 = TestRecord.get(24);
@@ -537,39 +537,29 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen5 = (decoder.arrayNext());
         }
         TestRecord.put(24, recordsArray0);
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen6 = (decoder.readMapStart());
         if (chunkLen6 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen6 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen6)));
             do {
                 for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen6 = (decoder.mapNext());
             } while (chunkLen6 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
         int unionIndex15 = (decoder.readIndex());
@@ -603,7 +593,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex16 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex16));
                             }
@@ -618,7 +608,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         }
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex17 = (decoder.readIndex());
@@ -630,17 +620,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen8 = (decoder.readMapStart());
                 if (chunkLen8 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen8 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen8)));
                     do {
                         for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
                             Utf8 key1 = (decoder.readString(null));
@@ -650,7 +630,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                                 recordsMapUnionOption0 .put(key1, null);
                             } else {
                                 if (unionIndex18 == 1) {
-                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex18));
                                 }
@@ -659,7 +639,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                         chunkLen8 = (decoder.mapNext());
                     } while (chunkLen8 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -688,16 +668,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen10 = (decoder.readMapStart());
                 if (chunkLen10 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen10)));
                     do {
                         for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -707,7 +678,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                                 recordsArrayMapElem0 .put(key2, null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex19));
                                 }
@@ -716,7 +687,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                         chunkLen10 = (decoder.mapNext());
                     } while (chunkLen10 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -725,23 +696,13 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(28, recordsArrayMap0);
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen11 = (decoder.readMapStart());
         if (chunkLen11 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen11 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen11)));
             do {
                 for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
                     Utf8 key3 = (decoder.readString(null));
@@ -769,7 +730,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex20 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex20));
                                 }
@@ -782,7 +743,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                 chunkLen11 = (decoder.mapNext());
             } while (chunkLen11 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
         int unionIndex21 = (decoder.readIndex());
@@ -813,16 +774,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen14 = (decoder.readMapStart());
                         if (chunkLen14 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen14)));
                             do {
                                 for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                                     Utf8 key4 = (decoder.readString(null));
@@ -832,7 +784,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                                         recordsArrayMapUnionOptionElem0 .put(key4, null);
                                     } else {
                                         if (unionIndex22 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex22));
                                         }
@@ -841,7 +793,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                                 chunkLen14 = (decoder.mapNext());
                             } while (chunkLen14 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -854,7 +806,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         }
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex23 = (decoder.readIndex());
@@ -866,17 +818,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen15 = (decoder.readMapStart());
                 if (chunkLen15 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen15 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen15)));
                     do {
                         for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
                             Utf8 key5 = (decoder.readString(null));
@@ -904,7 +846,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex24 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex24));
                                         }
@@ -917,7 +859,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
                         chunkLen15 = (decoder.mapNext());
                     } while (chunkLen15 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -930,7 +872,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
             TestRecord.put(32, null);
         } else {
             if (unionIndex25 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex25 == 2) {
                     Utf8 charSequence4;
@@ -952,7 +894,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveBooleanList booleanArray0 = null;
@@ -989,7 +931,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(34, doubleArray0);
     }
 
-    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
@@ -1013,7 +955,7 @@ public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
         TestRecord.put(36, intArray0);
     }
 
-    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveLongList longArray0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_record_GenericDeserializer_1606337179_2018567528.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_record_GenericDeserializer_1606337179_2018567528.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
@@ -22,7 +23,7 @@ public class Array_of_record_GenericDeserializer_1606337179_2018567528
         this.unionOptionArrayElemSchema0 = readerSchema.getElementType();
     }
 
-    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -48,7 +49,7 @@ public class Array_of_record_GenericDeserializer_1606337179_2018567528
                         if ((reuse) instanceof GenericArray) {
                             unionOptionArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                         }
-                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder)));
+                        unionOption0 .add(deserializerecord0(unionOptionArrayElementReuseVar0, (decoder), (customization)));
                     }
                     chunkLen0 = (decoder.arrayNext());
                 }
@@ -59,7 +60,7 @@ public class Array_of_record_GenericDeserializer_1606337179_2018567528
         }
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_record_GenericDeserializer_477614132_477614132.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_record_GenericDeserializer_477614132_477614132.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -24,7 +25,7 @@ public class Array_of_record_GenericDeserializer_477614132_477614132
         this.field0 = arrayArrayElemSchema0 .getField("field").schema();
     }
 
-    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         List<IndexedRecord> array0 = null;
@@ -45,14 +46,14 @@ public class Array_of_record_GenericDeserializer_477614132_477614132
                 if ((reuse) instanceof GenericArray) {
                     arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                 }
-                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema_GenericDeserializer_836892732_836892732.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema_GenericDeserializer_836892732_836892732.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -2018,13 +2019,13 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         this.f9990 = readerSchema.getField("F999").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema;
@@ -2051,510 +2052,510 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
                 throw new RuntimeException(("Illegal union index for 'F0': "+ unionIndex0));
             }
         }
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema1((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema2((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema3((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema4((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema5((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema6((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema7((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema8((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema9((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema10((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema11((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema12((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema13((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema14((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema15((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema16((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema17((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema18((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema19((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema20((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema21((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema22((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema23((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema24((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema25((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema26((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema27((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema28((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema29((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema30((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema31((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema32((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema33((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema34((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema35((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema36((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema37((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema38((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema39((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema40((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema41((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema42((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema43((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema44((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema45((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema46((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema47((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema48((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema49((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema50((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema51((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema52((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema53((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema54((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema55((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema56((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema57((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema58((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema59((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema60((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema61((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema62((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema63((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema64((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema65((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema66((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema67((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema68((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema69((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema70((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema71((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema72((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema73((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema74((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema75((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema76((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema77((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema78((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema79((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema80((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema81((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema82((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema83((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema84((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema85((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema86((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema87((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema88((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema89((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema90((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema91((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema92((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema93((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema94((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema95((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema96((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema97((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema98((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema99((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema100((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema101((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema102((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema103((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema104((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema105((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema106((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema107((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema108((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema109((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema110((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema111((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema112((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema113((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema114((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema115((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema116((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema117((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema118((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema119((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema120((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema121((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema122((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema123((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema124((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema125((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema126((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema127((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema128((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema129((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema130((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema131((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema132((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema133((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema134((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema135((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema136((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema137((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema138((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema139((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema140((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema141((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema142((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema143((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema144((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema145((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema146((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema147((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema148((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema149((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema150((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema151((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema152((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema153((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema154((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema155((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema156((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema157((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema158((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema159((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema160((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema161((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema162((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema163((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema164((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema165((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema166((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema167((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema168((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema169((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema170((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema171((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema172((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema173((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema174((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema175((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema176((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema177((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema178((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema179((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema180((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema181((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema182((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema183((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema184((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema185((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema186((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema187((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema188((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema189((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema190((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema191((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema192((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema193((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema194((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema195((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema196((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema197((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema198((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema199((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema200((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema201((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema202((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema203((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema204((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema205((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema206((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema207((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema208((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema209((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema210((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema211((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema212((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema213((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema214((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema215((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema216((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema217((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema218((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema219((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema220((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema221((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema222((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema223((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema224((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema225((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema226((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema227((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema228((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema229((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema230((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema231((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema232((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema233((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema234((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema235((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema236((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema237((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema238((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema239((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema240((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema241((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema242((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema243((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema244((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema245((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema246((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema247((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema248((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema249((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema250((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema251((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema252((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema253((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema254((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema255((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema256((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema257((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema258((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema259((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema260((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema261((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema262((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema263((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema264((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema265((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema266((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema267((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema268((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema269((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema270((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema271((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema272((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema273((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema274((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema275((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema276((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema277((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema278((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema279((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema280((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema281((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema282((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema283((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema284((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema285((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema286((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema287((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema288((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema289((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema290((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema291((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema292((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema293((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema294((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema295((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema296((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema297((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema298((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema299((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema300((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema301((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema302((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema303((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema304((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema305((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema306((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema307((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema308((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema309((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema310((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema311((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema312((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema313((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema314((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema315((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema316((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema317((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema318((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema319((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema320((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema321((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema322((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema323((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema324((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema325((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema326((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema327((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema328((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema329((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema330((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema331((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema332((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema333((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema334((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema335((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema336((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema337((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema338((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema339((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema340((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema341((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema342((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema343((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema344((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema345((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema346((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema347((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema348((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema349((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema350((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema351((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema352((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema353((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema354((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema355((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema356((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema357((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema358((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema359((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema360((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema361((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema362((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema363((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema364((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema365((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema366((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema367((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema368((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema369((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema370((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema371((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema372((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema373((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema374((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema375((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema376((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema377((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema378((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema379((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema380((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema381((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema382((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema383((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema384((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema385((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema386((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema387((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema388((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema389((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema390((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema391((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema392((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema393((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema394((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema395((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema396((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema397((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema398((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema399((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema400((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema401((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema402((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema403((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema404((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema405((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema406((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema407((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema408((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema409((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema410((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema411((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema412((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema413((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema414((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema415((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema416((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema417((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema418((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema419((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema420((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema421((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema422((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema423((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema424((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema425((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema426((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema427((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema428((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema429((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema430((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema431((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema432((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema433((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema434((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema435((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema436((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema437((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema438((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema439((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema440((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema441((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema442((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema443((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema444((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema445((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema446((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema447((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema448((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema449((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema450((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema451((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema452((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema453((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema454((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema455((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema456((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema457((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema458((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema459((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema460((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema461((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema462((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema463((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema464((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema465((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema466((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema467((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema468((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema469((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema470((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema471((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema472((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema473((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema474((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema475((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema476((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema477((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema478((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema479((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema480((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema481((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema482((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema483((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema484((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema485((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema486((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema487((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema488((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema489((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema490((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema491((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema492((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema493((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema494((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema495((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema496((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema497((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema498((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema499((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema1((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema2((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema3((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema4((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema5((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema6((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema7((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema8((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema9((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema10((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema11((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema12((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema13((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema14((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema15((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema16((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema17((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema18((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema19((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema20((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema21((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema22((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema23((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema24((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema25((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema26((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema27((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema28((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema29((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema30((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema31((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema32((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema33((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema34((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema35((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema36((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema37((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema38((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema39((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema40((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema41((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema42((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema43((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema44((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema45((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema46((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema47((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema48((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema49((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema50((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema51((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema52((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema53((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema54((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema55((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema56((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema57((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema58((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema59((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema60((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema61((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema62((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema63((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema64((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema65((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema66((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema67((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema68((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema69((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema70((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema71((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema72((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema73((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema74((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema75((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema76((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema77((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema78((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema79((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema80((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema81((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema82((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema83((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema84((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema85((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema86((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema87((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema88((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema89((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema90((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema91((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema92((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema93((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema94((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema95((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema96((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema97((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema98((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema99((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema100((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema101((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema102((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema103((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema104((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema105((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema106((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema107((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema108((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema109((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema110((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema111((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema112((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema113((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema114((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema115((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema116((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema117((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema118((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema119((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema120((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema121((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema122((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema123((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema124((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema125((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema126((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema127((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema128((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema129((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema130((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema131((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema132((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema133((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema134((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema135((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema136((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema137((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema138((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema139((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema140((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema141((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema142((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema143((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema144((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema145((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema146((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema147((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema148((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema149((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema150((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema151((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema152((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema153((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema154((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema155((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema156((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema157((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema158((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema159((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema160((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema161((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema162((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema163((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema164((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema165((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema166((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema167((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema168((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema169((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema170((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema171((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema172((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema173((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema174((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema175((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema176((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema177((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema178((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema179((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema180((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema181((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema182((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema183((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema184((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema185((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema186((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema187((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema188((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema189((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema190((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema191((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema192((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema193((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema194((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema195((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema196((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema197((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema198((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema199((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema200((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema201((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema202((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema203((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema204((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema205((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema206((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema207((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema208((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema209((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema210((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema211((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema212((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema213((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema214((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema215((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema216((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema217((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema218((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema219((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema220((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema221((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema222((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema223((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema224((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema225((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema226((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema227((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema228((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema229((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema230((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema231((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema232((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema233((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema234((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema235((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema236((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema237((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema238((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema239((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema240((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema241((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema242((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema243((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema244((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema245((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema246((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema247((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema248((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema249((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema250((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema251((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema252((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema253((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema254((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema255((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema256((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema257((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema258((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema259((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema260((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema261((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema262((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema263((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema264((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema265((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema266((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema267((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema268((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema269((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema270((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema271((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema272((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema273((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema274((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema275((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema276((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema277((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema278((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema279((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema280((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema281((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema282((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema283((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema284((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema285((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema286((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema287((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema288((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema289((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema290((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema291((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema292((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema293((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema294((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema295((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema296((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema297((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema298((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema299((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema300((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema301((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema302((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema303((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema304((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema305((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema306((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema307((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema308((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema309((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema310((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema311((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema312((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema313((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema314((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema315((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema316((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema317((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema318((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema319((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema320((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema321((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema322((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema323((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema324((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema325((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema326((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema327((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema328((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema329((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema330((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema331((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema332((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema333((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema334((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema335((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema336((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema337((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema338((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema339((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema340((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema341((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema342((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema343((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema344((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema345((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema346((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema347((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema348((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema349((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema350((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema351((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema352((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema353((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema354((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema355((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema356((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema357((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema358((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema359((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema360((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema361((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema362((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema363((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema364((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema365((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema366((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema367((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema368((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema369((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema370((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema371((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema372((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema373((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema374((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema375((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema376((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema377((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema378((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema379((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema380((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema381((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema382((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema383((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema384((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema385((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema386((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema387((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema388((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema389((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema390((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema391((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema392((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema393((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema394((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema395((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema396((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema397((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema398((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema399((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema400((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema401((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema402((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema403((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema404((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema405((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema406((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema407((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema408((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema409((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema410((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema411((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema412((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema413((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema414((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema415((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema416((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema417((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema418((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema419((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema420((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema421((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema422((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema423((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema424((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema425((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema426((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema427((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema428((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema429((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema430((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema431((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema432((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema433((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema434((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema435((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema436((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema437((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema438((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema439((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema440((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema441((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema442((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema443((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema444((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema445((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema446((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema447((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema448((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema449((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema450((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema451((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema452((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema453((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema454((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema455((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema456((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema457((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema458((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema459((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema460((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema461((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema462((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema463((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema464((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema465((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema466((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema467((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema468((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema469((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema470((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema471((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema472((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema473((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema474((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema475((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema476((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema477((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema478((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema479((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema480((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema481((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema482((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema483((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema484((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema485((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema486((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema487((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema488((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema489((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema490((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema491((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema492((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema493((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema494((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema495((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema496((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema497((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema498((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema499((FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -2595,7 +2596,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -2636,7 +2637,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema2(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema2(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -2677,7 +2678,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema3(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema3(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex7 = (decoder.readIndex());
@@ -2718,7 +2719,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema4(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema4(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex9 = (decoder.readIndex());
@@ -2759,7 +2760,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema5(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema5(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex11 = (decoder.readIndex());
@@ -2800,7 +2801,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema6(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema6(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex13 = (decoder.readIndex());
@@ -2841,7 +2842,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema7(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema7(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex15 = (decoder.readIndex());
@@ -2882,7 +2883,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema8(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema8(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex17 = (decoder.readIndex());
@@ -2923,7 +2924,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema9(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema9(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex19 = (decoder.readIndex());
@@ -2964,7 +2965,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema10(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema10(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex21 = (decoder.readIndex());
@@ -3005,7 +3006,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema11(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema11(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex23 = (decoder.readIndex());
@@ -3046,7 +3047,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema12(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema12(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex25 = (decoder.readIndex());
@@ -3087,7 +3088,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema13(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema13(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex27 = (decoder.readIndex());
@@ -3128,7 +3129,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema14(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema14(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex29 = (decoder.readIndex());
@@ -3169,7 +3170,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema15(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema15(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex31 = (decoder.readIndex());
@@ -3210,7 +3211,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema16(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema16(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex33 = (decoder.readIndex());
@@ -3251,7 +3252,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema17(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema17(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex35 = (decoder.readIndex());
@@ -3292,7 +3293,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema18(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema18(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex37 = (decoder.readIndex());
@@ -3333,7 +3334,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema19(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema19(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex39 = (decoder.readIndex());
@@ -3374,7 +3375,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema20(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema20(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex41 = (decoder.readIndex());
@@ -3415,7 +3416,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema21(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema21(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex43 = (decoder.readIndex());
@@ -3456,7 +3457,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema22(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema22(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex45 = (decoder.readIndex());
@@ -3497,7 +3498,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema23(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema23(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex47 = (decoder.readIndex());
@@ -3538,7 +3539,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema24(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema24(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex49 = (decoder.readIndex());
@@ -3579,7 +3580,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema25(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema25(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex51 = (decoder.readIndex());
@@ -3620,7 +3621,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema26(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema26(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex53 = (decoder.readIndex());
@@ -3661,7 +3662,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema27(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema27(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex55 = (decoder.readIndex());
@@ -3702,7 +3703,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema28(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema28(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex57 = (decoder.readIndex());
@@ -3743,7 +3744,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema29(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema29(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex59 = (decoder.readIndex());
@@ -3784,7 +3785,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema30(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema30(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex61 = (decoder.readIndex());
@@ -3825,7 +3826,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema31(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema31(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex63 = (decoder.readIndex());
@@ -3866,7 +3867,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema32(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema32(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex65 = (decoder.readIndex());
@@ -3907,7 +3908,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema33(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema33(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex67 = (decoder.readIndex());
@@ -3948,7 +3949,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema34(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema34(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex69 = (decoder.readIndex());
@@ -3989,7 +3990,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema35(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema35(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex71 = (decoder.readIndex());
@@ -4030,7 +4031,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema36(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema36(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex73 = (decoder.readIndex());
@@ -4071,7 +4072,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema37(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema37(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex75 = (decoder.readIndex());
@@ -4112,7 +4113,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema38(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema38(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex77 = (decoder.readIndex());
@@ -4153,7 +4154,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema39(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema39(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex79 = (decoder.readIndex());
@@ -4194,7 +4195,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema40(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema40(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex81 = (decoder.readIndex());
@@ -4235,7 +4236,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema41(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema41(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex83 = (decoder.readIndex());
@@ -4276,7 +4277,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema42(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema42(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex85 = (decoder.readIndex());
@@ -4317,7 +4318,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema43(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema43(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex87 = (decoder.readIndex());
@@ -4358,7 +4359,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema44(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema44(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex89 = (decoder.readIndex());
@@ -4399,7 +4400,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema45(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema45(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex91 = (decoder.readIndex());
@@ -4440,7 +4441,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema46(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema46(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex93 = (decoder.readIndex());
@@ -4481,7 +4482,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema47(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema47(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex95 = (decoder.readIndex());
@@ -4522,7 +4523,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema48(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema48(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex97 = (decoder.readIndex());
@@ -4563,7 +4564,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema49(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema49(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex99 = (decoder.readIndex());
@@ -4604,7 +4605,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema50(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema50(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex101 = (decoder.readIndex());
@@ -4645,7 +4646,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema51(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema51(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex103 = (decoder.readIndex());
@@ -4686,7 +4687,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema52(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema52(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex105 = (decoder.readIndex());
@@ -4727,7 +4728,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema53(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema53(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex107 = (decoder.readIndex());
@@ -4768,7 +4769,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema54(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema54(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex109 = (decoder.readIndex());
@@ -4809,7 +4810,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema55(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema55(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex111 = (decoder.readIndex());
@@ -4850,7 +4851,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema56(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema56(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex113 = (decoder.readIndex());
@@ -4891,7 +4892,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema57(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema57(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex115 = (decoder.readIndex());
@@ -4932,7 +4933,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema58(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema58(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex117 = (decoder.readIndex());
@@ -4973,7 +4974,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema59(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema59(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex119 = (decoder.readIndex());
@@ -5014,7 +5015,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema60(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema60(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex121 = (decoder.readIndex());
@@ -5055,7 +5056,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema61(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema61(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex123 = (decoder.readIndex());
@@ -5096,7 +5097,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema62(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema62(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex125 = (decoder.readIndex());
@@ -5137,7 +5138,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema63(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema63(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex127 = (decoder.readIndex());
@@ -5178,7 +5179,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema64(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema64(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex129 = (decoder.readIndex());
@@ -5219,7 +5220,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema65(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema65(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex131 = (decoder.readIndex());
@@ -5260,7 +5261,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema66(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema66(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex133 = (decoder.readIndex());
@@ -5301,7 +5302,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema67(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema67(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex135 = (decoder.readIndex());
@@ -5342,7 +5343,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema68(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema68(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex137 = (decoder.readIndex());
@@ -5383,7 +5384,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema69(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema69(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex139 = (decoder.readIndex());
@@ -5424,7 +5425,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema70(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema70(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex141 = (decoder.readIndex());
@@ -5465,7 +5466,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema71(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema71(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex143 = (decoder.readIndex());
@@ -5506,7 +5507,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema72(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema72(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex145 = (decoder.readIndex());
@@ -5547,7 +5548,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema73(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema73(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex147 = (decoder.readIndex());
@@ -5588,7 +5589,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema74(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema74(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex149 = (decoder.readIndex());
@@ -5629,7 +5630,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema75(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema75(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex151 = (decoder.readIndex());
@@ -5670,7 +5671,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema76(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema76(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex153 = (decoder.readIndex());
@@ -5711,7 +5712,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema77(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema77(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex155 = (decoder.readIndex());
@@ -5752,7 +5753,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema78(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema78(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex157 = (decoder.readIndex());
@@ -5793,7 +5794,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema79(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema79(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex159 = (decoder.readIndex());
@@ -5834,7 +5835,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema80(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema80(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex161 = (decoder.readIndex());
@@ -5875,7 +5876,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema81(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema81(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex163 = (decoder.readIndex());
@@ -5916,7 +5917,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema82(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema82(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex165 = (decoder.readIndex());
@@ -5957,7 +5958,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema83(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema83(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex167 = (decoder.readIndex());
@@ -5998,7 +5999,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema84(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema84(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex169 = (decoder.readIndex());
@@ -6039,7 +6040,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema85(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema85(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex171 = (decoder.readIndex());
@@ -6080,7 +6081,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema86(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema86(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex173 = (decoder.readIndex());
@@ -6121,7 +6122,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema87(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema87(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex175 = (decoder.readIndex());
@@ -6162,7 +6163,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema88(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema88(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex177 = (decoder.readIndex());
@@ -6203,7 +6204,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema89(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema89(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex179 = (decoder.readIndex());
@@ -6244,7 +6245,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema90(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema90(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex181 = (decoder.readIndex());
@@ -6285,7 +6286,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema91(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema91(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex183 = (decoder.readIndex());
@@ -6326,7 +6327,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema92(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema92(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex185 = (decoder.readIndex());
@@ -6367,7 +6368,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema93(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema93(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex187 = (decoder.readIndex());
@@ -6408,7 +6409,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema94(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema94(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex189 = (decoder.readIndex());
@@ -6449,7 +6450,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema95(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema95(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex191 = (decoder.readIndex());
@@ -6490,7 +6491,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema96(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema96(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex193 = (decoder.readIndex());
@@ -6531,7 +6532,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema97(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema97(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex195 = (decoder.readIndex());
@@ -6572,7 +6573,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema98(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema98(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex197 = (decoder.readIndex());
@@ -6613,7 +6614,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema99(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema99(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex199 = (decoder.readIndex());
@@ -6654,7 +6655,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema100(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema100(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex201 = (decoder.readIndex());
@@ -6695,7 +6696,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema101(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema101(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex203 = (decoder.readIndex());
@@ -6736,7 +6737,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema102(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema102(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex205 = (decoder.readIndex());
@@ -6777,7 +6778,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema103(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema103(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex207 = (decoder.readIndex());
@@ -6818,7 +6819,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema104(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema104(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex209 = (decoder.readIndex());
@@ -6859,7 +6860,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema105(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema105(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex211 = (decoder.readIndex());
@@ -6900,7 +6901,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema106(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema106(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex213 = (decoder.readIndex());
@@ -6941,7 +6942,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema107(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema107(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex215 = (decoder.readIndex());
@@ -6982,7 +6983,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema108(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema108(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex217 = (decoder.readIndex());
@@ -7023,7 +7024,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema109(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema109(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex219 = (decoder.readIndex());
@@ -7064,7 +7065,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema110(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema110(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex221 = (decoder.readIndex());
@@ -7105,7 +7106,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema111(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema111(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex223 = (decoder.readIndex());
@@ -7146,7 +7147,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema112(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema112(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex225 = (decoder.readIndex());
@@ -7187,7 +7188,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema113(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema113(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex227 = (decoder.readIndex());
@@ -7228,7 +7229,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema114(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema114(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex229 = (decoder.readIndex());
@@ -7269,7 +7270,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema115(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema115(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex231 = (decoder.readIndex());
@@ -7310,7 +7311,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema116(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema116(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex233 = (decoder.readIndex());
@@ -7351,7 +7352,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema117(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema117(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex235 = (decoder.readIndex());
@@ -7392,7 +7393,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema118(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema118(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex237 = (decoder.readIndex());
@@ -7433,7 +7434,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema119(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema119(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex239 = (decoder.readIndex());
@@ -7474,7 +7475,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema120(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema120(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex241 = (decoder.readIndex());
@@ -7515,7 +7516,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema121(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema121(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex243 = (decoder.readIndex());
@@ -7556,7 +7557,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema122(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema122(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex245 = (decoder.readIndex());
@@ -7597,7 +7598,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema123(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema123(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex247 = (decoder.readIndex());
@@ -7638,7 +7639,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema124(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema124(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex249 = (decoder.readIndex());
@@ -7679,7 +7680,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema125(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema125(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex251 = (decoder.readIndex());
@@ -7720,7 +7721,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema126(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema126(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex253 = (decoder.readIndex());
@@ -7761,7 +7762,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema127(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema127(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex255 = (decoder.readIndex());
@@ -7802,7 +7803,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema128(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema128(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex257 = (decoder.readIndex());
@@ -7843,7 +7844,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema129(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema129(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex259 = (decoder.readIndex());
@@ -7884,7 +7885,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema130(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema130(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex261 = (decoder.readIndex());
@@ -7925,7 +7926,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema131(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema131(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex263 = (decoder.readIndex());
@@ -7966,7 +7967,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema132(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema132(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex265 = (decoder.readIndex());
@@ -8007,7 +8008,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema133(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema133(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex267 = (decoder.readIndex());
@@ -8048,7 +8049,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema134(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema134(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex269 = (decoder.readIndex());
@@ -8089,7 +8090,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema135(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema135(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex271 = (decoder.readIndex());
@@ -8130,7 +8131,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema136(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema136(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex273 = (decoder.readIndex());
@@ -8171,7 +8172,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema137(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema137(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex275 = (decoder.readIndex());
@@ -8212,7 +8213,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema138(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema138(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex277 = (decoder.readIndex());
@@ -8253,7 +8254,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema139(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema139(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex279 = (decoder.readIndex());
@@ -8294,7 +8295,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema140(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema140(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex281 = (decoder.readIndex());
@@ -8335,7 +8336,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema141(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema141(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex283 = (decoder.readIndex());
@@ -8376,7 +8377,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema142(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema142(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex285 = (decoder.readIndex());
@@ -8417,7 +8418,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema143(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema143(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex287 = (decoder.readIndex());
@@ -8458,7 +8459,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema144(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema144(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex289 = (decoder.readIndex());
@@ -8499,7 +8500,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema145(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema145(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex291 = (decoder.readIndex());
@@ -8540,7 +8541,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema146(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema146(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex293 = (decoder.readIndex());
@@ -8581,7 +8582,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema147(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema147(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex295 = (decoder.readIndex());
@@ -8622,7 +8623,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema148(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema148(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex297 = (decoder.readIndex());
@@ -8663,7 +8664,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema149(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema149(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex299 = (decoder.readIndex());
@@ -8704,7 +8705,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema150(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema150(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex301 = (decoder.readIndex());
@@ -8745,7 +8746,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema151(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema151(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex303 = (decoder.readIndex());
@@ -8786,7 +8787,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema152(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema152(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex305 = (decoder.readIndex());
@@ -8827,7 +8828,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema153(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema153(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex307 = (decoder.readIndex());
@@ -8868,7 +8869,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema154(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema154(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex309 = (decoder.readIndex());
@@ -8909,7 +8910,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema155(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema155(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex311 = (decoder.readIndex());
@@ -8950,7 +8951,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema156(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema156(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex313 = (decoder.readIndex());
@@ -8991,7 +8992,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema157(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema157(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex315 = (decoder.readIndex());
@@ -9032,7 +9033,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema158(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema158(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex317 = (decoder.readIndex());
@@ -9073,7 +9074,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema159(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema159(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex319 = (decoder.readIndex());
@@ -9114,7 +9115,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema160(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema160(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex321 = (decoder.readIndex());
@@ -9155,7 +9156,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema161(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema161(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex323 = (decoder.readIndex());
@@ -9196,7 +9197,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema162(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema162(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex325 = (decoder.readIndex());
@@ -9237,7 +9238,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema163(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema163(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex327 = (decoder.readIndex());
@@ -9278,7 +9279,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema164(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema164(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex329 = (decoder.readIndex());
@@ -9319,7 +9320,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema165(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema165(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex331 = (decoder.readIndex());
@@ -9360,7 +9361,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema166(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema166(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex333 = (decoder.readIndex());
@@ -9401,7 +9402,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema167(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema167(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex335 = (decoder.readIndex());
@@ -9442,7 +9443,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema168(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema168(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex337 = (decoder.readIndex());
@@ -9483,7 +9484,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema169(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema169(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex339 = (decoder.readIndex());
@@ -9524,7 +9525,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema170(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema170(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex341 = (decoder.readIndex());
@@ -9565,7 +9566,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema171(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema171(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex343 = (decoder.readIndex());
@@ -9606,7 +9607,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema172(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema172(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex345 = (decoder.readIndex());
@@ -9647,7 +9648,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema173(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema173(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex347 = (decoder.readIndex());
@@ -9688,7 +9689,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema174(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema174(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex349 = (decoder.readIndex());
@@ -9729,7 +9730,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema175(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema175(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex351 = (decoder.readIndex());
@@ -9770,7 +9771,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema176(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema176(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex353 = (decoder.readIndex());
@@ -9811,7 +9812,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema177(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema177(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex355 = (decoder.readIndex());
@@ -9852,7 +9853,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema178(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema178(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex357 = (decoder.readIndex());
@@ -9893,7 +9894,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema179(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema179(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex359 = (decoder.readIndex());
@@ -9934,7 +9935,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema180(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema180(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex361 = (decoder.readIndex());
@@ -9975,7 +9976,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema181(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema181(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex363 = (decoder.readIndex());
@@ -10016,7 +10017,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema182(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema182(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex365 = (decoder.readIndex());
@@ -10057,7 +10058,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema183(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema183(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex367 = (decoder.readIndex());
@@ -10098,7 +10099,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema184(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema184(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex369 = (decoder.readIndex());
@@ -10139,7 +10140,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema185(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema185(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex371 = (decoder.readIndex());
@@ -10180,7 +10181,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema186(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema186(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex373 = (decoder.readIndex());
@@ -10221,7 +10222,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema187(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema187(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex375 = (decoder.readIndex());
@@ -10262,7 +10263,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema188(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema188(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex377 = (decoder.readIndex());
@@ -10303,7 +10304,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema189(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema189(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex379 = (decoder.readIndex());
@@ -10344,7 +10345,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema190(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema190(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex381 = (decoder.readIndex());
@@ -10385,7 +10386,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema191(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema191(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex383 = (decoder.readIndex());
@@ -10426,7 +10427,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema192(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema192(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex385 = (decoder.readIndex());
@@ -10467,7 +10468,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema193(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema193(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex387 = (decoder.readIndex());
@@ -10508,7 +10509,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema194(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema194(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex389 = (decoder.readIndex());
@@ -10549,7 +10550,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema195(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema195(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex391 = (decoder.readIndex());
@@ -10590,7 +10591,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema196(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema196(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex393 = (decoder.readIndex());
@@ -10631,7 +10632,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema197(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema197(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex395 = (decoder.readIndex());
@@ -10672,7 +10673,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema198(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema198(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex397 = (decoder.readIndex());
@@ -10713,7 +10714,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema199(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema199(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex399 = (decoder.readIndex());
@@ -10754,7 +10755,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema200(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema200(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex401 = (decoder.readIndex());
@@ -10795,7 +10796,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema201(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema201(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex403 = (decoder.readIndex());
@@ -10836,7 +10837,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema202(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema202(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex405 = (decoder.readIndex());
@@ -10877,7 +10878,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema203(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema203(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex407 = (decoder.readIndex());
@@ -10918,7 +10919,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema204(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema204(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex409 = (decoder.readIndex());
@@ -10959,7 +10960,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema205(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema205(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex411 = (decoder.readIndex());
@@ -11000,7 +11001,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema206(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema206(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex413 = (decoder.readIndex());
@@ -11041,7 +11042,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema207(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema207(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex415 = (decoder.readIndex());
@@ -11082,7 +11083,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema208(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema208(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex417 = (decoder.readIndex());
@@ -11123,7 +11124,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema209(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema209(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex419 = (decoder.readIndex());
@@ -11164,7 +11165,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema210(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema210(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex421 = (decoder.readIndex());
@@ -11205,7 +11206,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema211(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema211(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex423 = (decoder.readIndex());
@@ -11246,7 +11247,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema212(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema212(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex425 = (decoder.readIndex());
@@ -11287,7 +11288,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema213(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema213(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex427 = (decoder.readIndex());
@@ -11328,7 +11329,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema214(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema214(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex429 = (decoder.readIndex());
@@ -11369,7 +11370,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema215(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema215(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex431 = (decoder.readIndex());
@@ -11410,7 +11411,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema216(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema216(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex433 = (decoder.readIndex());
@@ -11451,7 +11452,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema217(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema217(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex435 = (decoder.readIndex());
@@ -11492,7 +11493,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema218(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema218(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex437 = (decoder.readIndex());
@@ -11533,7 +11534,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema219(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema219(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex439 = (decoder.readIndex());
@@ -11574,7 +11575,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema220(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema220(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex441 = (decoder.readIndex());
@@ -11615,7 +11616,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema221(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema221(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex443 = (decoder.readIndex());
@@ -11656,7 +11657,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema222(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema222(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex445 = (decoder.readIndex());
@@ -11697,7 +11698,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema223(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema223(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex447 = (decoder.readIndex());
@@ -11738,7 +11739,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema224(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema224(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex449 = (decoder.readIndex());
@@ -11779,7 +11780,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema225(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema225(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex451 = (decoder.readIndex());
@@ -11820,7 +11821,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema226(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema226(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex453 = (decoder.readIndex());
@@ -11861,7 +11862,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema227(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema227(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex455 = (decoder.readIndex());
@@ -11902,7 +11903,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema228(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema228(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex457 = (decoder.readIndex());
@@ -11943,7 +11944,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema229(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema229(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex459 = (decoder.readIndex());
@@ -11984,7 +11985,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema230(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema230(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex461 = (decoder.readIndex());
@@ -12025,7 +12026,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema231(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema231(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex463 = (decoder.readIndex());
@@ -12066,7 +12067,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema232(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema232(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex465 = (decoder.readIndex());
@@ -12107,7 +12108,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema233(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema233(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex467 = (decoder.readIndex());
@@ -12148,7 +12149,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema234(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema234(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex469 = (decoder.readIndex());
@@ -12189,7 +12190,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema235(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema235(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex471 = (decoder.readIndex());
@@ -12230,7 +12231,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema236(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema236(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex473 = (decoder.readIndex());
@@ -12271,7 +12272,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema237(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema237(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex475 = (decoder.readIndex());
@@ -12312,7 +12313,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema238(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema238(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex477 = (decoder.readIndex());
@@ -12353,7 +12354,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema239(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema239(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex479 = (decoder.readIndex());
@@ -12394,7 +12395,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema240(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema240(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex481 = (decoder.readIndex());
@@ -12435,7 +12436,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema241(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema241(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex483 = (decoder.readIndex());
@@ -12476,7 +12477,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema242(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema242(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex485 = (decoder.readIndex());
@@ -12517,7 +12518,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema243(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema243(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex487 = (decoder.readIndex());
@@ -12558,7 +12559,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema244(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema244(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex489 = (decoder.readIndex());
@@ -12599,7 +12600,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema245(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema245(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex491 = (decoder.readIndex());
@@ -12640,7 +12641,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema246(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema246(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex493 = (decoder.readIndex());
@@ -12681,7 +12682,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema247(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema247(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex495 = (decoder.readIndex());
@@ -12722,7 +12723,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema248(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema248(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex497 = (decoder.readIndex());
@@ -12763,7 +12764,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema249(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema249(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex499 = (decoder.readIndex());
@@ -12804,7 +12805,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema250(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema250(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex501 = (decoder.readIndex());
@@ -12845,7 +12846,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema251(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema251(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex503 = (decoder.readIndex());
@@ -12886,7 +12887,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema252(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema252(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex505 = (decoder.readIndex());
@@ -12927,7 +12928,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema253(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema253(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex507 = (decoder.readIndex());
@@ -12968,7 +12969,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema254(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema254(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex509 = (decoder.readIndex());
@@ -13009,7 +13010,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema255(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema255(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex511 = (decoder.readIndex());
@@ -13050,7 +13051,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema256(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema256(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex513 = (decoder.readIndex());
@@ -13091,7 +13092,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema257(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema257(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex515 = (decoder.readIndex());
@@ -13132,7 +13133,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema258(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema258(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex517 = (decoder.readIndex());
@@ -13173,7 +13174,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema259(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema259(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex519 = (decoder.readIndex());
@@ -13214,7 +13215,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema260(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema260(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex521 = (decoder.readIndex());
@@ -13255,7 +13256,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema261(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema261(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex523 = (decoder.readIndex());
@@ -13296,7 +13297,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema262(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema262(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex525 = (decoder.readIndex());
@@ -13337,7 +13338,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema263(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema263(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex527 = (decoder.readIndex());
@@ -13378,7 +13379,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema264(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema264(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex529 = (decoder.readIndex());
@@ -13419,7 +13420,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema265(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema265(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex531 = (decoder.readIndex());
@@ -13460,7 +13461,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema266(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema266(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex533 = (decoder.readIndex());
@@ -13501,7 +13502,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema267(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema267(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex535 = (decoder.readIndex());
@@ -13542,7 +13543,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema268(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema268(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex537 = (decoder.readIndex());
@@ -13583,7 +13584,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema269(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema269(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex539 = (decoder.readIndex());
@@ -13624,7 +13625,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema270(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema270(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex541 = (decoder.readIndex());
@@ -13665,7 +13666,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema271(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema271(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex543 = (decoder.readIndex());
@@ -13706,7 +13707,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema272(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema272(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex545 = (decoder.readIndex());
@@ -13747,7 +13748,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema273(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema273(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex547 = (decoder.readIndex());
@@ -13788,7 +13789,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema274(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema274(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex549 = (decoder.readIndex());
@@ -13829,7 +13830,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema275(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema275(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex551 = (decoder.readIndex());
@@ -13870,7 +13871,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema276(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema276(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex553 = (decoder.readIndex());
@@ -13911,7 +13912,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema277(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema277(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex555 = (decoder.readIndex());
@@ -13952,7 +13953,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema278(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema278(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex557 = (decoder.readIndex());
@@ -13993,7 +13994,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema279(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema279(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex559 = (decoder.readIndex());
@@ -14034,7 +14035,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema280(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema280(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex561 = (decoder.readIndex());
@@ -14075,7 +14076,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema281(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema281(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex563 = (decoder.readIndex());
@@ -14116,7 +14117,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema282(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema282(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex565 = (decoder.readIndex());
@@ -14157,7 +14158,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema283(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema283(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex567 = (decoder.readIndex());
@@ -14198,7 +14199,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema284(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema284(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex569 = (decoder.readIndex());
@@ -14239,7 +14240,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema285(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema285(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex571 = (decoder.readIndex());
@@ -14280,7 +14281,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema286(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema286(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex573 = (decoder.readIndex());
@@ -14321,7 +14322,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema287(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema287(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex575 = (decoder.readIndex());
@@ -14362,7 +14363,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema288(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema288(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex577 = (decoder.readIndex());
@@ -14403,7 +14404,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema289(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema289(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex579 = (decoder.readIndex());
@@ -14444,7 +14445,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema290(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema290(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex581 = (decoder.readIndex());
@@ -14485,7 +14486,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema291(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema291(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex583 = (decoder.readIndex());
@@ -14526,7 +14527,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema292(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema292(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex585 = (decoder.readIndex());
@@ -14567,7 +14568,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema293(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema293(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex587 = (decoder.readIndex());
@@ -14608,7 +14609,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema294(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema294(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex589 = (decoder.readIndex());
@@ -14649,7 +14650,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema295(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema295(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex591 = (decoder.readIndex());
@@ -14690,7 +14691,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema296(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema296(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex593 = (decoder.readIndex());
@@ -14731,7 +14732,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema297(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema297(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex595 = (decoder.readIndex());
@@ -14772,7 +14773,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema298(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema298(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex597 = (decoder.readIndex());
@@ -14813,7 +14814,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema299(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema299(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex599 = (decoder.readIndex());
@@ -14854,7 +14855,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema300(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema300(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex601 = (decoder.readIndex());
@@ -14895,7 +14896,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema301(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema301(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex603 = (decoder.readIndex());
@@ -14936,7 +14937,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema302(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema302(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex605 = (decoder.readIndex());
@@ -14977,7 +14978,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema303(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema303(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex607 = (decoder.readIndex());
@@ -15018,7 +15019,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema304(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema304(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex609 = (decoder.readIndex());
@@ -15059,7 +15060,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema305(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema305(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex611 = (decoder.readIndex());
@@ -15100,7 +15101,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema306(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema306(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex613 = (decoder.readIndex());
@@ -15141,7 +15142,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema307(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema307(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex615 = (decoder.readIndex());
@@ -15182,7 +15183,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema308(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema308(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex617 = (decoder.readIndex());
@@ -15223,7 +15224,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema309(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema309(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex619 = (decoder.readIndex());
@@ -15264,7 +15265,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema310(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema310(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex621 = (decoder.readIndex());
@@ -15305,7 +15306,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema311(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema311(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex623 = (decoder.readIndex());
@@ -15346,7 +15347,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema312(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema312(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex625 = (decoder.readIndex());
@@ -15387,7 +15388,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema313(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema313(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex627 = (decoder.readIndex());
@@ -15428,7 +15429,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema314(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema314(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex629 = (decoder.readIndex());
@@ -15469,7 +15470,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema315(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema315(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex631 = (decoder.readIndex());
@@ -15510,7 +15511,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema316(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema316(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex633 = (decoder.readIndex());
@@ -15551,7 +15552,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema317(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema317(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex635 = (decoder.readIndex());
@@ -15592,7 +15593,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema318(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema318(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex637 = (decoder.readIndex());
@@ -15633,7 +15634,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema319(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema319(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex639 = (decoder.readIndex());
@@ -15674,7 +15675,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema320(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema320(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex641 = (decoder.readIndex());
@@ -15715,7 +15716,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema321(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema321(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex643 = (decoder.readIndex());
@@ -15756,7 +15757,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema322(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema322(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex645 = (decoder.readIndex());
@@ -15797,7 +15798,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema323(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema323(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex647 = (decoder.readIndex());
@@ -15838,7 +15839,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema324(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema324(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex649 = (decoder.readIndex());
@@ -15879,7 +15880,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema325(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema325(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex651 = (decoder.readIndex());
@@ -15920,7 +15921,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema326(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema326(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex653 = (decoder.readIndex());
@@ -15961,7 +15962,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema327(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema327(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex655 = (decoder.readIndex());
@@ -16002,7 +16003,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema328(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema328(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex657 = (decoder.readIndex());
@@ -16043,7 +16044,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema329(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema329(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex659 = (decoder.readIndex());
@@ -16084,7 +16085,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema330(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema330(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex661 = (decoder.readIndex());
@@ -16125,7 +16126,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema331(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema331(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex663 = (decoder.readIndex());
@@ -16166,7 +16167,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema332(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema332(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex665 = (decoder.readIndex());
@@ -16207,7 +16208,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema333(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema333(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex667 = (decoder.readIndex());
@@ -16248,7 +16249,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema334(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema334(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex669 = (decoder.readIndex());
@@ -16289,7 +16290,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema335(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema335(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex671 = (decoder.readIndex());
@@ -16330,7 +16331,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema336(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema336(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex673 = (decoder.readIndex());
@@ -16371,7 +16372,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema337(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema337(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex675 = (decoder.readIndex());
@@ -16412,7 +16413,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema338(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema338(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex677 = (decoder.readIndex());
@@ -16453,7 +16454,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema339(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema339(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex679 = (decoder.readIndex());
@@ -16494,7 +16495,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema340(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema340(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex681 = (decoder.readIndex());
@@ -16535,7 +16536,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema341(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema341(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex683 = (decoder.readIndex());
@@ -16576,7 +16577,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema342(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema342(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex685 = (decoder.readIndex());
@@ -16617,7 +16618,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema343(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema343(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex687 = (decoder.readIndex());
@@ -16658,7 +16659,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema344(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema344(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex689 = (decoder.readIndex());
@@ -16699,7 +16700,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema345(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema345(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex691 = (decoder.readIndex());
@@ -16740,7 +16741,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema346(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema346(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex693 = (decoder.readIndex());
@@ -16781,7 +16782,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema347(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema347(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex695 = (decoder.readIndex());
@@ -16822,7 +16823,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema348(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema348(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex697 = (decoder.readIndex());
@@ -16863,7 +16864,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema349(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema349(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex699 = (decoder.readIndex());
@@ -16904,7 +16905,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema350(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema350(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex701 = (decoder.readIndex());
@@ -16945,7 +16946,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema351(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema351(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex703 = (decoder.readIndex());
@@ -16986,7 +16987,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema352(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema352(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex705 = (decoder.readIndex());
@@ -17027,7 +17028,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema353(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema353(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex707 = (decoder.readIndex());
@@ -17068,7 +17069,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema354(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema354(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex709 = (decoder.readIndex());
@@ -17109,7 +17110,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema355(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema355(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex711 = (decoder.readIndex());
@@ -17150,7 +17151,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema356(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema356(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex713 = (decoder.readIndex());
@@ -17191,7 +17192,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema357(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema357(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex715 = (decoder.readIndex());
@@ -17232,7 +17233,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema358(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema358(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex717 = (decoder.readIndex());
@@ -17273,7 +17274,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema359(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema359(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex719 = (decoder.readIndex());
@@ -17314,7 +17315,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema360(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema360(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex721 = (decoder.readIndex());
@@ -17355,7 +17356,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema361(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema361(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex723 = (decoder.readIndex());
@@ -17396,7 +17397,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema362(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema362(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex725 = (decoder.readIndex());
@@ -17437,7 +17438,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema363(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema363(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex727 = (decoder.readIndex());
@@ -17478,7 +17479,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema364(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema364(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex729 = (decoder.readIndex());
@@ -17519,7 +17520,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema365(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema365(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex731 = (decoder.readIndex());
@@ -17560,7 +17561,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema366(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema366(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex733 = (decoder.readIndex());
@@ -17601,7 +17602,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema367(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema367(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex735 = (decoder.readIndex());
@@ -17642,7 +17643,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema368(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema368(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex737 = (decoder.readIndex());
@@ -17683,7 +17684,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema369(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema369(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex739 = (decoder.readIndex());
@@ -17724,7 +17725,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema370(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema370(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex741 = (decoder.readIndex());
@@ -17765,7 +17766,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema371(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema371(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex743 = (decoder.readIndex());
@@ -17806,7 +17807,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema372(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema372(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex745 = (decoder.readIndex());
@@ -17847,7 +17848,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema373(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema373(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex747 = (decoder.readIndex());
@@ -17888,7 +17889,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema374(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema374(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex749 = (decoder.readIndex());
@@ -17929,7 +17930,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema375(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema375(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex751 = (decoder.readIndex());
@@ -17970,7 +17971,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema376(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema376(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex753 = (decoder.readIndex());
@@ -18011,7 +18012,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema377(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema377(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex755 = (decoder.readIndex());
@@ -18052,7 +18053,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema378(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema378(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex757 = (decoder.readIndex());
@@ -18093,7 +18094,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema379(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema379(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex759 = (decoder.readIndex());
@@ -18134,7 +18135,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema380(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema380(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex761 = (decoder.readIndex());
@@ -18175,7 +18176,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema381(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema381(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex763 = (decoder.readIndex());
@@ -18216,7 +18217,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema382(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema382(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex765 = (decoder.readIndex());
@@ -18257,7 +18258,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema383(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema383(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex767 = (decoder.readIndex());
@@ -18298,7 +18299,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema384(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema384(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex769 = (decoder.readIndex());
@@ -18339,7 +18340,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema385(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema385(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex771 = (decoder.readIndex());
@@ -18380,7 +18381,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema386(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema386(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex773 = (decoder.readIndex());
@@ -18421,7 +18422,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema387(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema387(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex775 = (decoder.readIndex());
@@ -18462,7 +18463,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema388(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema388(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex777 = (decoder.readIndex());
@@ -18503,7 +18504,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema389(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema389(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex779 = (decoder.readIndex());
@@ -18544,7 +18545,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema390(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema390(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex781 = (decoder.readIndex());
@@ -18585,7 +18586,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema391(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema391(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex783 = (decoder.readIndex());
@@ -18626,7 +18627,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema392(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema392(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex785 = (decoder.readIndex());
@@ -18667,7 +18668,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema393(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema393(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex787 = (decoder.readIndex());
@@ -18708,7 +18709,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema394(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema394(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex789 = (decoder.readIndex());
@@ -18749,7 +18750,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema395(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema395(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex791 = (decoder.readIndex());
@@ -18790,7 +18791,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema396(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema396(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex793 = (decoder.readIndex());
@@ -18831,7 +18832,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema397(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema397(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex795 = (decoder.readIndex());
@@ -18872,7 +18873,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema398(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema398(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex797 = (decoder.readIndex());
@@ -18913,7 +18914,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema399(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema399(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex799 = (decoder.readIndex());
@@ -18954,7 +18955,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema400(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema400(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex801 = (decoder.readIndex());
@@ -18995,7 +18996,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema401(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema401(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex803 = (decoder.readIndex());
@@ -19036,7 +19037,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema402(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema402(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex805 = (decoder.readIndex());
@@ -19077,7 +19078,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema403(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema403(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex807 = (decoder.readIndex());
@@ -19118,7 +19119,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema404(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema404(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex809 = (decoder.readIndex());
@@ -19159,7 +19160,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema405(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema405(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex811 = (decoder.readIndex());
@@ -19200,7 +19201,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema406(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema406(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex813 = (decoder.readIndex());
@@ -19241,7 +19242,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema407(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema407(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex815 = (decoder.readIndex());
@@ -19282,7 +19283,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema408(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema408(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex817 = (decoder.readIndex());
@@ -19323,7 +19324,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema409(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema409(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex819 = (decoder.readIndex());
@@ -19364,7 +19365,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema410(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema410(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex821 = (decoder.readIndex());
@@ -19405,7 +19406,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema411(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema411(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex823 = (decoder.readIndex());
@@ -19446,7 +19447,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema412(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema412(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex825 = (decoder.readIndex());
@@ -19487,7 +19488,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema413(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema413(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex827 = (decoder.readIndex());
@@ -19528,7 +19529,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema414(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema414(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex829 = (decoder.readIndex());
@@ -19569,7 +19570,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema415(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema415(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex831 = (decoder.readIndex());
@@ -19610,7 +19611,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema416(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema416(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex833 = (decoder.readIndex());
@@ -19651,7 +19652,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema417(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema417(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex835 = (decoder.readIndex());
@@ -19692,7 +19693,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema418(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema418(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex837 = (decoder.readIndex());
@@ -19733,7 +19734,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema419(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema419(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex839 = (decoder.readIndex());
@@ -19774,7 +19775,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema420(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema420(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex841 = (decoder.readIndex());
@@ -19815,7 +19816,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema421(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema421(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex843 = (decoder.readIndex());
@@ -19856,7 +19857,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema422(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema422(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex845 = (decoder.readIndex());
@@ -19897,7 +19898,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema423(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema423(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex847 = (decoder.readIndex());
@@ -19938,7 +19939,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema424(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema424(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex849 = (decoder.readIndex());
@@ -19979,7 +19980,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema425(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema425(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex851 = (decoder.readIndex());
@@ -20020,7 +20021,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema426(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema426(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex853 = (decoder.readIndex());
@@ -20061,7 +20062,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema427(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema427(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex855 = (decoder.readIndex());
@@ -20102,7 +20103,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema428(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema428(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex857 = (decoder.readIndex());
@@ -20143,7 +20144,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema429(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema429(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex859 = (decoder.readIndex());
@@ -20184,7 +20185,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema430(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema430(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex861 = (decoder.readIndex());
@@ -20225,7 +20226,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema431(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema431(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex863 = (decoder.readIndex());
@@ -20266,7 +20267,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema432(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema432(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex865 = (decoder.readIndex());
@@ -20307,7 +20308,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema433(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema433(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex867 = (decoder.readIndex());
@@ -20348,7 +20349,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema434(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema434(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex869 = (decoder.readIndex());
@@ -20389,7 +20390,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema435(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema435(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex871 = (decoder.readIndex());
@@ -20430,7 +20431,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema436(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema436(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex873 = (decoder.readIndex());
@@ -20471,7 +20472,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema437(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema437(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex875 = (decoder.readIndex());
@@ -20512,7 +20513,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema438(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema438(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex877 = (decoder.readIndex());
@@ -20553,7 +20554,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema439(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema439(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex879 = (decoder.readIndex());
@@ -20594,7 +20595,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema440(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema440(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex881 = (decoder.readIndex());
@@ -20635,7 +20636,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema441(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema441(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex883 = (decoder.readIndex());
@@ -20676,7 +20677,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema442(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema442(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex885 = (decoder.readIndex());
@@ -20717,7 +20718,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema443(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema443(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex887 = (decoder.readIndex());
@@ -20758,7 +20759,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema444(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema444(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex889 = (decoder.readIndex());
@@ -20799,7 +20800,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema445(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema445(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex891 = (decoder.readIndex());
@@ -20840,7 +20841,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema446(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema446(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex893 = (decoder.readIndex());
@@ -20881,7 +20882,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema447(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema447(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex895 = (decoder.readIndex());
@@ -20922,7 +20923,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema448(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema448(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex897 = (decoder.readIndex());
@@ -20963,7 +20964,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema449(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema449(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex899 = (decoder.readIndex());
@@ -21004,7 +21005,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema450(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema450(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex901 = (decoder.readIndex());
@@ -21045,7 +21046,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema451(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema451(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex903 = (decoder.readIndex());
@@ -21086,7 +21087,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema452(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema452(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex905 = (decoder.readIndex());
@@ -21127,7 +21128,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema453(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema453(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex907 = (decoder.readIndex());
@@ -21168,7 +21169,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema454(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema454(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex909 = (decoder.readIndex());
@@ -21209,7 +21210,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema455(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema455(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex911 = (decoder.readIndex());
@@ -21250,7 +21251,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema456(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema456(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex913 = (decoder.readIndex());
@@ -21291,7 +21292,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema457(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema457(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex915 = (decoder.readIndex());
@@ -21332,7 +21333,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema458(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema458(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex917 = (decoder.readIndex());
@@ -21373,7 +21374,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema459(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema459(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex919 = (decoder.readIndex());
@@ -21414,7 +21415,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema460(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema460(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex921 = (decoder.readIndex());
@@ -21455,7 +21456,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema461(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema461(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex923 = (decoder.readIndex());
@@ -21496,7 +21497,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema462(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema462(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex925 = (decoder.readIndex());
@@ -21537,7 +21538,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema463(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema463(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex927 = (decoder.readIndex());
@@ -21578,7 +21579,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema464(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema464(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex929 = (decoder.readIndex());
@@ -21619,7 +21620,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema465(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema465(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex931 = (decoder.readIndex());
@@ -21660,7 +21661,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema466(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema466(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex933 = (decoder.readIndex());
@@ -21701,7 +21702,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema467(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema467(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex935 = (decoder.readIndex());
@@ -21742,7 +21743,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema468(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema468(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex937 = (decoder.readIndex());
@@ -21783,7 +21784,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema469(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema469(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex939 = (decoder.readIndex());
@@ -21824,7 +21825,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema470(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema470(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex941 = (decoder.readIndex());
@@ -21865,7 +21866,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema471(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema471(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex943 = (decoder.readIndex());
@@ -21906,7 +21907,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema472(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema472(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex945 = (decoder.readIndex());
@@ -21947,7 +21948,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema473(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema473(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex947 = (decoder.readIndex());
@@ -21988,7 +21989,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema474(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema474(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex949 = (decoder.readIndex());
@@ -22029,7 +22030,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema475(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema475(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex951 = (decoder.readIndex());
@@ -22070,7 +22071,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema476(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema476(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex953 = (decoder.readIndex());
@@ -22111,7 +22112,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema477(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema477(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex955 = (decoder.readIndex());
@@ -22152,7 +22153,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema478(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema478(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex957 = (decoder.readIndex());
@@ -22193,7 +22194,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema479(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema479(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex959 = (decoder.readIndex());
@@ -22234,7 +22235,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema480(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema480(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex961 = (decoder.readIndex());
@@ -22275,7 +22276,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema481(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema481(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex963 = (decoder.readIndex());
@@ -22316,7 +22317,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema482(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema482(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex965 = (decoder.readIndex());
@@ -22357,7 +22358,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema483(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema483(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex967 = (decoder.readIndex());
@@ -22398,7 +22399,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema484(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema484(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex969 = (decoder.readIndex());
@@ -22439,7 +22440,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema485(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema485(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex971 = (decoder.readIndex());
@@ -22480,7 +22481,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema486(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema486(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex973 = (decoder.readIndex());
@@ -22521,7 +22522,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema487(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema487(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex975 = (decoder.readIndex());
@@ -22562,7 +22563,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema488(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema488(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex977 = (decoder.readIndex());
@@ -22603,7 +22604,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema489(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema489(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex979 = (decoder.readIndex());
@@ -22644,7 +22645,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema490(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema490(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex981 = (decoder.readIndex());
@@ -22685,7 +22686,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema491(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema491(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex983 = (decoder.readIndex());
@@ -22726,7 +22727,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema492(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema492(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex985 = (decoder.readIndex());
@@ -22767,7 +22768,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema493(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema493(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex987 = (decoder.readIndex());
@@ -22808,7 +22809,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema494(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema494(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex989 = (decoder.readIndex());
@@ -22849,7 +22850,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema495(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema495(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex991 = (decoder.readIndex());
@@ -22890,7 +22891,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema496(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema496(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex993 = (decoder.readIndex());
@@ -22931,7 +22932,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema497(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema497(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex995 = (decoder.readIndex());
@@ -22972,7 +22973,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema498(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema498(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex997 = (decoder.readIndex());
@@ -23013,7 +23014,7 @@ public class FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSch
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema499(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema499(IndexedRecord FastGenericDeserializerGeneratorTest_shouldBeAbleToReadVeryLargeSchema, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex999 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_1824759546_1574596677.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadAliasedField_GenericDeserializer_1824759546_1574596677.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -22,13 +23,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
         this.testStringUnionAlias0 = readerSchema.getField("testStringUnionAlias").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadAliasedField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
@@ -55,11 +56,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadAliasedField_Generic
                 throw new RuntimeException(("Illegal union index for 'testString': "+ unionIndex0));
             }
         }
-        populate_FastGenericDeserializerGeneratorTest_shouldReadAliasedField0((FastGenericDeserializerGeneratorTest_shouldReadAliasedField), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadAliasedField0((FastGenericDeserializerGeneratorTest_shouldReadAliasedField), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadAliasedField;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadAliasedField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadAliasedField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadAliasedField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadEnumDefault_GenericDeserializer_693116719_1739184158.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadEnumDefault_GenericDeserializer_693116719_1739184158.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
@@ -58,13 +59,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnumDefault_GenericD
         this.enumMappingtestEnum3 = Collections.unmodifiableMap(tempEnumMapping3);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnumDefault0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnumDefault0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnumDefault0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnumDefault0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnumDefault;
@@ -86,12 +87,12 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnumDefault_GenericD
             }
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnumDefault.put(0, enumValue0);
-        populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault0((FastGenericDeserializerGeneratorTest_shouldReadEnumDefault), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault1((FastGenericDeserializerGeneratorTest_shouldReadEnumDefault), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault0((FastGenericDeserializerGeneratorTest_shouldReadEnumDefault), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault1((FastGenericDeserializerGeneratorTest_shouldReadEnumDefault), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadEnumDefault;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnumDefault, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnumDefault, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -151,7 +152,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnumDefault_GenericD
         FastGenericDeserializerGeneratorTest_shouldReadEnumDefault.put(2, testEnumArray1);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnumDefault, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnumDefault1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnumDefault, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericEnumSymbol> testEnumUnionArray1 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_695378847_695378847.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserializer_695378847_695378847.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -30,13 +31,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         this.testEnumUnionArrayArrayElemSchema0 = testEnumUnionArray0 .getElementType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadEnum0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum;
@@ -46,12 +47,12 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
             FastGenericDeserializerGeneratorTest_shouldReadEnum = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(0, new org.apache.avro.generic.GenericData.EnumSymbol(testEnum0, testEnum0 .getEnumSymbols().get((decoder.readEnum()))));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadEnum0((FastGenericDeserializerGeneratorTest_shouldReadEnum), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadEnum1((FastGenericDeserializerGeneratorTest_shouldReadEnum), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadEnum0((FastGenericDeserializerGeneratorTest_shouldReadEnum), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadEnum1((FastGenericDeserializerGeneratorTest_shouldReadEnum), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadEnum;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnum0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnum0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -87,7 +88,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadEnum_GenericDeserial
         FastGenericDeserializerGeneratorTest_shouldReadEnum.put(2, testEnumArray1);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnum1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadEnum1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadEnum, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericEnumSymbol> testEnumUnionArray1 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_1590965143_1590965143.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeserializer_1590965143_1590965143.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.GenericFixed;
@@ -30,13 +31,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         this.testFixedUnionArrayArrayElemSchema0 = testFixedUnionArray0 .getElementType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadFixed0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed;
@@ -54,12 +55,12 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         }
         decoder.readFixed(testFixed1);
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(0, new org.apache.avro.generic.GenericData.Fixed(testFixed0, testFixed1));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadFixed0((FastGenericDeserializerGeneratorTest_shouldReadFixed), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadFixed1((FastGenericDeserializerGeneratorTest_shouldReadFixed), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadFixed0((FastGenericDeserializerGeneratorTest_shouldReadFixed), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadFixed1((FastGenericDeserializerGeneratorTest_shouldReadFixed), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadFixed;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadFixed0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadFixed0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -115,7 +116,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadFixed_GenericDeseria
         FastGenericDeserializerGeneratorTest_shouldReadFixed.put(2, testFixedArray1);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadFixed1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadFixed1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadFixed, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray1 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_2643982_2643982.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_GenericDeserializer_2643982_2643982.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +25,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         this.subField0 = unionOptionSchema0 .getField("subField").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
@@ -45,7 +46,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
             FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, null);
         } else {
             if (unionIndex0 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion.get(0), (decoder), (customization)));
             } else {
                 if (unionIndex0 == 2) {
                     Utf8 charSequence1;
@@ -68,7 +69,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion_
         return FastGenericDeserializerGeneratorTest_shouldReadMultipleChoiceUnion;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_1870075541_1870075541.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDeserializer_1870075541_1870075541.java
@@ -2,11 +2,11 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -29,13 +29,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
         this.mapFieldValueMapValueSchema0 = mapFieldMapValueSchema0 .getValueType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadNestedMap0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadNestedMap;
@@ -47,33 +47,14 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
         Map<Utf8, Map<Utf8, List<Integer>>> mapField1 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, Map<Utf8, List<Integer>>> mapFieldReuse0 = null;
-            Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0);
-            if (oldMap0 instanceof Map) {
-                mapFieldReuse0 = ((Map) oldMap0);
-            }
-            if (mapFieldReuse0 != (null)) {
-                mapFieldReuse0 .clear();
-                mapField1 = mapFieldReuse0;
-            } else {
-                mapField1 = new HashMap<Utf8, Map<Utf8, List<Integer>>>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            mapField1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
                     Map<Utf8, List<Integer>> mapFieldValue0 = null;
                     long chunkLen1 = (decoder.readMapStart());
                     if (chunkLen1 > 0) {
-                        Map<Utf8, List<Integer>> mapFieldValueReuse0 = null;
-                        if (null instanceof Map) {
-                            mapFieldValueReuse0 = ((Map) null);
-                        }
-                        if (mapFieldValueReuse0 != (null)) {
-                            mapFieldValueReuse0 .clear();
-                            mapFieldValue0 = mapFieldValueReuse0;
-                        } else {
-                            mapFieldValue0 = new HashMap<Utf8, List<Integer>>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-                        }
+                        mapFieldValue0 = ((Map)(customization).getNewMapOverrideFunc().apply(null, ((int) chunkLen1)));
                         do {
                             for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                                 Utf8 key1 = (decoder.readString(null));
@@ -96,14 +77,14 @@ public class FastGenericDeserializerGeneratorTest_shouldReadNestedMap_GenericDes
                             chunkLen1 = (decoder.mapNext());
                         } while (chunkLen1 > 0);
                     } else {
-                        mapFieldValue0 = new HashMap<Utf8, List<Integer>>(0);
+                        mapFieldValue0 = ((Map)(customization).getNewMapOverrideFunc().apply(null, 0));
                     }
                     mapField1 .put(key0, mapFieldValue0);
                 }
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            mapField1 = new HashMap<Utf8, Map<Utf8, List<Integer>>>(0);
+            mapField1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadNestedMap.get(0), 0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadNestedMap.put(0, mapField1);
         return FastGenericDeserializerGeneratorTest_shouldReadNestedMap;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_611749105_646016208.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_GenericDeserializer_611749105_646016208.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
@@ -66,13 +67,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         this.enumMappingtestEnum3 = Collections.unmodifiableMap(tempEnumMapping3);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
@@ -94,12 +95,12 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
             }
         }
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(0, enumValue0);
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum1((FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0((FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum1((FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -159,7 +160,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum_Gener
         FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum.put(2, testEnumArray1);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPermutatedEnum, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericEnumSymbol> testEnumUnionArray1 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_1966544736_1966544736.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDeserializer_1966544736_1966544736.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -33,13 +34,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         this.testBytesUnion0 = readerSchema.getField("testBytesUnion").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadPrimitives0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
@@ -49,17 +50,17 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
             FastGenericDeserializerGeneratorTest_shouldReadPrimitives = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(0, (decoder.readInt()));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives0((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives1((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives2((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives3((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives4((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives5((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives6((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives0((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives1((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives2((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives3((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives4((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives5((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives6((FastGenericDeserializerGeneratorTest_shouldReadPrimitives), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadPrimitives;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -83,7 +84,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(2, charSequence0);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -107,7 +108,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(4, (decoder.readLong()));
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives2(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives2(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -124,7 +125,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(6, (decoder.readDouble()));
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives3(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives3(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -141,7 +142,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(8, (decoder.readFloat()));
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives4(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives4(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -158,7 +159,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(10, (decoder.readBoolean()));
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives5(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives5(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -182,7 +183,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadPrimitives_GenericDe
         FastGenericDeserializerGeneratorTest_shouldReadPrimitives.put(12, byteBuffer0);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives6(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadPrimitives6(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadPrimitives, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_1274815349_1365753944.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_1274815349_1365753944.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -32,13 +33,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
         this.recordArray0 = readerSchema.getField("recordArray").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
@@ -47,12 +48,12 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields), (decoder));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder), (customization)));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -83,10 +84,10 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
         return subRecord;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord1(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder), (customization)));
         List<IndexedRecord> recordArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
         Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
@@ -106,14 +107,14 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
                 if (oldArray0 instanceof GenericArray) {
                     recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
                 }
-                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+                recordArray1 .add(deserializesubRecord0(recordArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
     }
 
-    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord1(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -133,11 +134,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
                 throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex1));
             }
         }
-        populate_subRecord0((subRecord), (decoder));
+        populate_subRecord0((subRecord), (customization), (decoder));
         return subRecord;
     }
 
-    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord0(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_1365753944_1274815349.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields_GenericDeserializer_1365753944_1274815349.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -32,13 +33,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
         this.recordArray0 = readerSchema.getField("recordArray").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
@@ -47,12 +48,12 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
         } else {
             FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder)));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields), (decoder));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(0, deserializealiasedSubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(0), (decoder), (customization)));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0((FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields;
     }
 
-    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializealiasedSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord aliasedSubRecord;
@@ -71,11 +72,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
                 throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex0));
             }
         }
-        populate_aliasedSubRecord0((aliasedSubRecord), (decoder));
+        populate_aliasedSubRecord0((aliasedSubRecord), (customization), (decoder));
         return aliasedSubRecord;
     }
 
-    private void populate_aliasedSubRecord0(IndexedRecord aliasedSubRecord, Decoder decoder)
+    private void populate_aliasedSubRecord0(IndexedRecord aliasedSubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -98,10 +99,10 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(1), (decoder), (customization)));
         List<IndexedRecord> recordArray1 = null;
         long chunkLen0 = (decoder.readArrayStart());
         Object oldArray0 = FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.get(2);
@@ -121,14 +122,14 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
                 if (oldArray0 instanceof GenericArray) {
                     recordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
                 }
-                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder)));
+                recordArray1 .add(deserializealiasedSubRecord0(recordArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSubRecordFields.put(2, recordArray1);
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord aliasedSubRecord;
@@ -148,11 +149,11 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSplittedAndAliasedSu
                 throw new RuntimeException(("Illegal union index for 'intField': "+ unionIndex2));
             }
         }
-        populate_aliasedSubRecord1((aliasedSubRecord), (decoder));
+        populate_aliasedSubRecord1((aliasedSubRecord), (customization), (decoder));
         return aliasedSubRecord;
     }
 
-    private void populate_aliasedSubRecord1(IndexedRecord aliasedSubRecord, Decoder decoder)
+    private void populate_aliasedSubRecord1(IndexedRecord aliasedSubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_1602399407_1602399407.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField_GenericDeserializer_1602399407_1602399407.java
@@ -2,10 +2,10 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -42,13 +42,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         this.recordsMapUnionOptionMapValueSchema0 = recordsMapUnionOptionSchema0 .getValueType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
@@ -76,17 +76,17 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 if (oldArray0 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
                 }
-                recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray1 .add(deserializesubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(0, recordsArray1);
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField1((FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0((FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField1((FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -116,32 +116,22 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         return subRecord;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, IndexedRecord> recordsMap1 = null;
         long chunkLen1 = (decoder.readMapStart());
         if (chunkLen1 > 0) {
-            Map<Utf8, IndexedRecord> recordsMapReuse0 = null;
-            Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap1 = recordsMapReuse0;
-            } else {
-                recordsMap1 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-            }
+            recordsMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1), ((int) chunkLen1)));
             do {
                 for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    recordsMap1 .put(key0, deserializesubRecord0(null, (decoder)));
+                    recordsMap1 .put(key0, deserializesubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen1 = (decoder.mapNext());
             } while (chunkLen1 > 0);
         } else {
-            recordsMap1 = new HashMap<Utf8, IndexedRecord>(0);
+            recordsMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(1), 0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(1, recordsMap1);
         int unionIndex1 = (decoder.readIndex());
@@ -175,7 +165,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex2 == 1) {
-                                recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializesubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex2));
                             }
@@ -190,7 +180,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -202,17 +192,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                 Map<Utf8, IndexedRecord> recordsMapUnionOption0 = null;
                 long chunkLen3 = (decoder.readMapStart());
                 if (chunkLen3 > 0) {
-                    Map<Utf8, IndexedRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen3 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3), ((int) chunkLen3)));
                     do {
                         for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
                             Utf8 key1 = (decoder.readString(null));
@@ -222,7 +202,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                                 recordsMapUnionOption0 .put(key1, null);
                             } else {
                                 if (unionIndex4 == 1) {
-                                    recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key1, deserializesubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex4));
                                 }
@@ -231,7 +211,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollections
                         chunkLen3 = (decoder.mapNext());
                     } while (chunkLen3 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.get(3), 0));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordCollectionsField.put(3, recordsMapUnionOption0);
             } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_624658481_624658481.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField_GenericDeserializer_624658481_624658481.java
@@ -2,10 +2,10 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -50,13 +50,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         this.recordsMapArrayUnionOptionValueArrayElemSchema0 = recordsMapArrayMapValueSchema0 .getElementType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
@@ -87,16 +87,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 Map<Utf8, IndexedRecord> recordsArrayMapElem0 = null;
                 long chunkLen1 = (decoder.readMapStart());
                 if (chunkLen1 > 0) {
-                    Map<Utf8, IndexedRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen1)));
                     do {
                         for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -106,7 +97,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                 recordsArrayMapElem0 .put(key0, null);
                             } else {
                                 if (unionIndex0 == 1) {
-                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key0, deserializesubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex0));
                                 }
@@ -115,19 +106,19 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                         chunkLen1 = (decoder.mapNext());
                     } while (chunkLen1 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, IndexedRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap1 .add(recordsArrayMapElem0);
             }
             chunkLen0 = (decoder.arrayNext());
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(0, recordsArrayMap1);
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField1((FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0((FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField1((FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -157,23 +148,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         return subRecord;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, List<IndexedRecord>> recordsMapArray1 = null;
         long chunkLen2 = (decoder.readMapStart());
         if (chunkLen2 > 0) {
-            Map<Utf8, List<IndexedRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1);
-            if (oldMap0 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray1 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray1 = new HashMap<Utf8, List<IndexedRecord>>(((int)(((chunkLen2 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1), ((int) chunkLen2)));
             do {
                 for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                     Utf8 key1 = (decoder.readString(null));
@@ -201,7 +182,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex2 == 1) {
-                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializesubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex2));
                                 }
@@ -214,7 +195,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 chunkLen2 = (decoder.mapNext());
             } while (chunkLen2 > 0);
         } else {
-            recordsMapArray1 = new HashMap<Utf8, List<IndexedRecord>>(0);
+            recordsMapArray1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(1), 0));
         }
         FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(1, recordsMapArray1);
         int unionIndex3 = (decoder.readIndex());
@@ -245,16 +226,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                         Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen5 = (decoder.readMapStart());
                         if (chunkLen5 > 0) {
-                            Map<Utf8, IndexedRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen5 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen5)));
                             do {
                                 for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
                                     Utf8 key2 = (decoder.readString(null));
@@ -264,7 +236,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                         recordsArrayMapUnionOptionElem0 .put(key2, null);
                                     } else {
                                         if (unionIndex4 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key2, deserializesubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex4));
                                         }
@@ -273,7 +245,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                 chunkLen5 = (decoder.mapNext());
                             } while (chunkLen5 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, IndexedRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -286,7 +258,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -298,17 +270,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                 Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen6 = (decoder.readMapStart());
                 if (chunkLen6 > 0) {
-                    Map<Utf8, List<IndexedRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap1 = FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<IndexedRecord>>(((int)(((chunkLen6 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3), ((int) chunkLen6)));
                     do {
                         for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
                             Utf8 key3 = (decoder.readString(null));
@@ -336,7 +298,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex6 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializesubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex6));
                                         }
@@ -349,7 +311,7 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexColl
                         chunkLen6 = (decoder.mapNext());
                     } while (chunkLen6 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<IndexedRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.get(3), 0));
                 }
                 FastGenericDeserializerGeneratorTest_shouldReadSubRecordComplexCollectionsField.put(3, recordsMapArrayUnionOption0);
             } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1111917046_1111917046.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_GenericDeserializer_1111917046_1111917046.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -26,13 +27,13 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         this.field0 = readerSchema.getField("field").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
@@ -47,16 +48,16 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
             FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, null);
         } else {
             if (unionIndex0 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(0), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'record': "+ unionIndex0));
             }
         }
-        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((FastGenericDeserializerGeneratorTest_shouldReadSubRecordField), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordField0((FastGenericDeserializerGeneratorTest_shouldReadSubRecordField), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldReadSubRecordField;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -86,10 +87,10 @@ public class FastGenericDeserializerGeneratorTest_shouldReadSubRecordField_Gener
         return subRecord;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldReadSubRecordField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldReadSubRecordField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldReadSubRecordField.get(1), (decoder), (customization)));
         int unionIndex2 = (decoder.readIndex());
         if (unionIndex2 == 0) {
             decoder.readNull();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_1830076637_292632696.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_GenericDeserializer_1830076637_292632696.java
@@ -2,10 +2,10 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -38,13 +38,13 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         this.subRecordArray0 = readerSchema.getField("subRecordArray").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
@@ -71,13 +71,13 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 throw new RuntimeException(("Illegal union index for 'testNotRemoved': "+ unionIndex0));
             }
         }
-        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((FastGenericDeserializerGeneratorTest_shouldSkipRemovedField), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField1((FastGenericDeserializerGeneratorTest_shouldSkipRemovedField), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField2((FastGenericDeserializerGeneratorTest_shouldSkipRemovedField), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField0((FastGenericDeserializerGeneratorTest_shouldSkipRemovedField), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField1((FastGenericDeserializerGeneratorTest_shouldSkipRemovedField), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField2((FastGenericDeserializerGeneratorTest_shouldSkipRemovedField), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedField;
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -110,7 +110,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -119,7 +119,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, null);
         } else {
             if (unionIndex3 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(2, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(2), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex3));
             }
@@ -127,31 +127,21 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         Map<Utf8, IndexedRecord> subRecordMap1 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, IndexedRecord> subRecordMapReuse0 = null;
-            Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3);
-            if (oldMap0 instanceof Map) {
-                subRecordMapReuse0 = ((Map) oldMap0);
-            }
-            if (subRecordMapReuse0 != (null)) {
-                subRecordMapReuse0 .clear();
-                subRecordMap1 = subRecordMapReuse0;
-            } else {
-                subRecordMap1 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            subRecordMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    subRecordMap1 .put(key0, deserializesubRecord0(null, (decoder)));
+                    subRecordMap1 .put(key0, deserializesubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            subRecordMap1 = new HashMap<Utf8, IndexedRecord>(0);
+            subRecordMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.get(3), 0));
         }
         FastGenericDeserializerGeneratorTest_shouldSkipRemovedField.put(3, subRecordMap1);
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -178,11 +168,11 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 throw new RuntimeException(("Illegal union index for 'testNotRemoved': "+ unionIndex4));
             }
         }
-        populate_subRecord0((subRecord), (decoder));
+        populate_subRecord0((subRecord), (customization), (decoder));
         return subRecord;
     }
 
-    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord0(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -215,7 +205,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
         }
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField2(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedField2(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedField, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<IndexedRecord> subRecordArray1 = null;
@@ -237,7 +227,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedField_Generic
                 if (oldArray0 instanceof GenericArray) {
                     subRecordArrayArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
                 }
-                subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder)));
+                subRecordArray1 .add(deserializesubRecord0(subRecordArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen1 = (decoder.arrayNext());
         }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1090641932_438987109.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1090641932_438987109.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         this.subRecord0 = readerSchema.getField("subRecord").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
@@ -35,11 +36,11 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord.get(0), (decoder), (customization)));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -56,28 +57,28 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
             charSequence0 = (decoder).readString(null);
         }
         subRecord.put(0, charSequence0);
-        populate_subRecord0((subRecord), (decoder));
-        populate_subRecord1((subRecord), (decoder));
+        populate_subRecord0((subRecord), (customization), (decoder));
+        populate_subRecord1((subRecord), (customization), (decoder));
         return subRecord;
     }
 
-    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord0(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        deserializesubSubRecord0(null, (decoder));
+        deserializesubSubRecord0(null, (decoder), (customization));
         int unionIndex0 = (decoder.readIndex());
         if (unionIndex0 == 0) {
             decoder.readNull();
         } else {
             if (unionIndex0 == 1) {
-                deserializesubSubRecord0(null, (decoder));
+                deserializesubSubRecord0(null, (decoder), (customization));
             } else {
                 throw new RuntimeException(("Illegal union index for 'test3': "+ unionIndex0));
             }
         }
     }
 
-    public void deserializesubSubRecord0(Object reuse, Decoder decoder)
+    public void deserializesubSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         decoder.skipString();
@@ -90,7 +91,7 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         decoder.skipString();
     }
 
-    private void populate_subRecord1(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord1(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Utf8 charSequence1;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_1932590611_1452595291.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_1932590611_1452595291.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         this.subRecord10 = readerSchema.getField("subRecord1").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
@@ -35,13 +36,13 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         } else {
             FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder)));
-        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord), (decoder));
-        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1((FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord), (decoder));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(0, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(0), (decoder), (customization)));
+        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0((FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord), (customization), (decoder));
+        populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1((FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord), (customization), (decoder));
         return FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -58,11 +59,11 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
             charSequence0 = (decoder).readString(null);
         }
         subRecord.put(0, charSequence0);
-        populate_subRecord0((subRecord), (decoder));
+        populate_subRecord0((subRecord), (customization), (decoder));
         return subRecord;
     }
 
-    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord0(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Utf8 charSequence1;
@@ -75,23 +76,23 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         subRecord.put(1, charSequence1);
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord0(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        deserializesubRecord20(null, (decoder));
+        deserializesubRecord20(null, (decoder), (customization));
         int unionIndex0 = (decoder.readIndex());
         if (unionIndex0 == 0) {
             decoder.readNull();
         } else {
             if (unionIndex0 == 1) {
-                deserializesubRecord20(null, (decoder));
+                deserializesubRecord20(null, (decoder), (customization));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecord3': "+ unionIndex0));
             }
         }
     }
 
-    public void deserializesubRecord20(Object reuse, Decoder decoder)
+    public void deserializesubRecord20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         decoder.skipString();
@@ -104,10 +105,10 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         decoder.skipString();
     }
 
-    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord, Decoder decoder)
+    private void populate_FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord1(IndexedRecord FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder)));
+        FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.put(1, deserializesubRecord0(FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord.get(1), (decoder), (customization)));
     }
 
 }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_1186244769_1186244769.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_1186244769_1186244769.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_1186244769_367446918.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_1186244769_367446918.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_367446918_1186244769.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_367446918_1186244769.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -21,13 +22,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_367446918_367446918.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType_GenericDeserializer_367446918_367446918.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanill
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateOrFailLikeVanillaAvroWhenTheReaderUnionIsMissingAType;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1986844009_1986844009.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1986844009_1986844009.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1986844009_611693319.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_1986844009_611693319.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_611693319_1986844009.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_611693319_1986844009.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_611693319_611693319.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString_GenericDeserializer_611693319_611693319.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingT
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingThatIncludeString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_1778260273_1778260273.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_1778260273_1778260273.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(0);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_1778260273_906204958.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_1778260273_906204958.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_906204958_1778260273.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_906204958_1778260273.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(0);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_906204958_906204958.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays_GenericDeserializer_906204958_906204958.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithArrays;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_2127585735_2127585735.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_2127585735_2127585735.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(0);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
@@ -44,17 +44,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
             Map<Utf8, Integer> testOption0 = null;
             long chunkLen0 = (decoder.readMapStart());
             if (chunkLen0 > 0) {
-                Map<Utf8, Integer> testOptionReuse0 = null;
-                Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0);
-                if (oldMap0 instanceof Map) {
-                    testOptionReuse0 = ((Map) oldMap0);
-                }
-                if (testOptionReuse0 != (null)) {
-                    testOptionReuse0 .clear();
-                    testOption0 = testOptionReuse0;
-                } else {
-                    testOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                }
+                testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), ((int) chunkLen0)));
                 do {
                     for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                         Utf8 key0 = (decoder.readString(null));
@@ -63,7 +53,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                     chunkLen0 = (decoder.mapNext());
                 } while (chunkLen0 > 0);
             } else {
-                testOption0 = new HashMap<Utf8, Integer>(0);
+                testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), 0));
             }
             FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.put(0, testOption0);
         } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_2127585735_539246803.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_2127585735_539246803.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
@@ -44,17 +44,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
             Map<Utf8, Integer> testOption0 = null;
             long chunkLen0 = (decoder.readMapStart());
             if (chunkLen0 > 0) {
-                Map<Utf8, Integer> testOptionReuse0 = null;
-                Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0);
-                if (oldMap0 instanceof Map) {
-                    testOptionReuse0 = ((Map) oldMap0);
-                }
-                if (testOptionReuse0 != (null)) {
-                    testOptionReuse0 .clear();
-                    testOption0 = testOptionReuse0;
-                } else {
-                    testOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                }
+                testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), ((int) chunkLen0)));
                 do {
                     for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                         Utf8 key0 = (decoder.readString(null));
@@ -63,7 +53,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                     chunkLen0 = (decoder.mapNext());
                 } while (chunkLen0 > 0);
             } else {
-                testOption0 = new HashMap<Utf8, Integer>(0);
+                testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), 0));
             }
             FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.put(0, testOption0);
         } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_539246803_2127585735.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_539246803_2127585735.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(0);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
@@ -48,17 +48,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 Map<Utf8, Integer> testOption0 = null;
                 long chunkLen0 = (decoder.readMapStart());
                 if (chunkLen0 > 0) {
-                    Map<Utf8, Integer> testOptionReuse0 = null;
-                    Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0);
-                    if (oldMap0 instanceof Map) {
-                        testOptionReuse0 = ((Map) oldMap0);
-                    }
-                    if (testOptionReuse0 != (null)) {
-                        testOptionReuse0 .clear();
-                        testOption0 = testOptionReuse0;
-                    } else {
-                        testOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                    }
+                    testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), ((int) chunkLen0)));
                     do {
                         for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -67,7 +57,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                         chunkLen0 = (decoder.mapNext());
                     } while (chunkLen0 > 0);
                 } else {
-                    testOption0 = new HashMap<Utf8, Integer>(0);
+                    testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), 0));
                 }
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.put(0, testOption0);
             } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_539246803_539246803.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps_GenericDeserializer_539246803_539246803.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema0 = test0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps;
@@ -48,17 +48,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                 Map<Utf8, Integer> testOption0 = null;
                 long chunkLen0 = (decoder.readMapStart());
                 if (chunkLen0 > 0) {
-                    Map<Utf8, Integer> testOptionReuse0 = null;
-                    Object oldMap0 = FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0);
-                    if (oldMap0 instanceof Map) {
-                        testOptionReuse0 = ((Map) oldMap0);
-                    }
-                    if (testOptionReuse0 != (null)) {
-                        testOptionReuse0 .clear();
-                        testOption0 = testOptionReuse0;
-                    } else {
-                        testOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                    }
+                    testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), ((int) chunkLen0)));
                     do {
                         for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -67,7 +57,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
                         chunkLen0 = (decoder.mapNext());
                     } while (chunkLen0 > 0);
                 } else {
-                    testOption0 = new HashMap<Utf8, Integer>(0);
+                    testOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.get(0), 0));
                 }
                 FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithMaps.put(0, testOption0);
             } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_1284646643_1284646643.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_1284646643_1284646643.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_1284646643_616931169.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_1284646643_616931169.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_616931169_1284646643.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_616931169_1284646643.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_616931169_616931169.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString_GenericDeserializer_616931169_616931169.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.test0 = readerSchema.getField("test").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithNonString;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_524692447_524692447.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_524692447_524692447.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema1 = test0 .getTypes().get(2);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
@@ -44,10 +45,10 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
             FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, null);
         } else {
             if (unionIndex0 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
             } else {
                 if (unionIndex0 == 2) {
-                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
                 } else {
                     throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
                 }
@@ -56,7 +57,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }
 
-    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord1;
@@ -69,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return subRecord1;
     }
 
-    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord2;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_524692447_963368136.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_524692447_963368136.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema1 = test0 .getTypes().get(0);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
@@ -44,10 +45,10 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
             FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, null);
         } else {
             if (unionIndex0 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
             } else {
                 if (unionIndex0 == 2) {
-                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+                    FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
                 } else {
                     throw new RuntimeException(("Illegal union index for 'test': "+ unionIndex0));
                 }
@@ -56,7 +57,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }
 
-    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord1;
@@ -69,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return subRecord1;
     }
 
-    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord2;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_963368136_524692447.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_963368136_524692447.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema1 = test0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
@@ -40,10 +41,10 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         }
         int unionIndex0 = (decoder.readIndex());
         if (unionIndex0 == 0) {
-            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
         } else {
             if (unionIndex0 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
             } else {
                 if (unionIndex0 == 2) {
                     decoder.readNull();
@@ -56,7 +57,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }
 
-    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord2;
@@ -69,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return subRecord2;
     }
 
-    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord1;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_963368136_963368136.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords_GenericDeserializer_963368136_963368136.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -23,13 +24,13 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         this.testOptionSchema1 = test0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder));
+        return deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
@@ -40,10 +41,10 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         }
         int unionIndex0 = (decoder.readIndex());
         if (unionIndex0 == 0) {
-            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+            FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord20(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
         } else {
             if (unionIndex0 == 1) {
-                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder)));
+                FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.put(0, deserializesubRecord10(FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords.get(0), (decoder), (customization)));
             } else {
                 if (unionIndex0 == 2) {
                     decoder.readNull();
@@ -56,7 +57,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingWithSubRecords;
     }
 
-    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord2;
@@ -69,7 +70,7 @@ public class FastGenericDeserializerGeneratorTest_shouldTolerateUnionReorderingW
         return subRecord2;
     }
 
-    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord1;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesDefined_GenericDeserializer_229156053_229156053.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesDefined_GenericDeserializer_229156053_229156053.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
@@ -41,13 +42,13 @@ public class FastSerdeLogicalTypesDefined_GenericDeserializer_229156053_22915605
         this.arrayOfUnionOfDateAndTimestampMillisElemOptionSchema1 = arrayOfUnionOfDateAndTimestampMillisArrayElemSchema0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastSerdeLogicalTypesDefined0((reuse), (decoder));
+        return deserializeFastSerdeLogicalTypesDefined0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastSerdeLogicalTypesDefined0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastSerdeLogicalTypesDefined0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastSerdeLogicalTypesDefined;
@@ -58,11 +59,11 @@ public class FastSerdeLogicalTypesDefined_GenericDeserializer_229156053_22915605
         }
         LocalTime convertedValue0 = ((LocalTime) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__419105534, this.logicalTypeSchema__419105534 .getLogicalType(), this.conversion_time_millis));
         FastSerdeLogicalTypesDefined.put(0, convertedValue0);
-        populate_FastSerdeLogicalTypesDefined0((FastSerdeLogicalTypesDefined), (decoder));
+        populate_FastSerdeLogicalTypesDefined0((FastSerdeLogicalTypesDefined), (customization), (decoder));
         return FastSerdeLogicalTypesDefined;
     }
 
-    private void populate_FastSerdeLogicalTypesDefined0(IndexedRecord FastSerdeLogicalTypesDefined, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesDefined0(IndexedRecord FastSerdeLogicalTypesDefined, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         LocalDate convertedValue1 = ((LocalDate) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesDefined_SpecificDeserializer_229156053_229156053.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesDefined_SpecificDeserializer_229156053_229156053.java
@@ -8,6 +8,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
@@ -29,13 +30,13 @@ public class FastSerdeLogicalTypesDefined_SpecificDeserializer_229156053_2291560
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined deserialize(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined deserialize(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastSerdeLogicalTypesDefined0((reuse), (decoder));
+        return deserializeFastSerdeLogicalTypesDefined0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined deserializeFastSerdeLogicalTypesDefined0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined deserializeFastSerdeLogicalTypesDefined0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined FastSerdeLogicalTypesDefined;
@@ -46,11 +47,11 @@ public class FastSerdeLogicalTypesDefined_SpecificDeserializer_229156053_2291560
         }
         LocalTime convertedValue0 = ((LocalTime) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__419105534, this.logicalTypeSchema__419105534 .getLogicalType(), this.conversion_time_millis));
         FastSerdeLogicalTypesDefined.put(0, convertedValue0);
-        populate_FastSerdeLogicalTypesDefined0((FastSerdeLogicalTypesDefined), (decoder));
+        populate_FastSerdeLogicalTypesDefined0((FastSerdeLogicalTypesDefined), (customization), (decoder));
         return FastSerdeLogicalTypesDefined;
     }
 
-    private void populate_FastSerdeLogicalTypesDefined0(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined FastSerdeLogicalTypesDefined, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesDefined0(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined FastSerdeLogicalTypesDefined, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         LocalDate convertedValue1 = ((LocalDate) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_1007574890.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_1007574890.java
@@ -8,11 +8,11 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -113,13 +113,13 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         this.unionOfDateAndLocalTimestampOptionSchema1 = unionOfDateAndLocalTimestamp0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastSerdeLogicalTypesTest10((reuse), (decoder));
+        return deserializeFastSerdeLogicalTypesTest10((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastSerdeLogicalTypesTest10(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastSerdeLogicalTypesTest10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastSerdeLogicalTypesTest1;
@@ -152,17 +152,7 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
                 Map<Utf8, LocalDate> unionOfArrayAndMapOption1 = null;
                 long chunkLen1 = (decoder.readMapStart());
                 if (chunkLen1 > 0) {
-                    Map<Utf8, LocalDate> unionOfArrayAndMapOptionReuse0 = null;
-                    Object oldMap0 = FastSerdeLogicalTypesTest1 .get(0);
-                    if (oldMap0 instanceof Map) {
-                        unionOfArrayAndMapOptionReuse0 = ((Map) oldMap0);
-                    }
-                    if (unionOfArrayAndMapOptionReuse0 != (null)) {
-                        unionOfArrayAndMapOptionReuse0 .clear();
-                        unionOfArrayAndMapOption1 = unionOfArrayAndMapOptionReuse0;
-                    } else {
-                        unionOfArrayAndMapOption1 = new HashMap<Utf8, LocalDate>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-                    }
+                    unionOfArrayAndMapOption1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(0), ((int) chunkLen1)));
                     do {
                         for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -172,39 +162,29 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
                         chunkLen1 = (decoder.mapNext());
                     } while (chunkLen1 > 0);
                 } else {
-                    unionOfArrayAndMapOption1 = new HashMap<Utf8, LocalDate>(0);
+                    unionOfArrayAndMapOption1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(0), 0));
                 }
                 FastSerdeLogicalTypesTest1 .put(0, unionOfArrayAndMapOption1);
             } else {
                 throw new RuntimeException(("Illegal union index for 'unionOfArrayAndMap': "+ unionIndex0));
             }
         }
-        populate_FastSerdeLogicalTypesTest10((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest11((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest12((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest13((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest14((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest15((FastSerdeLogicalTypesTest1), (decoder));
+        populate_FastSerdeLogicalTypesTest10((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest11((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest12((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest13((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest14((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest15((FastSerdeLogicalTypesTest1), (customization), (decoder));
         return FastSerdeLogicalTypesTest1;
     }
 
-    private void populate_FastSerdeLogicalTypesTest10(IndexedRecord FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest10(IndexedRecord FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, Object> mapOfUnionsOfDateAndTimestampMillis1 = null;
         long chunkLen2 = (decoder.readMapStart());
         if (chunkLen2 > 0) {
-            Map<Utf8, Object> mapOfUnionsOfDateAndTimestampMillisReuse0 = null;
-            Object oldMap1 = FastSerdeLogicalTypesTest1 .get(1);
-            if (oldMap1 instanceof Map) {
-                mapOfUnionsOfDateAndTimestampMillisReuse0 = ((Map) oldMap1);
-            }
-            if (mapOfUnionsOfDateAndTimestampMillisReuse0 != (null)) {
-                mapOfUnionsOfDateAndTimestampMillisReuse0 .clear();
-                mapOfUnionsOfDateAndTimestampMillis1 = mapOfUnionsOfDateAndTimestampMillisReuse0;
-            } else {
-                mapOfUnionsOfDateAndTimestampMillis1 = new HashMap<Utf8, Object>(((int)(((chunkLen2 * 4)+ 2)/ 3)));
-            }
+            mapOfUnionsOfDateAndTimestampMillis1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(1), ((int) chunkLen2)));
             do {
                 for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                     Utf8 key1 = (decoder.readString(null));
@@ -224,23 +204,13 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
                 chunkLen2 = (decoder.mapNext());
             } while (chunkLen2 > 0);
         } else {
-            mapOfUnionsOfDateAndTimestampMillis1 = new HashMap<Utf8, Object>(0);
+            mapOfUnionsOfDateAndTimestampMillis1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(1), 0));
         }
         FastSerdeLogicalTypesTest1 .put(1, mapOfUnionsOfDateAndTimestampMillis1);
         Map<Utf8, Instant> timestampMillisMap1 = null;
         long chunkLen3 = (decoder.readMapStart());
         if (chunkLen3 > 0) {
-            Map<Utf8, Instant> timestampMillisMapReuse0 = null;
-            Object oldMap2 = FastSerdeLogicalTypesTest1 .get(2);
-            if (oldMap2 instanceof Map) {
-                timestampMillisMapReuse0 = ((Map) oldMap2);
-            }
-            if (timestampMillisMapReuse0 != (null)) {
-                timestampMillisMapReuse0 .clear();
-                timestampMillisMap1 = timestampMillisMapReuse0;
-            } else {
-                timestampMillisMap1 = new HashMap<Utf8, Instant>(((int)(((chunkLen3 * 4)+ 2)/ 3)));
-            }
+            timestampMillisMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(2), ((int) chunkLen3)));
             do {
                 for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
                     Utf8 key2 = (decoder.readString(null));
@@ -250,12 +220,12 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
                 chunkLen3 = (decoder.mapNext());
             } while (chunkLen3 > 0);
         } else {
-            timestampMillisMap1 = new HashMap<Utf8, Instant>(0);
+            timestampMillisMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(2), 0));
         }
         FastSerdeLogicalTypesTest1 .put(2, timestampMillisMap1);
     }
 
-    private void populate_FastSerdeLogicalTypesTest11(IndexedRecord FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest11(IndexedRecord FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -304,7 +274,7 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         FastSerdeLogicalTypesTest1 .put(4, arrayOfDates0);
     }
 
-    private void populate_FastSerdeLogicalTypesTest12(IndexedRecord FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest12(IndexedRecord FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -337,7 +307,7 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         FastSerdeLogicalTypesTest1 .put(6, convertedValue9);
     }
 
-    private void populate_FastSerdeLogicalTypesTest13(IndexedRecord FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest13(IndexedRecord FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Instant convertedValue10 = ((Instant) Conversions.convertToLogicalType((decoder.readLong()), this.logicalTypeSchema_1074306973, this.logicalTypeSchema_1074306973 .getLogicalType(), this.conversion_timestamp_millis));
@@ -346,7 +316,7 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         FastSerdeLogicalTypesTest1 .put(8, convertedValue11);
     }
 
-    private void populate_FastSerdeLogicalTypesTest14(IndexedRecord FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest14(IndexedRecord FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         LocalTime convertedValue12 = ((LocalTime) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__419105534, this.logicalTypeSchema__419105534 .getLogicalType(), this.conversion_time_millis));
@@ -355,15 +325,15 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         FastSerdeLogicalTypesTest1 .put(10, convertedValue13);
     }
 
-    private void populate_FastSerdeLogicalTypesTest15(IndexedRecord FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest15(IndexedRecord FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         LocalDate convertedValue14 = ((LocalDate) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date));
         FastSerdeLogicalTypesTest1 .put(11, convertedValue14);
-        FastSerdeLogicalTypesTest1 .put(12, deserializeLocalTimestampRecord0(FastSerdeLogicalTypesTest1 .get(12), (decoder)));
+        FastSerdeLogicalTypesTest1 .put(12, deserializeLocalTimestampRecord0(FastSerdeLogicalTypesTest1 .get(12), (decoder), (customization)));
     }
 
-    public IndexedRecord deserializeLocalTimestampRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeLocalTimestampRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord LocalTimestampRecord;
@@ -374,12 +344,12 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         }
         LocalDateTime convertedValue15 = ((LocalDateTime) Conversions.convertToLogicalType((decoder.readLong()), this.logicalTypeSchema__250645780, this.logicalTypeSchema__250645780 .getLogicalType(), this.conversion_local_timestamp_millis));
         LocalTimestampRecord.put(0, convertedValue15);
-        populate_LocalTimestampRecord0((LocalTimestampRecord), (decoder));
-        populate_LocalTimestampRecord1((LocalTimestampRecord), (decoder));
+        populate_LocalTimestampRecord0((LocalTimestampRecord), (customization), (decoder));
+        populate_LocalTimestampRecord1((LocalTimestampRecord), (customization), (decoder));
         return LocalTimestampRecord;
     }
 
-    private void populate_LocalTimestampRecord0(IndexedRecord LocalTimestampRecord, Decoder decoder)
+    private void populate_LocalTimestampRecord0(IndexedRecord LocalTimestampRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -413,7 +383,7 @@ public class FastSerdeLogicalTypesTest1_GenericDeserializer_1007574890_100757489
         }
     }
 
-    private void populate_LocalTimestampRecord1(IndexedRecord LocalTimestampRecord, Decoder decoder)
+    private void populate_LocalTimestampRecord1(IndexedRecord LocalTimestampRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_1007574890.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_1007574890.java
@@ -9,11 +9,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -45,13 +45,13 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastSerdeLogicalTypesTest10((reuse), (decoder));
+        return deserializeFastSerdeLogicalTypesTest10((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 deserializeFastSerdeLogicalTypesTest10(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 deserializeFastSerdeLogicalTypesTest10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1;
@@ -84,17 +84,7 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
                 Map<Utf8, LocalDate> unionOfArrayAndMapOption1 = null;
                 long chunkLen1 = (decoder.readMapStart());
                 if (chunkLen1 > 0) {
-                    Map<Utf8, LocalDate> unionOfArrayAndMapOptionReuse0 = null;
-                    Object oldMap0 = FastSerdeLogicalTypesTest1 .get(0);
-                    if (oldMap0 instanceof Map) {
-                        unionOfArrayAndMapOptionReuse0 = ((Map) oldMap0);
-                    }
-                    if (unionOfArrayAndMapOptionReuse0 != (null)) {
-                        unionOfArrayAndMapOptionReuse0 .clear();
-                        unionOfArrayAndMapOption1 = unionOfArrayAndMapOptionReuse0;
-                    } else {
-                        unionOfArrayAndMapOption1 = new HashMap<Utf8, LocalDate>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-                    }
+                    unionOfArrayAndMapOption1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(0), ((int) chunkLen1)));
                     do {
                         for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -104,39 +94,29 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
                         chunkLen1 = (decoder.mapNext());
                     } while (chunkLen1 > 0);
                 } else {
-                    unionOfArrayAndMapOption1 = new HashMap<Utf8, LocalDate>(0);
+                    unionOfArrayAndMapOption1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(0), 0));
                 }
                 FastSerdeLogicalTypesTest1 .put(0, unionOfArrayAndMapOption1);
             } else {
                 throw new RuntimeException(("Illegal union index for 'unionOfArrayAndMap': "+ unionIndex0));
             }
         }
-        populate_FastSerdeLogicalTypesTest10((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest11((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest12((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest13((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest14((FastSerdeLogicalTypesTest1), (decoder));
-        populate_FastSerdeLogicalTypesTest15((FastSerdeLogicalTypesTest1), (decoder));
+        populate_FastSerdeLogicalTypesTest10((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest11((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest12((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest13((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest14((FastSerdeLogicalTypesTest1), (customization), (decoder));
+        populate_FastSerdeLogicalTypesTest15((FastSerdeLogicalTypesTest1), (customization), (decoder));
         return FastSerdeLogicalTypesTest1;
     }
 
-    private void populate_FastSerdeLogicalTypesTest10(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest10(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, Object> mapOfUnionsOfDateAndTimestampMillis0 = null;
         long chunkLen2 = (decoder.readMapStart());
         if (chunkLen2 > 0) {
-            Map<Utf8, Object> mapOfUnionsOfDateAndTimestampMillisReuse0 = null;
-            Object oldMap1 = FastSerdeLogicalTypesTest1 .get(1);
-            if (oldMap1 instanceof Map) {
-                mapOfUnionsOfDateAndTimestampMillisReuse0 = ((Map) oldMap1);
-            }
-            if (mapOfUnionsOfDateAndTimestampMillisReuse0 != (null)) {
-                mapOfUnionsOfDateAndTimestampMillisReuse0 .clear();
-                mapOfUnionsOfDateAndTimestampMillis0 = mapOfUnionsOfDateAndTimestampMillisReuse0;
-            } else {
-                mapOfUnionsOfDateAndTimestampMillis0 = new HashMap<Utf8, Object>(((int)(((chunkLen2 * 4)+ 2)/ 3)));
-            }
+            mapOfUnionsOfDateAndTimestampMillis0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(1), ((int) chunkLen2)));
             do {
                 for (int counter2 = 0; (counter2 <chunkLen2); counter2 ++) {
                     Utf8 key1 = (decoder.readString(null));
@@ -156,23 +136,13 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
                 chunkLen2 = (decoder.mapNext());
             } while (chunkLen2 > 0);
         } else {
-            mapOfUnionsOfDateAndTimestampMillis0 = new HashMap<Utf8, Object>(0);
+            mapOfUnionsOfDateAndTimestampMillis0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(1), 0));
         }
         FastSerdeLogicalTypesTest1 .put(1, mapOfUnionsOfDateAndTimestampMillis0);
         Map<Utf8, Instant> timestampMillisMap0 = null;
         long chunkLen3 = (decoder.readMapStart());
         if (chunkLen3 > 0) {
-            Map<Utf8, Instant> timestampMillisMapReuse0 = null;
-            Object oldMap2 = FastSerdeLogicalTypesTest1 .get(2);
-            if (oldMap2 instanceof Map) {
-                timestampMillisMapReuse0 = ((Map) oldMap2);
-            }
-            if (timestampMillisMapReuse0 != (null)) {
-                timestampMillisMapReuse0 .clear();
-                timestampMillisMap0 = timestampMillisMapReuse0;
-            } else {
-                timestampMillisMap0 = new HashMap<Utf8, Instant>(((int)(((chunkLen3 * 4)+ 2)/ 3)));
-            }
+            timestampMillisMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(2), ((int) chunkLen3)));
             do {
                 for (int counter3 = 0; (counter3 <chunkLen3); counter3 ++) {
                     Utf8 key2 = (decoder.readString(null));
@@ -182,12 +152,12 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
                 chunkLen3 = (decoder.mapNext());
             } while (chunkLen3 > 0);
         } else {
-            timestampMillisMap0 = new HashMap<Utf8, Instant>(0);
+            timestampMillisMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(FastSerdeLogicalTypesTest1 .get(2), 0));
         }
         FastSerdeLogicalTypesTest1 .put(2, timestampMillisMap0);
     }
 
-    private void populate_FastSerdeLogicalTypesTest11(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest11(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -236,7 +206,7 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         FastSerdeLogicalTypesTest1 .put(4, arrayOfDates0);
     }
 
-    private void populate_FastSerdeLogicalTypesTest12(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest12(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -269,7 +239,7 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         FastSerdeLogicalTypesTest1 .put(6, convertedValue9);
     }
 
-    private void populate_FastSerdeLogicalTypesTest13(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest13(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Instant convertedValue10 = ((Instant) Conversions.convertToLogicalType((decoder.readLong()), this.logicalTypeSchema_1074306973, this.logicalTypeSchema_1074306973 .getLogicalType(), this.conversion_timestamp_millis));
@@ -278,7 +248,7 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         FastSerdeLogicalTypesTest1 .put(8, convertedValue11);
     }
 
-    private void populate_FastSerdeLogicalTypesTest14(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest14(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         LocalTime convertedValue12 = ((LocalTime) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__419105534, this.logicalTypeSchema__419105534 .getLogicalType(), this.conversion_time_millis));
@@ -287,15 +257,15 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         FastSerdeLogicalTypesTest1 .put(10, convertedValue13);
     }
 
-    private void populate_FastSerdeLogicalTypesTest15(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesTest15(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1 FastSerdeLogicalTypesTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         LocalDate convertedValue14 = ((LocalDate) Conversions.convertToLogicalType((decoder.readInt()), this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date));
         FastSerdeLogicalTypesTest1 .put(11, convertedValue14);
-        FastSerdeLogicalTypesTest1 .put(12, deserializeLocalTimestampRecord0(FastSerdeLogicalTypesTest1 .get(12), (decoder)));
+        FastSerdeLogicalTypesTest1 .put(12, deserializeLocalTimestampRecord0(FastSerdeLogicalTypesTest1 .get(12), (decoder), (customization)));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord deserializeLocalTimestampRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord deserializeLocalTimestampRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord LocalTimestampRecord;
@@ -306,12 +276,12 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         }
         LocalDateTime convertedValue15 = ((LocalDateTime) Conversions.convertToLogicalType((decoder.readLong()), this.logicalTypeSchema__250645780, this.logicalTypeSchema__250645780 .getLogicalType(), this.conversion_local_timestamp_millis));
         LocalTimestampRecord.put(0, convertedValue15);
-        populate_LocalTimestampRecord0((LocalTimestampRecord), (decoder));
-        populate_LocalTimestampRecord1((LocalTimestampRecord), (decoder));
+        populate_LocalTimestampRecord0((LocalTimestampRecord), (customization), (decoder));
+        populate_LocalTimestampRecord1((LocalTimestampRecord), (customization), (decoder));
         return LocalTimestampRecord;
     }
 
-    private void populate_LocalTimestampRecord0(com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord LocalTimestampRecord, Decoder decoder)
+    private void populate_LocalTimestampRecord0(com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord LocalTimestampRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -345,7 +315,7 @@ public class FastSerdeLogicalTypesTest1_SpecificDeserializer_1007574890_10075748
         }
     }
 
-    private void populate_LocalTimestampRecord1(com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord LocalTimestampRecord, Decoder decoder)
+    private void populate_LocalTimestampRecord1(com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord LocalTimestampRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_GenericDeserializer_1982763418_1982763418.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_GenericDeserializer_1982763418_1982763418.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +24,13 @@ public class FastSerdeLogicalTypesUndefined_GenericDeserializer_1982763418_19827
         this.arrayOfUnionOfDateAndTimestampMillisArrayElemSchema0 = arrayOfUnionOfDateAndTimestampMillis0 .getElementType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastSerdeLogicalTypesUndefined0((reuse), (decoder));
+        return deserializeFastSerdeLogicalTypesUndefined0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastSerdeLogicalTypesUndefined0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastSerdeLogicalTypesUndefined0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastSerdeLogicalTypesUndefined;
@@ -39,11 +40,11 @@ public class FastSerdeLogicalTypesUndefined_GenericDeserializer_1982763418_19827
             FastSerdeLogicalTypesUndefined = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
         FastSerdeLogicalTypesUndefined.put(0, (decoder.readInt()));
-        populate_FastSerdeLogicalTypesUndefined0((FastSerdeLogicalTypesUndefined), (decoder));
+        populate_FastSerdeLogicalTypesUndefined0((FastSerdeLogicalTypesUndefined), (customization), (decoder));
         return FastSerdeLogicalTypesUndefined;
     }
 
-    private void populate_FastSerdeLogicalTypesUndefined0(IndexedRecord FastSerdeLogicalTypesUndefined, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesUndefined0(IndexedRecord FastSerdeLogicalTypesUndefined, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         FastSerdeLogicalTypesUndefined.put(1, (decoder.readInt()));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_SpecificDeserializer_1982763418_1982763418.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_SpecificDeserializer_1982763418_1982763418.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class FastSerdeLogicalTypesUndefined_SpecificDeserializer_1982763418_1982
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined deserialize(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined deserialize(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastSerdeLogicalTypesUndefined0((reuse), (decoder));
+        return deserializeFastSerdeLogicalTypesUndefined0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined deserializeFastSerdeLogicalTypesUndefined0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined deserializeFastSerdeLogicalTypesUndefined0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined FastSerdeLogicalTypesUndefined;
@@ -35,11 +36,11 @@ public class FastSerdeLogicalTypesUndefined_SpecificDeserializer_1982763418_1982
             FastSerdeLogicalTypesUndefined = new com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined();
         }
         FastSerdeLogicalTypesUndefined.put(0, (decoder.readInt()));
-        populate_FastSerdeLogicalTypesUndefined0((FastSerdeLogicalTypesUndefined), (decoder));
+        populate_FastSerdeLogicalTypesUndefined0((FastSerdeLogicalTypesUndefined), (customization), (decoder));
         return FastSerdeLogicalTypesUndefined;
     }
 
-    private void populate_FastSerdeLogicalTypesUndefined0(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined FastSerdeLogicalTypesUndefined, Decoder decoder)
+    private void populate_FastSerdeLogicalTypesUndefined0(com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined FastSerdeLogicalTypesUndefined, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         FastSerdeLogicalTypesUndefined.put(1, (decoder.readInt()));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_205569_205569.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_205569_205569.java
@@ -2,10 +2,10 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -28,13 +28,13 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
         this.testStringMap0 = readerSchema.getField("testStringMap").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0((reuse), (decoder));
+        return deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest;
@@ -51,12 +51,12 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
             charSequence0 = (decoder).readString(null);
         }
         FastStringableTest_javaStringPropertyInReaderSchemaTest.put(0, charSequence0);
-        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0((FastStringableTest_javaStringPropertyInReaderSchemaTest), (decoder));
-        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1((FastStringableTest_javaStringPropertyInReaderSchemaTest), (decoder));
+        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0((FastStringableTest_javaStringPropertyInReaderSchemaTest), (customization), (decoder));
+        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1((FastStringableTest_javaStringPropertyInReaderSchemaTest), (customization), (decoder));
         return FastStringableTest_javaStringPropertyInReaderSchemaTest;
     }
 
-    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, Decoder decoder)
+    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -109,23 +109,13 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
         FastStringableTest_javaStringPropertyInReaderSchemaTest.put(2, testStringArray1);
     }
 
-    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, Decoder decoder)
+    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, Utf8> testStringMap1 = null;
         long chunkLen1 = (decoder.readMapStart());
         if (chunkLen1 > 0) {
-            Map<Utf8, Utf8> testStringMapReuse0 = null;
-            Object oldMap0 = FastStringableTest_javaStringPropertyInReaderSchemaTest.get(3);
-            if (oldMap0 instanceof Map) {
-                testStringMapReuse0 = ((Map) oldMap0);
-            }
-            if (testStringMapReuse0 != (null)) {
-                testStringMapReuse0 .clear();
-                testStringMap1 = testStringMapReuse0;
-            } else {
-                testStringMap1 = new HashMap<Utf8, Utf8>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-            }
+            testStringMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastStringableTest_javaStringPropertyInReaderSchemaTest.get(3), ((int) chunkLen1)));
             do {
                 for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                     Utf8 key0 = (decoder.readString(null));
@@ -135,7 +125,7 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
                 chunkLen1 = (decoder.mapNext());
             } while (chunkLen1 > 0);
         } else {
-            testStringMap1 = new HashMap<Utf8, Utf8>(0);
+            testStringMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastStringableTest_javaStringPropertyInReaderSchemaTest.get(3), 0));
         }
         FastStringableTest_javaStringPropertyInReaderSchemaTest.put(3, testStringMap1);
     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_205569_941602558.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDeserializer_205569_941602558.java
@@ -2,10 +2,10 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -27,13 +27,13 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
         this.testStringMap0 = readerSchema.getField("testStringMap").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0((reuse), (decoder));
+        return deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest;
@@ -44,12 +44,12 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
         }
         String charSequence0 = (decoder).readString();
         FastStringableTest_javaStringPropertyInReaderSchemaTest.put(0, charSequence0);
-        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0((FastStringableTest_javaStringPropertyInReaderSchemaTest), (decoder));
-        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1((FastStringableTest_javaStringPropertyInReaderSchemaTest), (decoder));
+        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0((FastStringableTest_javaStringPropertyInReaderSchemaTest), (customization), (decoder));
+        populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1((FastStringableTest_javaStringPropertyInReaderSchemaTest), (customization), (decoder));
         return FastStringableTest_javaStringPropertyInReaderSchemaTest;
     }
 
-    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, Decoder decoder)
+    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -91,23 +91,13 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
         FastStringableTest_javaStringPropertyInReaderSchemaTest.put(2, testStringArray1);
     }
 
-    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, Decoder decoder)
+    private void populate_FastStringableTest_javaStringPropertyInReaderSchemaTest1(IndexedRecord FastStringableTest_javaStringPropertyInReaderSchemaTest, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<String, String> testStringMap1 = null;
         long chunkLen1 = (decoder.readMapStart());
         if (chunkLen1 > 0) {
-            Map<String, String> testStringMapReuse0 = null;
-            Object oldMap0 = FastStringableTest_javaStringPropertyInReaderSchemaTest.get(3);
-            if (oldMap0 instanceof Map) {
-                testStringMapReuse0 = ((Map) oldMap0);
-            }
-            if (testStringMapReuse0 != (null)) {
-                testStringMapReuse0 .clear();
-                testStringMap1 = testStringMapReuse0;
-            } else {
-                testStringMap1 = new HashMap<String, String>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-            }
+            testStringMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastStringableTest_javaStringPropertyInReaderSchemaTest.get(3), ((int) chunkLen1)));
             do {
                 for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                     String key0 = (decoder.readString());
@@ -117,7 +107,7 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericDese
                 chunkLen1 = (decoder.mapNext());
             } while (chunkLen1 > 0);
         } else {
-            testStringMap1 = new HashMap<String, String>(0);
+            testStringMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastStringableTest_javaStringPropertyInReaderSchemaTest.get(3), 0));
         }
         FastStringableTest_javaStringPropertyInReaderSchemaTest.put(3, testStringMap1);
     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastStringableTest_javaStringPropertyTest_GenericDeserializer_1110978985_1110978985.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastStringableTest_javaStringPropertyTest_GenericDeserializer_1110978985_1110978985.java
@@ -2,10 +2,10 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -27,13 +27,13 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_11109
         this.testStringMap0 = readerSchema.getField("testStringMap").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeFastStringableTest_javaStringPropertyTest0((reuse), (decoder));
+        return deserializeFastStringableTest_javaStringPropertyTest0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeFastStringableTest_javaStringPropertyTest0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeFastStringableTest_javaStringPropertyTest0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord FastStringableTest_javaStringPropertyTest;
@@ -44,12 +44,12 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_11109
         }
         String charSequence0 = (decoder).readString();
         FastStringableTest_javaStringPropertyTest.put(0, charSequence0);
-        populate_FastStringableTest_javaStringPropertyTest0((FastStringableTest_javaStringPropertyTest), (decoder));
-        populate_FastStringableTest_javaStringPropertyTest1((FastStringableTest_javaStringPropertyTest), (decoder));
+        populate_FastStringableTest_javaStringPropertyTest0((FastStringableTest_javaStringPropertyTest), (customization), (decoder));
+        populate_FastStringableTest_javaStringPropertyTest1((FastStringableTest_javaStringPropertyTest), (customization), (decoder));
         return FastStringableTest_javaStringPropertyTest;
     }
 
-    private void populate_FastStringableTest_javaStringPropertyTest0(IndexedRecord FastStringableTest_javaStringPropertyTest, Decoder decoder)
+    private void populate_FastStringableTest_javaStringPropertyTest0(IndexedRecord FastStringableTest_javaStringPropertyTest, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -91,23 +91,13 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_11109
         FastStringableTest_javaStringPropertyTest.put(2, testStringArray1);
     }
 
-    private void populate_FastStringableTest_javaStringPropertyTest1(IndexedRecord FastStringableTest_javaStringPropertyTest, Decoder decoder)
+    private void populate_FastStringableTest_javaStringPropertyTest1(IndexedRecord FastStringableTest_javaStringPropertyTest, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<String, String> testStringMap1 = null;
         long chunkLen1 = (decoder.readMapStart());
         if (chunkLen1 > 0) {
-            Map<String, String> testStringMapReuse0 = null;
-            Object oldMap0 = FastStringableTest_javaStringPropertyTest.get(3);
-            if (oldMap0 instanceof Map) {
-                testStringMapReuse0 = ((Map) oldMap0);
-            }
-            if (testStringMapReuse0 != (null)) {
-                testStringMapReuse0 .clear();
-                testStringMap1 = testStringMapReuse0;
-            } else {
-                testStringMap1 = new HashMap<String, String>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-            }
+            testStringMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastStringableTest_javaStringPropertyTest.get(3), ((int) chunkLen1)));
             do {
                 for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                     String key0 = (decoder.readString());
@@ -117,7 +107,7 @@ public class FastStringableTest_javaStringPropertyTest_GenericDeserializer_11109
                 chunkLen1 = (decoder.mapNext());
             } while (chunkLen1 > 0);
         } else {
-            testStringMap1 = new HashMap<String, String>(0);
+            testStringMap1 = ((Map)(customization).getNewMapOverrideFunc().apply(FastStringableTest_javaStringPropertyTest.get(3), 0));
         }
         FastStringableTest_javaStringPropertyTest.put(3, testStringMap1);
     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978.java
@@ -4,7 +4,6 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveBooleanList;
@@ -14,6 +13,7 @@ import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
@@ -37,36 +37,27 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         this.readerSchema = readerSchema;
     }
 
-    public Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder)
+    public Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> map0 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> mapReuse0 = null;
-            if ((reuse) instanceof Map) {
-                mapReuse0 = ((Map)(reuse));
-            }
-            if (mapReuse0 != (null)) {
-                mapReuse0 .clear();
-                map0 = mapReuse0;
-            } else {
-                map0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    map0 .put(key0, deserializeTestRecord0(null, (decoder)));
+                    map0 .put(key0, deserializeTestRecord0(null, (decoder), (customization)));
                 }
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            map0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord>(0);
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), 0));
         }
         return map0;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -76,29 +67,29 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
-        populate_TestRecord17((TestRecord), (decoder));
-        populate_TestRecord18((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
+        populate_TestRecord17((TestRecord), (customization), (decoder));
+        populate_TestRecord18((TestRecord), (customization), (decoder));
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -115,7 +106,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -132,7 +123,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -149,7 +140,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -166,7 +157,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -190,7 +181,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -221,7 +212,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -255,7 +246,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(14, testFixed1);
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex7 = (decoder.readIndex());
@@ -315,7 +306,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(16, testFixedArray0);
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray0 = null;
@@ -365,7 +356,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(18, Enums.getConstant(TestEnum.class, (decoder.readEnum())));
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex9 = (decoder.readIndex());
@@ -401,7 +392,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(20, testEnumArray0);
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumUnionArray0 = null;
@@ -444,14 +435,14 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
             TestRecord.put(22, null);
         } else {
             if (unionIndex11 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex11));
             }
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -478,11 +469,11 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex12));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex13 = (decoder.readIndex());
@@ -505,10 +496,10 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         }
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
         long chunkLen5 = (decoder.readArrayStart());
         Object oldArray4 = TestRecord.get(24);
@@ -528,39 +519,29 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen5 = (decoder.arrayNext());
         }
         TestRecord.put(24, recordsArray0);
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen6 = (decoder.readMapStart());
         if (chunkLen6 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen6 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen6)));
             do {
                 for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
                     Utf8 key1 = (decoder.readString(null));
-                    recordsMap0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen6 = (decoder.mapNext());
             } while (chunkLen6 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
         int unionIndex14 = (decoder.readIndex());
@@ -594,7 +575,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex15 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex15));
                             }
@@ -609,7 +590,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         }
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex16 = (decoder.readIndex());
@@ -621,17 +602,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen8 = (decoder.readMapStart());
                 if (chunkLen8 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen8 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen8)));
                     do {
                         for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -641,7 +612,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                                 recordsMapUnionOption0 .put(key2, null);
                             } else {
                                 if (unionIndex17 == 1) {
-                                    recordsMapUnionOption0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex17));
                                 }
@@ -650,7 +621,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                         chunkLen8 = (decoder.mapNext());
                     } while (chunkLen8 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -679,16 +650,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen10 = (decoder.readMapStart());
                 if (chunkLen10 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen10)));
                     do {
                         for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                             Utf8 key3 = (decoder.readString(null));
@@ -698,7 +660,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                                 recordsArrayMapElem0 .put(key3, null);
                             } else {
                                 if (unionIndex18 == 1) {
-                                    recordsArrayMapElem0 .put(key3, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key3, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex18));
                                 }
@@ -707,7 +669,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                         chunkLen10 = (decoder.mapNext());
                     } while (chunkLen10 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -716,23 +678,13 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(28, recordsArrayMap0);
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen11 = (decoder.readMapStart());
         if (chunkLen11 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen11 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen11)));
             do {
                 for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
                     Utf8 key4 = (decoder.readString(null));
@@ -760,7 +712,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex19));
                                 }
@@ -773,7 +725,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                 chunkLen11 = (decoder.mapNext());
             } while (chunkLen11 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
         int unionIndex20 = (decoder.readIndex());
@@ -804,16 +756,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen14 = (decoder.readMapStart());
                         if (chunkLen14 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen14)));
                             do {
                                 for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                                     Utf8 key5 = (decoder.readString(null));
@@ -823,7 +766,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                                         recordsArrayMapUnionOptionElem0 .put(key5, null);
                                     } else {
                                         if (unionIndex21 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key5, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key5, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex21));
                                         }
@@ -832,7 +775,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                                 chunkLen14 = (decoder.mapNext());
                             } while (chunkLen14 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -845,7 +788,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         }
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex22 = (decoder.readIndex());
@@ -857,17 +800,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen15 = (decoder.readMapStart());
                 if (chunkLen15 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen15 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen15)));
                     do {
                         for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
                             Utf8 key6 = (decoder.readString(null));
@@ -895,7 +828,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex23 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex23));
                                         }
@@ -908,7 +841,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
                         chunkLen15 = (decoder.mapNext());
                     } while (chunkLen15 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -921,7 +854,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
             TestRecord.put(32, null);
         } else {
             if (unionIndex24 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex24 == 2) {
                     Utf8 charSequence4;
@@ -943,7 +876,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveBooleanList booleanArray0 = null;
@@ -980,7 +913,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(34, doubleArray0);
     }
 
-    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
@@ -1004,7 +937,7 @@ public class Map_of_TestRecord_SpecificDeserializer_1100791978_1100791978
         TestRecord.put(36, intArray0);
     }
 
-    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveLongList longArray0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_UNION_GenericDeserializer_2140000109_2140000109.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_UNION_GenericDeserializer_2140000109_2140000109.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -26,22 +26,13 @@ public class Map_of_UNION_GenericDeserializer_2140000109_2140000109
         this.field0 = mapValueOptionSchema0 .getField("field").schema();
     }
 
-    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         Map<Utf8, IndexedRecord> map0 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse0 = null;
-            if ((reuse) instanceof Map) {
-                mapReuse0 = ((Map)(reuse));
-            }
-            if (mapReuse0 != (null)) {
-                mapReuse0 .clear();
-                map0 = mapReuse0;
-            } else {
-                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
@@ -51,7 +42,7 @@ public class Map_of_UNION_GenericDeserializer_2140000109_2140000109
                         map0 .put(key0, null);
                     } else {
                         if (unionIndex0 == 1) {
-                            map0 .put(key0, deserializerecord0(null, (decoder)));
+                            map0 .put(key0, deserializerecord0(null, (decoder), (customization)));
                         } else {
                             throw new RuntimeException(("Illegal union index for 'mapValue': "+ unionIndex0));
                         }
@@ -60,12 +51,12 @@ public class Map_of_UNION_GenericDeserializer_2140000109_2140000109
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            map0 = new HashMap<Utf8, IndexedRecord>(0);
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), 0));
         }
         return map0;
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_UNION_SpecificDeserializer_971650236_971650236.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_UNION_SpecificDeserializer_971650236_971650236.java
@@ -4,7 +4,6 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveBooleanList;
@@ -14,6 +13,7 @@ import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
@@ -37,22 +37,13 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         this.readerSchema = readerSchema;
     }
 
-    public Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder)
+    public Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> deserialize(Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> map0 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord> mapReuse0 = null;
-            if ((reuse) instanceof Map) {
-                mapReuse0 = ((Map)(reuse));
-            }
-            if (mapReuse0 != (null)) {
-                mapReuse0 .clear();
-                map0 = mapReuse0;
-            } else {
-                map0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
@@ -62,7 +53,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                         map0 .put(key0, null);
                     } else {
                         if (unionIndex0 == 1) {
-                            map0 .put(key0, deserializeTestRecord0(null, (decoder)));
+                            map0 .put(key0, deserializeTestRecord0(null, (decoder), (customization)));
                         } else {
                             throw new RuntimeException(("Illegal union index for 'mapValue': "+ unionIndex0));
                         }
@@ -71,12 +62,12 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            map0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.TestRecord>(0);
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), 0));
         }
         return map0;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -86,29 +77,29 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
-        populate_TestRecord17((TestRecord), (decoder));
-        populate_TestRecord18((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
+        populate_TestRecord17((TestRecord), (customization), (decoder));
+        populate_TestRecord18((TestRecord), (customization), (decoder));
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -125,7 +116,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -142,7 +133,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -159,7 +150,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -176,7 +167,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -200,7 +191,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -231,7 +222,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex7 = (decoder.readIndex());
@@ -265,7 +256,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(14, testFixed1);
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex8 = (decoder.readIndex());
@@ -325,7 +316,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(16, testFixedArray0);
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray0 = null;
@@ -375,7 +366,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(18, Enums.getConstant(TestEnum.class, (decoder.readEnum())));
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex10 = (decoder.readIndex());
@@ -411,7 +402,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(20, testEnumArray0);
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumUnionArray0 = null;
@@ -454,14 +445,14 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
             TestRecord.put(22, null);
         } else {
             if (unionIndex12 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex12));
             }
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -488,11 +479,11 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex13));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex14 = (decoder.readIndex());
@@ -515,10 +506,10 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         }
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
         long chunkLen5 = (decoder.readArrayStart());
         Object oldArray4 = TestRecord.get(24);
@@ -538,39 +529,29 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen5 = (decoder.arrayNext());
         }
         TestRecord.put(24, recordsArray0);
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen6 = (decoder.readMapStart());
         if (chunkLen6 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen6 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen6)));
             do {
                 for (int counter6 = 0; (counter6 <chunkLen6); counter6 ++) {
                     Utf8 key1 = (decoder.readString(null));
-                    recordsMap0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen6 = (decoder.mapNext());
             } while (chunkLen6 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
         int unionIndex15 = (decoder.readIndex());
@@ -604,7 +585,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex16 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex16));
                             }
@@ -619,7 +600,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         }
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex17 = (decoder.readIndex());
@@ -631,17 +612,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen8 = (decoder.readMapStart());
                 if (chunkLen8 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen8 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen8)));
                     do {
                         for (int counter8 = 0; (counter8 <chunkLen8); counter8 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -651,7 +622,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                                 recordsMapUnionOption0 .put(key2, null);
                             } else {
                                 if (unionIndex18 == 1) {
-                                    recordsMapUnionOption0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex18));
                                 }
@@ -660,7 +631,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                         chunkLen8 = (decoder.mapNext());
                     } while (chunkLen8 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -689,16 +660,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen10 = (decoder.readMapStart());
                 if (chunkLen10 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen10)));
                     do {
                         for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                             Utf8 key3 = (decoder.readString(null));
@@ -708,7 +670,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                                 recordsArrayMapElem0 .put(key3, null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsArrayMapElem0 .put(key3, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key3, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex19));
                                 }
@@ -717,7 +679,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                         chunkLen10 = (decoder.mapNext());
                     } while (chunkLen10 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -726,23 +688,13 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(28, recordsArrayMap0);
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen11 = (decoder.readMapStart());
         if (chunkLen11 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen11 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen11)));
             do {
                 for (int counter11 = 0; (counter11 <chunkLen11); counter11 ++) {
                     Utf8 key4 = (decoder.readString(null));
@@ -770,7 +722,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex20 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex20));
                                 }
@@ -783,7 +735,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 chunkLen11 = (decoder.mapNext());
             } while (chunkLen11 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
         int unionIndex21 = (decoder.readIndex());
@@ -814,16 +766,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen14 = (decoder.readMapStart());
                         if (chunkLen14 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen14)));
                             do {
                                 for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                                     Utf8 key5 = (decoder.readString(null));
@@ -833,7 +776,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                                         recordsArrayMapUnionOptionElem0 .put(key5, null);
                                     } else {
                                         if (unionIndex22 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key5, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key5, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex22));
                                         }
@@ -842,7 +785,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                                 chunkLen14 = (decoder.mapNext());
                             } while (chunkLen14 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -855,7 +798,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         }
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex23 = (decoder.readIndex());
@@ -867,17 +810,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen15 = (decoder.readMapStart());
                 if (chunkLen15 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen15 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen15)));
                     do {
                         for (int counter15 = 0; (counter15 <chunkLen15); counter15 ++) {
                             Utf8 key6 = (decoder.readString(null));
@@ -905,7 +838,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex24 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex24));
                                         }
@@ -918,7 +851,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
                         chunkLen15 = (decoder.mapNext());
                     } while (chunkLen15 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -931,7 +864,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
             TestRecord.put(32, null);
         } else {
             if (unionIndex25 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex25 == 2) {
                     Utf8 charSequence4;
@@ -953,7 +886,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveBooleanList booleanArray0 = null;
@@ -990,7 +923,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(34, doubleArray0);
     }
 
-    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
@@ -1014,7 +947,7 @@ public class Map_of_UNION_SpecificDeserializer_971650236_971650236
         TestRecord.put(36, intArray0);
     }
 
-    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveLongList longArray0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_record_GenericDeserializer_1223705675_568621313.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_record_GenericDeserializer_1223705675_568621313.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,7 +23,7 @@ public class Map_of_record_GenericDeserializer_1223705675_568621313
         this.unionOptionMapValueSchema0 = readerSchema.getValueType();
     }
 
-    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -34,25 +34,16 @@ public class Map_of_record_GenericDeserializer_1223705675_568621313
                 Map<Utf8, IndexedRecord> unionOption0 = null;
                 long chunkLen0 = (decoder.readMapStart());
                 if (chunkLen0 > 0) {
-                    Map<Utf8, IndexedRecord> unionOptionReuse0 = null;
-                    if ((reuse) instanceof Map) {
-                        unionOptionReuse0 = ((Map)(reuse));
-                    }
-                    if (unionOptionReuse0 != (null)) {
-                        unionOptionReuse0 .clear();
-                        unionOption0 = unionOptionReuse0;
-                    } else {
-                        unionOption0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                    }
+                    unionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), ((int) chunkLen0)));
                     do {
                         for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                             Utf8 key0 = (decoder.readString(null));
-                            unionOption0 .put(key0, deserializerecord0(null, (decoder)));
+                            unionOption0 .put(key0, deserializerecord0(null, (decoder), (customization)));
                         }
                         chunkLen0 = (decoder.mapNext());
                     } while (chunkLen0 > 0);
                 } else {
-                    unionOption0 = new HashMap<Utf8, IndexedRecord>(0);
+                    unionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), 0));
                 }
                 return unionOption0;
             } else {
@@ -61,7 +52,7 @@ public class Map_of_record_GenericDeserializer_1223705675_568621313
         }
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_record_GenericDeserializer_1677529043_1677529043.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_record_GenericDeserializer_1677529043_1677529043.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,36 +24,27 @@ public class Map_of_record_GenericDeserializer_1677529043_1677529043
         this.field0 = mapMapValueSchema0 .getField("field").schema();
     }
 
-    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         Map<Utf8, IndexedRecord> map0 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse0 = null;
-            if ((reuse) instanceof Map) {
-                mapReuse0 = ((Map)(reuse));
-            }
-            if (mapReuse0 != (null)) {
-                mapReuse0 .clear();
-                map0 = mapReuse0;
-            } else {
-                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                    map0 .put(key0, deserializerecord0(null, (decoder), (customization)));
                 }
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            map0 = new HashMap<Utf8, IndexedRecord>(0);
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), 0));
         }
         return map0;
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithLargeUnionField_SpecificDeserializer_1132455741_1570175609.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithLargeUnionField_SpecificDeserializer_1132455741_1570175609.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
@@ -18,13 +19,13 @@ public class RecordWithLargeUnionField_SpecificDeserializer_1132455741_157017560
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField deserialize(com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField deserialize(com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeRecordWithLargeUnionField0((reuse), (decoder));
+        return deserializeRecordWithLargeUnionField0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField deserializeRecordWithLargeUnionField0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField deserializeRecordWithLargeUnionField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.RecordWithLargeUnionField RecordWithLargeUnionField;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RemovedTypesTestRecord_SpecificDeserializer_1438463600_36310691.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RemovedTypesTestRecord_SpecificDeserializer_1438463600_36310691.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
@@ -17,13 +18,13 @@ public class RemovedTypesTestRecord_SpecificDeserializer_1438463600_36310691
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeRemovedTypesTestRecord0((reuse), (decoder));
+        return deserializeRemovedTypesTestRecord0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserializeRemovedTypesTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserializeRemovedTypesTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.io.Decoder;
@@ -18,13 +19,13 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeRemovedTypesTestRecord0((reuse), (decoder));
+        return deserializeRemovedTypesTestRecord0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserializeRemovedTypesTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord deserializeRemovedTypesTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord;
@@ -41,22 +42,22 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
             charSequence0 = (decoder).readString(null);
         }
         RemovedTypesTestRecord.put(0, charSequence0);
-        populate_RemovedTypesTestRecord0((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord1((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord2((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord3((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord4((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord5((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord6((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord7((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord8((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord9((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord10((RemovedTypesTestRecord), (decoder));
-        populate_RemovedTypesTestRecord11((RemovedTypesTestRecord), (decoder));
+        populate_RemovedTypesTestRecord0((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord1((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord2((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord3((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord4((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord5((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord6((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord7((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord8((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord9((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord10((RemovedTypesTestRecord), (customization), (decoder));
+        populate_RemovedTypesTestRecord11((RemovedTypesTestRecord), (customization), (decoder));
         return RemovedTypesTestRecord;
     }
 
-    private void populate_RemovedTypesTestRecord0(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord0(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         decoder.skipBytes();
@@ -73,7 +74,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord1(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord1(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -98,7 +99,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord2(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord2(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen2 = (decoder.readArrayStart());
@@ -142,7 +143,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord3(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord3(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         decoder.skipFixed(1);
@@ -158,7 +159,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord4(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord4(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen4 = (decoder.readArrayStart());
@@ -184,7 +185,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord5(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord5(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen6 = (decoder.readArrayStart());
@@ -228,7 +229,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord6(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord6(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         decoder.readEnum();
@@ -244,7 +245,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord7(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord7(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen8 = (decoder.readArrayStart());
@@ -266,7 +267,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord8(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord8(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen10 = (decoder.readArrayStart());
@@ -310,29 +311,29 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord9(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord9(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        deserializeRemovedSubRecord0(null, (decoder));
+        deserializeRemovedSubRecord0(null, (decoder), (customization));
         int unionIndex9 = (decoder.readIndex());
         if (unionIndex9 == 0) {
             decoder.readNull();
         } else {
             if (unionIndex9 == 1) {
-                deserializeRemovedSubRecord0(null, (decoder));
+                deserializeRemovedSubRecord0(null, (decoder), (customization));
             } else {
                 throw new RuntimeException(("Illegal union index for 'removedSubRecordUnion': "+ unionIndex9));
             }
         }
     }
 
-    public void deserializeRemovedSubRecord0(Object reuse, Decoder decoder)
+    public void deserializeRemovedSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         decoder.skipString();
     }
 
-    private void populate_RemovedTypesTestRecord10(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord10(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen12 = (decoder.readArrayStart());
@@ -342,7 +343,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
                 if (null instanceof GenericArray) {
                     removedSubRecordArrayArrayElementReuseVar0 = ((GenericArray) null).peek();
                 }
-                deserializeRemovedSubRecord0(removedSubRecordArrayArrayElementReuseVar0, (decoder));
+                deserializeRemovedSubRecord0(removedSubRecordArrayArrayElementReuseVar0, (decoder), (customization));
             }
             chunkLen12 = (decoder.arrayNext());
         }
@@ -358,7 +359,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
                     decoder.readNull();
                 } else {
                     if (unionIndex10 == 1) {
-                        deserializeRemovedSubRecord0(removedSubRecordUnionArrayArrayElementReuseVar0, (decoder));
+                        deserializeRemovedSubRecord0(removedSubRecordUnionArrayArrayElementReuseVar0, (decoder), (customization));
                     } else {
                         throw new RuntimeException(("Illegal union index for 'removedSubRecordUnionArrayElem': "+ unionIndex10));
                     }
@@ -368,7 +369,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
         }
     }
 
-    private void populate_RemovedTypesTestRecord11(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, Decoder decoder)
+    private void populate_RemovedTypesTestRecord11(com.linkedin.avro.fastserde.generated.avro.RemovedTypesTestRecord RemovedTypesTestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         long chunkLen14 = (decoder.readMapStart());
@@ -376,7 +377,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
             do {
                 for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                     Utf8 key6 = (decoder.readString(null));
-                    deserializeRemovedSubRecord0(null, (decoder));
+                    deserializeRemovedSubRecord0(null, (decoder), (customization));
                 }
                 chunkLen14 = (decoder.mapNext());
             } while (chunkLen14 > 0);
@@ -391,7 +392,7 @@ public class RemovedTypesTestRecord_SpecificDeserializer_605055252_36310691
                         decoder.readNull();
                     } else {
                         if (unionIndex11 == 1) {
-                            deserializeRemovedSubRecord0(null, (decoder));
+                            deserializeRemovedSubRecord0(null, (decoder), (customization));
                         } else {
                             throw new RuntimeException(("Illegal union index for 'removedSubRecordUnionMapValue': "+ unionIndex11));
                         }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/SplitRecordTest1_SpecificDeserializer_1718878379_595582209.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/SplitRecordTest1_SpecificDeserializer_1718878379_595582209.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class SplitRecordTest1_SpecificDeserializer_1718878379_595582209
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeSplitRecordTest10((reuse), (decoder));
+        return deserializeSplitRecordTest10((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 deserializeSplitRecordTest10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1;
@@ -35,12 +36,12 @@ public class SplitRecordTest1_SpecificDeserializer_1718878379_595582209
         } else {
             SplitRecordTest1 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1();
         }
-        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder)));
-        populate_SplitRecordTest10((SplitRecordTest1), (decoder));
+        SplitRecordTest1 .put(0, deserializeFullRecord0(SplitRecordTest1 .get(0), (decoder), (customization)));
+        populate_SplitRecordTest10((SplitRecordTest1), (customization), (decoder));
         return SplitRecordTest1;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
@@ -71,10 +72,10 @@ public class SplitRecordTest1_SpecificDeserializer_1718878379_595582209
         return FullRecord;
     }
 
-    private void populate_SplitRecordTest10(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1, Decoder decoder)
+    private void populate_SplitRecordTest10(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest1 SplitRecordTest1, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder)));
+        SplitRecordTest1 .put(1, deserializeFullRecord1(SplitRecordTest1 .get(1), (decoder), (customization)));
         List<com.linkedin.avro.fastserde.generated.avro.FullRecord> record30 = null;
         long chunkLen0 = (decoder.readArrayStart());
         Object oldArray0 = SplitRecordTest1 .get(2);
@@ -94,14 +95,14 @@ public class SplitRecordTest1_SpecificDeserializer_1718878379_595582209
                 if (oldArray0 instanceof GenericArray) {
                     record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
                 }
-                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder)));
+                record30 .add(deserializeFullRecord2(record3ArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         SplitRecordTest1 .put(2, record30);
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord1(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
@@ -125,7 +126,7 @@ public class SplitRecordTest1_SpecificDeserializer_1718878379_595582209
         return FullRecord;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.FullRecord deserializeFullRecord2(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord;
@@ -152,11 +153,11 @@ public class SplitRecordTest1_SpecificDeserializer_1718878379_595582209
                 throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
             }
         }
-        populate_FullRecord0((FullRecord), (decoder));
+        populate_FullRecord0((FullRecord), (customization), (decoder));
         return FullRecord;
     }
 
-    private void populate_FullRecord0(com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord, Decoder decoder)
+    private void populate_FullRecord0(com.linkedin.avro.fastserde.generated.avro.FullRecord FullRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/SplitRecordTest2_SpecificDeserializer_595582209_1718878379.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/SplitRecordTest2_SpecificDeserializer_595582209_1718878379.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.FullRecord;
 import com.linkedin.avro.fastserde.generated.avro.StringRecord;
 import org.apache.avro.Schema;
@@ -22,13 +23,13 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserialize(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeSplitRecordTest20((reuse), (decoder));
+        return deserializeSplitRecordTest20((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 deserializeSplitRecordTest20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2;
@@ -37,12 +38,12 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
         } else {
             SplitRecordTest2 = new com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2();
         }
-        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder)));
-        populate_SplitRecordTest20((SplitRecordTest2), (decoder));
+        SplitRecordTest2 .put(0, deserializeStringRecord0(SplitRecordTest2 .get(0), (decoder), (customization)));
+        populate_SplitRecordTest20((SplitRecordTest2), (customization), (decoder));
         return SplitRecordTest2;
     }
 
-    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder)
+    public StringRecord deserializeStringRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         StringRecord IntRecord;
@@ -69,11 +70,11 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
                 throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex0));
             }
         }
-        populate_IntRecord0((IntRecord), (decoder));
+        populate_IntRecord0((IntRecord), (customization), (decoder));
         return IntRecord;
     }
 
-    private void populate_IntRecord0(StringRecord IntRecord, Decoder decoder)
+    private void populate_IntRecord0(StringRecord IntRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -88,10 +89,10 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
         }
     }
 
-    private void populate_SplitRecordTest20(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2, Decoder decoder)
+    private void populate_SplitRecordTest20(com.linkedin.avro.fastserde.generated.avro.SplitRecordTest2 SplitRecordTest2, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder)));
+        SplitRecordTest2 .put(1, deserializeIntRecord0(SplitRecordTest2 .get(1), (decoder), (customization)));
         List<FullRecord> record30 = null;
         long chunkLen0 = (decoder.readArrayStart());
         Object oldArray0 = SplitRecordTest2 .get(2);
@@ -111,14 +112,14 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
                 if (oldArray0 instanceof GenericArray) {
                     record3ArrayElementReuseVar0 = ((GenericArray) oldArray0).peek();
                 }
-                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder)));
+                record30 .add(deserializeFullRecord0(record3ArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         SplitRecordTest2 .put(2, record30);
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.IntRecord deserializeIntRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord;
@@ -137,11 +138,11 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
                 throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex2));
             }
         }
-        populate_IntRecord1((IntRecord), (decoder));
+        populate_IntRecord1((IntRecord), (customization), (decoder));
         return IntRecord;
     }
 
-    private void populate_IntRecord1(com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord, Decoder decoder)
+    private void populate_IntRecord1(com.linkedin.avro.fastserde.generated.avro.IntRecord IntRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -157,7 +158,7 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
         }
     }
 
-    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder)
+    public FullRecord deserializeFullRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         FullRecord IntRecord;
@@ -184,11 +185,11 @@ public class SplitRecordTest2_SpecificDeserializer_595582209_1718878379
                 throw new RuntimeException(("Illegal union index for 'field1': "+ unionIndex4));
             }
         }
-        populate_IntRecord2((IntRecord), (decoder));
+        populate_IntRecord2((IntRecord), (customization), (decoder));
         return IntRecord;
     }
 
-    private void populate_IntRecord2(FullRecord IntRecord, Decoder decoder)
+    private void populate_IntRecord2(FullRecord IntRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/StringableRecord_SpecificDeserializer_842267318_842267318.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/StringableRecord_SpecificDeserializer_842267318_842267318.java
@@ -10,10 +10,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
@@ -30,11 +30,11 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.StringableRecord deserialize(com.linkedin.avro.fastserde.generated.avro.StringableRecord reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.StringableRecord deserialize(com.linkedin.avro.fastserde.generated.avro.StringableRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         try {
-            return deserializeStringableRecord0((reuse), (decoder));
+            return deserializeStringableRecord0((reuse), (decoder), (customization));
         } catch (NumberFormatException e) {
             throw new AvroRuntimeException(e);
         } catch (MalformedURLException e) {
@@ -44,7 +44,7 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.StringableRecord deserializeStringableRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.StringableRecord deserializeStringableRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException, NumberFormatException, MalformedURLException, URISyntaxException
     {
         com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord;
@@ -55,15 +55,15 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         }
         BigInteger charSequence0 = new BigInteger((decoder.readString()));
         StringableRecord.put(0, charSequence0);
-        populate_StringableRecord0((StringableRecord), (decoder));
-        populate_StringableRecord1((StringableRecord), (decoder));
-        populate_StringableRecord2((StringableRecord), (decoder));
-        populate_StringableRecord3((StringableRecord), (decoder));
-        populate_StringableRecord4((StringableRecord), (decoder));
+        populate_StringableRecord0((StringableRecord), (customization), (decoder));
+        populate_StringableRecord1((StringableRecord), (customization), (decoder));
+        populate_StringableRecord2((StringableRecord), (customization), (decoder));
+        populate_StringableRecord3((StringableRecord), (customization), (decoder));
+        populate_StringableRecord4((StringableRecord), (customization), (decoder));
         return StringableRecord;
     }
 
-    private void populate_StringableRecord0(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, Decoder decoder)
+    private void populate_StringableRecord0(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException, NumberFormatException, URISyntaxException
     {
         BigDecimal charSequence1 = new BigDecimal((decoder.readString()));
@@ -72,7 +72,7 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         StringableRecord.put(2, charSequence2);
     }
 
-    private void populate_StringableRecord1(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, Decoder decoder)
+    private void populate_StringableRecord1(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException, NumberFormatException, MalformedURLException, URISyntaxException
     {
         URL charSequence3 = new URL((decoder.readString()));
@@ -81,7 +81,7 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         StringableRecord.put(4, charSequence4);
     }
 
-    private void populate_StringableRecord2(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, Decoder decoder)
+    private void populate_StringableRecord2(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException, NumberFormatException, MalformedURLException, URISyntaxException
     {
         List<URL> urlArray0 = null;
@@ -112,17 +112,7 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         Map<URL, BigInteger> urlMap0 = null;
         long chunkLen1 = (decoder.readMapStart());
         if (chunkLen1 > 0) {
-            Map<URL, BigInteger> urlMapReuse0 = null;
-            Object oldMap0 = StringableRecord.get(6);
-            if (oldMap0 instanceof Map) {
-                urlMapReuse0 = ((Map) oldMap0);
-            }
-            if (urlMapReuse0 != (null)) {
-                urlMapReuse0 .clear();
-                urlMap0 = urlMapReuse0;
-            } else {
-                urlMap0 = new HashMap<URL, BigInteger>(((int)(((chunkLen1 * 4)+ 2)/ 3)));
-            }
+            urlMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(StringableRecord.get(6), ((int) chunkLen1)));
             do {
                 for (int counter1 = 0; (counter1 <chunkLen1); counter1 ++) {
                     URL key0 = new URL((decoder.readString()));
@@ -132,19 +122,19 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
                 chunkLen1 = (decoder.mapNext());
             } while (chunkLen1 > 0);
         } else {
-            urlMap0 = new HashMap<URL, BigInteger>(0);
+            urlMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(StringableRecord.get(6), 0));
         }
         StringableRecord.put(6, urlMap0);
     }
 
-    private void populate_StringableRecord3(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, Decoder decoder)
+    private void populate_StringableRecord3(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException, NumberFormatException, MalformedURLException, URISyntaxException
     {
-        StringableRecord.put(7, deserializeStringableSubRecord0(StringableRecord.get(7), (decoder)));
-        StringableRecord.put(8, deserializeAnotherSubRecord0(StringableRecord.get(8), (decoder)));
+        StringableRecord.put(7, deserializeStringableSubRecord0(StringableRecord.get(7), (decoder), (customization)));
+        StringableRecord.put(8, deserializeAnotherSubRecord0(StringableRecord.get(8), (decoder), (customization)));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.StringableSubRecord deserializeStringableSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.StringableSubRecord deserializeStringableSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException, URISyntaxException
     {
         com.linkedin.avro.fastserde.generated.avro.StringableSubRecord StringableSubRecord;
@@ -155,11 +145,11 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         }
         URI charSequence7 = new URI((decoder.readString()));
         StringableSubRecord.put(0, charSequence7);
-        populate_StringableSubRecord0((StringableSubRecord), (decoder));
+        populate_StringableSubRecord0((StringableSubRecord), (customization), (decoder));
         return StringableSubRecord;
     }
 
-    private void populate_StringableSubRecord0(com.linkedin.avro.fastserde.generated.avro.StringableSubRecord StringableSubRecord, Decoder decoder)
+    private void populate_StringableSubRecord0(com.linkedin.avro.fastserde.generated.avro.StringableSubRecord StringableSubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException, URISyntaxException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -186,7 +176,7 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.AnotherSubRecord deserializeAnotherSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.AnotherSubRecord deserializeAnotherSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException, URISyntaxException
     {
         com.linkedin.avro.fastserde.generated.avro.AnotherSubRecord AnotherSubRecord;
@@ -195,11 +185,11 @@ public class StringableRecord_SpecificDeserializer_842267318_842267318
         } else {
             AnotherSubRecord = new com.linkedin.avro.fastserde.generated.avro.AnotherSubRecord();
         }
-        AnotherSubRecord.put(0, deserializeStringableSubRecord0(AnotherSubRecord.get(0), (decoder)));
+        AnotherSubRecord.put(0, deserializeStringableSubRecord0(AnotherSubRecord.get(0), (decoder), (customization)));
         return AnotherSubRecord;
     }
 
-    private void populate_StringableRecord4(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, Decoder decoder)
+    private void populate_StringableRecord4(com.linkedin.avro.fastserde.generated.avro.StringableRecord StringableRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException, NumberFormatException, MalformedURLException, URISyntaxException
     {
         int unionIndex1 = (decoder.readIndex());

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestArrayOfFloats_GenericDeserializer_1408566797_1408566797.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestArrayOfFloats_GenericDeserializer_1408566797_1408566797.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -21,13 +22,13 @@ public class TestArrayOfFloats_GenericDeserializer_1408566797_1408566797
         this.array_of_float0 = readerSchema.getField("array_of_float").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeTestArrayOfFloats0((reuse), (decoder));
+        return deserializeTestArrayOfFloats0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeTestArrayOfFloats0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeTestArrayOfFloats0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord TestArrayOfFloats;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_GenericDeserializer_473555078_473555078.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_GenericDeserializer_473555078_473555078.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -22,13 +22,13 @@ public class TestRecord_GenericDeserializer_473555078_473555078
         this.map_field0 = readerSchema.getField("map_field").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeTestRecord0((reuse), (decoder));
+        return deserializeTestRecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord TestRecord;
@@ -40,17 +40,7 @@ public class TestRecord_GenericDeserializer_473555078_473555078
         Map<Utf8, Utf8> map_field1 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, Utf8> map_fieldReuse0 = null;
-            Object oldMap0 = TestRecord.get(0);
-            if (oldMap0 instanceof Map) {
-                map_fieldReuse0 = ((Map) oldMap0);
-            }
-            if (map_fieldReuse0 != (null)) {
-                map_fieldReuse0 .clear();
-                map_field1 = map_fieldReuse0;
-            } else {
-                map_field1 = new HashMap<Utf8, Utf8>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            map_field1 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(0), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
@@ -60,7 +50,7 @@ public class TestRecord_GenericDeserializer_473555078_473555078
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            map_field1 = new HashMap<Utf8, Utf8>(0);
+            map_field1 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(0), 0));
         }
         TestRecord.put(0, map_field1);
         return TestRecord;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_1898726132_553331077.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_1898726132_553331077.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avroutil1.Enums;
@@ -61,13 +62,13 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         this.enumMappingTestEnum3 = Collections.unmodifiableMap(tempEnumMapping3);
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.TestRecord reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.TestRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeTestRecord0((reuse), (decoder));
+        return deserializeTestRecord0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -77,23 +78,23 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
         ArrayList<Boolean> defaultArray0 = new ArrayList<Boolean>();
         TestRecord.put(33, defaultArray0);
         ArrayList<Double> defaultArray1 = new ArrayList<Double>();
@@ -109,7 +110,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -126,7 +127,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -143,7 +144,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -160,7 +161,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -177,7 +178,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -201,7 +202,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -232,7 +233,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -265,7 +266,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         }
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         byte[] testFixed0;
@@ -302,7 +303,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         }
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedArray0 = null;
@@ -385,7 +386,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(17, testFixedUnionArray0);
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int enumIndex0 = (decoder.readEnum());
@@ -426,7 +427,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         }
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumArray0 = null;
@@ -509,7 +510,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         TestRecord.put(21, testEnumUnionArray0);
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex12 = (decoder.readIndex());
@@ -518,15 +519,15 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
             TestRecord.put(22, null);
         } else {
             if (unionIndex12 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex12));
             }
         }
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -553,11 +554,11 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex13));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex14 = (decoder.readIndex());
@@ -590,7 +591,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         }
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
@@ -612,7 +613,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen4 = (decoder.arrayNext());
         }
@@ -620,31 +621,21 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen5 = (decoder.readMapStart());
         if (chunkLen5 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen5 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen5)));
             do {
                 for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen5 = (decoder.mapNext());
             } while (chunkLen5 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex16 = (decoder.readIndex());
@@ -678,7 +669,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex17 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex17));
                             }
@@ -700,17 +691,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen7 = (decoder.readMapStart());
                 if (chunkLen7 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen7 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen7)));
                     do {
                         for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
                             Utf8 key1 = (decoder.readString(null));
@@ -720,7 +701,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                                 recordsMapUnionOption0 .put(key1, null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex19));
                                 }
@@ -729,7 +710,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                         chunkLen7 = (decoder.mapNext());
                     } while (chunkLen7 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -738,7 +719,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         }
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsArrayMap0 = null;
@@ -763,16 +744,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen9 = (decoder.readMapStart());
                 if (chunkLen9 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen9 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen9)));
                     do {
                         for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -782,7 +754,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                                 recordsArrayMapElem0 .put(key2, null);
                             } else {
                                 if (unionIndex20 == 1) {
-                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex20));
                                 }
@@ -791,7 +763,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                         chunkLen9 = (decoder.mapNext());
                     } while (chunkLen9 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -801,17 +773,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen10 = (decoder.readMapStart());
         if (chunkLen10 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen10)));
             do {
                 for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                     Utf8 key3 = (decoder.readString(null));
@@ -839,7 +801,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex21 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex21));
                                 }
@@ -852,12 +814,12 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                 chunkLen10 = (decoder.mapNext());
             } while (chunkLen10 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex22 = (decoder.readIndex());
@@ -888,16 +850,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen13 = (decoder.readMapStart());
                         if (chunkLen13 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen13 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen13)));
                             do {
                                 for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
                                     Utf8 key4 = (decoder.readString(null));
@@ -907,7 +860,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                                         recordsArrayMapUnionOptionElem0 .put(key4, null);
                                     } else {
                                         if (unionIndex23 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex23));
                                         }
@@ -916,7 +869,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                                 chunkLen13 = (decoder.mapNext());
                             } while (chunkLen13 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -936,17 +889,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen14 = (decoder.readMapStart());
                 if (chunkLen14 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen14)));
                     do {
                         for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                             Utf8 key5 = (decoder.readString(null));
@@ -974,7 +917,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex25 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex25));
                                         }
@@ -987,7 +930,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
                         chunkLen14 = (decoder.mapNext());
                     } while (chunkLen14 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -996,7 +939,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex26 = (decoder.readIndex());
@@ -1005,7 +948,7 @@ public class TestRecord_SpecificDeserializer_1898726132_553331077
             TestRecord.put(32, null);
         } else {
             if (unionIndex26 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex26 == 2) {
                     Utf8 charSequence4;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_1991094399_553331077.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_1991094399_553331077.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avroutil1.Enums;
@@ -65,13 +66,13 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         this.enumMappingTestEnum3 = Collections.unmodifiableMap(tempEnumMapping3);
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.TestRecord reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.TestRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeTestRecord0((reuse), (decoder));
+        return deserializeTestRecord0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -81,23 +82,23 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
         ArrayList<Boolean> defaultArray0 = new ArrayList<Boolean>();
         TestRecord.put(33, defaultArray0);
         ArrayList<Double> defaultArray1 = new ArrayList<Double>();
@@ -113,7 +114,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -130,7 +131,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -147,7 +148,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -164,7 +165,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -181,7 +182,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -205,7 +206,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -236,7 +237,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -269,7 +270,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         }
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         byte[] testFixed0;
@@ -306,7 +307,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         }
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedArray0 = null;
@@ -389,7 +390,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(17, testFixedUnionArray0);
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int enumIndex0 = (decoder.readEnum());
@@ -430,7 +431,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         }
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumArray0 = null;
@@ -513,7 +514,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         TestRecord.put(21, testEnumUnionArray0);
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex12 = (decoder.readIndex());
@@ -522,15 +523,15 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
             TestRecord.put(22, null);
         } else {
             if (unionIndex12 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex12));
             }
         }
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -557,11 +558,11 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex13));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex14 = (decoder.readIndex());
@@ -594,7 +595,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         }
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
@@ -616,7 +617,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen4 = (decoder.arrayNext());
         }
@@ -624,31 +625,21 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen5 = (decoder.readMapStart());
         if (chunkLen5 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen5 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen5)));
             do {
                 for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen5 = (decoder.mapNext());
             } while (chunkLen5 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex16 = (decoder.readIndex());
@@ -682,7 +673,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex17 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex17));
                             }
@@ -704,17 +695,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen7 = (decoder.readMapStart());
                 if (chunkLen7 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen7 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen7)));
                     do {
                         for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
                             Utf8 key1 = (decoder.readString(null));
@@ -724,7 +705,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                                 recordsMapUnionOption0 .put(key1, null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex19));
                                 }
@@ -733,7 +714,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                         chunkLen7 = (decoder.mapNext());
                     } while (chunkLen7 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -742,7 +723,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         }
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsArrayMap0 = null;
@@ -767,16 +748,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen9 = (decoder.readMapStart());
                 if (chunkLen9 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen9 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen9)));
                     do {
                         for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -786,7 +758,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                                 recordsArrayMapElem0 .put(key2, null);
                             } else {
                                 if (unionIndex20 == 1) {
-                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex20));
                                 }
@@ -795,7 +767,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                         chunkLen9 = (decoder.mapNext());
                     } while (chunkLen9 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -805,17 +777,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen10 = (decoder.readMapStart());
         if (chunkLen10 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen10)));
             do {
                 for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                     Utf8 key3 = (decoder.readString(null));
@@ -843,7 +805,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex21 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex21));
                                 }
@@ -856,12 +818,12 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                 chunkLen10 = (decoder.mapNext());
             } while (chunkLen10 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex22 = (decoder.readIndex());
@@ -892,16 +854,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen13 = (decoder.readMapStart());
                         if (chunkLen13 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen13 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen13)));
                             do {
                                 for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
                                     Utf8 key4 = (decoder.readString(null));
@@ -911,7 +864,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                                         recordsArrayMapUnionOptionElem0 .put(key4, null);
                                     } else {
                                         if (unionIndex23 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex23));
                                         }
@@ -920,7 +873,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                                 chunkLen13 = (decoder.mapNext());
                             } while (chunkLen13 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -940,17 +893,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen14 = (decoder.readMapStart());
                 if (chunkLen14 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen14)));
                     do {
                         for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                             Utf8 key5 = (decoder.readString(null));
@@ -978,7 +921,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex25 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex25));
                                         }
@@ -991,7 +934,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
                         chunkLen14 = (decoder.mapNext());
                     } while (chunkLen14 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -1000,7 +943,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex26 = (decoder.readIndex());
@@ -1009,7 +952,7 @@ public class TestRecord_SpecificDeserializer_1991094399_553331077
             TestRecord.put(32, null);
         } else {
             if (unionIndex26 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex26 == 2) {
                     Utf8 charSequence4;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_553331077_553331077.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/TestRecord_SpecificDeserializer_553331077_553331077.java
@@ -4,7 +4,6 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveBooleanList;
@@ -14,6 +13,7 @@ import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.TestEnum;
 import com.linkedin.avro.fastserde.generated.avro.TestFixed;
 import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
@@ -37,13 +37,13 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.TestRecord reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserialize(com.linkedin.avro.fastserde.generated.avro.TestRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeTestRecord0((reuse), (decoder));
+        return deserializeTestRecord0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.TestRecord deserializeTestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord;
@@ -53,29 +53,29 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
             TestRecord = new com.linkedin.avro.fastserde.generated.avro.TestRecord();
         }
         TestRecord.put(0, (decoder.readInt()));
-        populate_TestRecord0((TestRecord), (decoder));
-        populate_TestRecord1((TestRecord), (decoder));
-        populate_TestRecord2((TestRecord), (decoder));
-        populate_TestRecord3((TestRecord), (decoder));
-        populate_TestRecord4((TestRecord), (decoder));
-        populate_TestRecord5((TestRecord), (decoder));
-        populate_TestRecord6((TestRecord), (decoder));
-        populate_TestRecord7((TestRecord), (decoder));
-        populate_TestRecord8((TestRecord), (decoder));
-        populate_TestRecord9((TestRecord), (decoder));
-        populate_TestRecord10((TestRecord), (decoder));
-        populate_TestRecord11((TestRecord), (decoder));
-        populate_TestRecord12((TestRecord), (decoder));
-        populate_TestRecord13((TestRecord), (decoder));
-        populate_TestRecord14((TestRecord), (decoder));
-        populate_TestRecord15((TestRecord), (decoder));
-        populate_TestRecord16((TestRecord), (decoder));
-        populate_TestRecord17((TestRecord), (decoder));
-        populate_TestRecord18((TestRecord), (decoder));
+        populate_TestRecord0((TestRecord), (customization), (decoder));
+        populate_TestRecord1((TestRecord), (customization), (decoder));
+        populate_TestRecord2((TestRecord), (customization), (decoder));
+        populate_TestRecord3((TestRecord), (customization), (decoder));
+        populate_TestRecord4((TestRecord), (customization), (decoder));
+        populate_TestRecord5((TestRecord), (customization), (decoder));
+        populate_TestRecord6((TestRecord), (customization), (decoder));
+        populate_TestRecord7((TestRecord), (customization), (decoder));
+        populate_TestRecord8((TestRecord), (customization), (decoder));
+        populate_TestRecord9((TestRecord), (customization), (decoder));
+        populate_TestRecord10((TestRecord), (customization), (decoder));
+        populate_TestRecord11((TestRecord), (customization), (decoder));
+        populate_TestRecord12((TestRecord), (customization), (decoder));
+        populate_TestRecord13((TestRecord), (customization), (decoder));
+        populate_TestRecord14((TestRecord), (customization), (decoder));
+        populate_TestRecord15((TestRecord), (customization), (decoder));
+        populate_TestRecord16((TestRecord), (customization), (decoder));
+        populate_TestRecord17((TestRecord), (customization), (decoder));
+        populate_TestRecord18((TestRecord), (customization), (decoder));
         return TestRecord;
     }
 
-    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord0(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -92,7 +92,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(2, (decoder.readLong()));
     }
 
-    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord1(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex1 = (decoder.readIndex());
@@ -109,7 +109,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(4, (decoder.readDouble()));
     }
 
-    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord2(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex2 = (decoder.readIndex());
@@ -126,7 +126,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(6, (decoder.readFloat()));
     }
 
-    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord3(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());
@@ -143,7 +143,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(8, (decoder.readBoolean()));
     }
 
-    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord4(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex4 = (decoder.readIndex());
@@ -167,7 +167,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(10, byteBuffer0);
     }
 
-    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord5(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex5 = (decoder.readIndex());
@@ -198,7 +198,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(12, charSequence0);
     }
 
-    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord6(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex6 = (decoder.readIndex());
@@ -232,7 +232,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(14, testFixed1);
     }
 
-    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord7(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex7 = (decoder.readIndex());
@@ -292,7 +292,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(16, testFixedArray0);
     }
 
-    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord8(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray0 = null;
@@ -342,7 +342,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(18, Enums.getConstant(TestEnum.class, (decoder.readEnum())));
     }
 
-    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord9(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex9 = (decoder.readIndex());
@@ -378,7 +378,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(20, testEnumArray0);
     }
 
-    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord10(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         List<TestEnum> testEnumUnionArray0 = null;
@@ -421,14 +421,14 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
             TestRecord.put(22, null);
         } else {
             if (unionIndex11 == 1) {
-                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder)));
+                TestRecord.put(22, deserializeSubRecord0(TestRecord.get(22), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecordUnion': "+ unionIndex11));
             }
         }
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.SubRecord deserializeSubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord;
@@ -455,11 +455,11 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                 throw new RuntimeException(("Illegal union index for 'subField': "+ unionIndex12));
             }
         }
-        populate_SubRecord0((SubRecord), (decoder));
+        populate_SubRecord0((SubRecord), (customization), (decoder));
         return SubRecord;
     }
 
-    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, Decoder decoder)
+    private void populate_SubRecord0(com.linkedin.avro.fastserde.generated.avro.SubRecord SubRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex13 = (decoder.readIndex());
@@ -482,10 +482,10 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         }
     }
 
-    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord11(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
-        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder)));
+        TestRecord.put(23, deserializeSubRecord0(TestRecord.get(23), (decoder), (customization)));
         List<com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArray0 = null;
         long chunkLen4 = (decoder.readArrayStart());
         Object oldArray4 = TestRecord.get(24);
@@ -505,39 +505,29 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                 if (oldArray4 instanceof GenericArray) {
                     recordsArrayArrayElementReuseVar0 = ((GenericArray) oldArray4).peek();
                 }
-                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder)));
+                recordsArray0 .add(deserializeSubRecord0(recordsArrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen4 = (decoder.arrayNext());
         }
         TestRecord.put(24, recordsArray0);
     }
 
-    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord12(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMap0 = null;
         long chunkLen5 = (decoder.readMapStart());
         if (chunkLen5 > 0) {
-            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapReuse0 = null;
-            Object oldMap0 = TestRecord.get(25);
-            if (oldMap0 instanceof Map) {
-                recordsMapReuse0 = ((Map) oldMap0);
-            }
-            if (recordsMapReuse0 != (null)) {
-                recordsMapReuse0 .clear();
-                recordsMap0 = recordsMapReuse0;
-            } else {
-                recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen5 * 4)+ 2)/ 3)));
-            }
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), ((int) chunkLen5)));
             do {
                 for (int counter5 = 0; (counter5 <chunkLen5); counter5 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder)));
+                    recordsMap0 .put(key0, deserializeSubRecord0(null, (decoder), (customization)));
                 }
                 chunkLen5 = (decoder.mapNext());
             } while (chunkLen5 > 0);
         } else {
-            recordsMap0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+            recordsMap0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(25), 0));
         }
         TestRecord.put(25, recordsMap0);
         int unionIndex14 = (decoder.readIndex());
@@ -571,7 +561,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                             recordsArrayUnionOption0 .add(null);
                         } else {
                             if (unionIndex15 == 1) {
-                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder)));
+                                recordsArrayUnionOption0 .add(deserializeSubRecord0(recordsArrayUnionOptionArrayElementReuseVar0, (decoder), (customization)));
                             } else {
                                 throw new RuntimeException(("Illegal union index for 'recordsArrayUnionOptionElem': "+ unionIndex15));
                             }
@@ -586,7 +576,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         }
     }
 
-    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord13(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex16 = (decoder.readIndex());
@@ -598,17 +588,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOption0 = null;
                 long chunkLen7 = (decoder.readMapStart());
                 if (chunkLen7 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsMapUnionOptionReuse0 = null;
-                    Object oldMap1 = TestRecord.get(27);
-                    if (oldMap1 instanceof Map) {
-                        recordsMapUnionOptionReuse0 = ((Map) oldMap1);
-                    }
-                    if (recordsMapUnionOptionReuse0 != (null)) {
-                        recordsMapUnionOptionReuse0 .clear();
-                        recordsMapUnionOption0 = recordsMapUnionOptionReuse0;
-                    } else {
-                        recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen7 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), ((int) chunkLen7)));
                     do {
                         for (int counter7 = 0; (counter7 <chunkLen7); counter7 ++) {
                             Utf8 key1 = (decoder.readString(null));
@@ -618,7 +598,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                                 recordsMapUnionOption0 .put(key1, null);
                             } else {
                                 if (unionIndex17 == 1) {
-                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder)));
+                                    recordsMapUnionOption0 .put(key1, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapUnionOptionValue': "+ unionIndex17));
                                 }
@@ -627,7 +607,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                         chunkLen7 = (decoder.mapNext());
                     } while (chunkLen7 > 0);
                 } else {
-                    recordsMapUnionOption0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsMapUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(27), 0));
                 }
                 TestRecord.put(27, recordsMapUnionOption0);
             } else {
@@ -656,16 +636,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                 Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElem0 = null;
                 long chunkLen9 = (decoder.readMapStart());
                 if (chunkLen9 > 0) {
-                    Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapElemReuse0 = null;
-                    if (recordsArrayMapArrayElementReuseVar0 instanceof Map) {
-                        recordsArrayMapElemReuse0 = ((Map) recordsArrayMapArrayElementReuseVar0);
-                    }
-                    if (recordsArrayMapElemReuse0 != (null)) {
-                        recordsArrayMapElemReuse0 .clear();
-                        recordsArrayMapElem0 = recordsArrayMapElemReuse0;
-                    } else {
-                        recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen9 * 4)+ 2)/ 3)));
-                    }
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, ((int) chunkLen9)));
                     do {
                         for (int counter9 = 0; (counter9 <chunkLen9); counter9 ++) {
                             Utf8 key2 = (decoder.readString(null));
@@ -675,7 +646,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                                 recordsArrayMapElem0 .put(key2, null);
                             } else {
                                 if (unionIndex18 == 1) {
-                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder)));
+                                    recordsArrayMapElem0 .put(key2, deserializeSubRecord0(null, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsArrayMapElemValue': "+ unionIndex18));
                                 }
@@ -684,7 +655,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                         chunkLen9 = (decoder.mapNext());
                     } while (chunkLen9 > 0);
                 } else {
-                    recordsArrayMapElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                    recordsArrayMapElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapArrayElementReuseVar0, 0));
                 }
                 recordsArrayMap0 .add(recordsArrayMapElem0);
             }
@@ -693,23 +664,13 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(28, recordsArrayMap0);
     }
 
-    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord14(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArray0 = null;
         long chunkLen10 = (decoder.readMapStart());
         if (chunkLen10 > 0) {
-            Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayReuse0 = null;
-            Object oldMap2 = TestRecord.get(29);
-            if (oldMap2 instanceof Map) {
-                recordsMapArrayReuse0 = ((Map) oldMap2);
-            }
-            if (recordsMapArrayReuse0 != (null)) {
-                recordsMapArrayReuse0 .clear();
-                recordsMapArray0 = recordsMapArrayReuse0;
-            } else {
-                recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen10 * 4)+ 2)/ 3)));
-            }
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), ((int) chunkLen10)));
             do {
                 for (int counter10 = 0; (counter10 <chunkLen10); counter10 ++) {
                     Utf8 key3 = (decoder.readString(null));
@@ -737,7 +698,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                                 recordsMapArrayValue0 .add(null);
                             } else {
                                 if (unionIndex19 == 1) {
-                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder)));
+                                    recordsMapArrayValue0 .add(deserializeSubRecord0(recordsMapArrayValueArrayElementReuseVar0, (decoder), (customization)));
                                 } else {
                                     throw new RuntimeException(("Illegal union index for 'recordsMapArrayValueElem': "+ unionIndex19));
                                 }
@@ -750,7 +711,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                 chunkLen10 = (decoder.mapNext());
             } while (chunkLen10 > 0);
         } else {
-            recordsMapArray0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+            recordsMapArray0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(29), 0));
         }
         TestRecord.put(29, recordsMapArray0);
         int unionIndex20 = (decoder.readIndex());
@@ -781,16 +742,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                         Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElem0 = null;
                         long chunkLen13 = (decoder.readMapStart());
                         if (chunkLen13 > 0) {
-                            Map<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord> recordsArrayMapUnionOptionElemReuse0 = null;
-                            if (recordsArrayMapUnionOptionArrayElementReuseVar0 instanceof Map) {
-                                recordsArrayMapUnionOptionElemReuse0 = ((Map) recordsArrayMapUnionOptionArrayElementReuseVar0);
-                            }
-                            if (recordsArrayMapUnionOptionElemReuse0 != (null)) {
-                                recordsArrayMapUnionOptionElemReuse0 .clear();
-                                recordsArrayMapUnionOptionElem0 = recordsArrayMapUnionOptionElemReuse0;
-                            } else {
-                                recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(((int)(((chunkLen13 * 4)+ 2)/ 3)));
-                            }
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, ((int) chunkLen13)));
                             do {
                                 for (int counter13 = 0; (counter13 <chunkLen13); counter13 ++) {
                                     Utf8 key4 = (decoder.readString(null));
@@ -800,7 +752,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                                         recordsArrayMapUnionOptionElem0 .put(key4, null);
                                     } else {
                                         if (unionIndex21 == 1) {
-                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder)));
+                                            recordsArrayMapUnionOptionElem0 .put(key4, deserializeSubRecord0(null, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsArrayMapUnionOptionElemValue': "+ unionIndex21));
                                         }
@@ -809,7 +761,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                                 chunkLen13 = (decoder.mapNext());
                             } while (chunkLen13 > 0);
                         } else {
-                            recordsArrayMapUnionOptionElem0 = new HashMap<Utf8, com.linkedin.avro.fastserde.generated.avro.SubRecord>(0);
+                            recordsArrayMapUnionOptionElem0 = ((Map)(customization).getNewMapOverrideFunc().apply(recordsArrayMapUnionOptionArrayElementReuseVar0, 0));
                         }
                         recordsArrayMapUnionOption0 .add(recordsArrayMapUnionOptionElem0);
                     }
@@ -822,7 +774,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         }
     }
 
-    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord15(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex22 = (decoder.readIndex());
@@ -834,17 +786,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                 Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOption0 = null;
                 long chunkLen14 = (decoder.readMapStart());
                 if (chunkLen14 > 0) {
-                    Map<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>> recordsMapArrayUnionOptionReuse0 = null;
-                    Object oldMap3 = TestRecord.get(31);
-                    if (oldMap3 instanceof Map) {
-                        recordsMapArrayUnionOptionReuse0 = ((Map) oldMap3);
-                    }
-                    if (recordsMapArrayUnionOptionReuse0 != (null)) {
-                        recordsMapArrayUnionOptionReuse0 .clear();
-                        recordsMapArrayUnionOption0 = recordsMapArrayUnionOptionReuse0;
-                    } else {
-                        recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(((int)(((chunkLen14 * 4)+ 2)/ 3)));
-                    }
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), ((int) chunkLen14)));
                     do {
                         for (int counter14 = 0; (counter14 <chunkLen14); counter14 ++) {
                             Utf8 key5 = (decoder.readString(null));
@@ -872,7 +814,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                                         recordsMapArrayUnionOptionValue0 .add(null);
                                     } else {
                                         if (unionIndex23 == 1) {
-                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder)));
+                                            recordsMapArrayUnionOptionValue0 .add(deserializeSubRecord0(recordsMapArrayUnionOptionValueArrayElementReuseVar0, (decoder), (customization)));
                                         } else {
                                             throw new RuntimeException(("Illegal union index for 'recordsMapArrayUnionOptionValueElem': "+ unionIndex23));
                                         }
@@ -885,7 +827,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
                         chunkLen14 = (decoder.mapNext());
                     } while (chunkLen14 > 0);
                 } else {
-                    recordsMapArrayUnionOption0 = new HashMap<Utf8, List<com.linkedin.avro.fastserde.generated.avro.SubRecord>>(0);
+                    recordsMapArrayUnionOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(TestRecord.get(31), 0));
                 }
                 TestRecord.put(31, recordsMapArrayUnionOption0);
             } else {
@@ -898,7 +840,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
             TestRecord.put(32, null);
         } else {
             if (unionIndex24 == 1) {
-                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder)));
+                TestRecord.put(32, deserializeSubRecord0(TestRecord.get(32), (decoder), (customization)));
             } else {
                 if (unionIndex24 == 2) {
                     Utf8 charSequence4;
@@ -920,7 +862,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         }
     }
 
-    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord16(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveBooleanList booleanArray0 = null;
@@ -957,7 +899,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(34, doubleArray0);
     }
 
-    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord17(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveFloatList floatArray0 = null;
@@ -981,7 +923,7 @@ public class TestRecord_SpecificDeserializer_553331077_553331077
         TestRecord.put(36, intArray0);
     }
 
-    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, Decoder decoder)
+    private void populate_TestRecord18(com.linkedin.avro.fastserde.generated.avro.TestRecord TestRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         PrimitiveLongList longArray0 = null;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_1971822364_1672473580.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_1971822364_1672473580.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class UNION_GenericDeserializer_1971822364_1672473580
         this.recordRecordSchema0 = readerSchema.getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_2018567528_1606337179.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_2018567528_1606337179.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,7 +24,7 @@ public class UNION_GenericDeserializer_2018567528_1606337179
         this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();
     }
 
-    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder)
+    public List<IndexedRecord> deserialize(List<IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         List<IndexedRecord> array0 = null;
@@ -44,14 +45,14 @@ public class UNION_GenericDeserializer_2018567528_1606337179
                 if ((reuse) instanceof GenericArray) {
                     arrayArrayElementReuseVar0 = ((GenericArray)(reuse)).peek();
                 }
-                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder)));
+                array0 .add(deserializerecord0(arrayArrayElementReuseVar0, (decoder), (customization)));
             }
             chunkLen0 = (decoder.arrayNext());
         }
         return array0;
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_568621313_1223705675.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UNION_GenericDeserializer_568621313_1223705675.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,36 +24,27 @@ public class UNION_GenericDeserializer_568621313_1223705675
         this.mapMapValueSchema0 = mapMapSchema0 .getValueType();
     }
 
-    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder)
+    public Map<Utf8, IndexedRecord> deserialize(Map<Utf8, IndexedRecord> reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         Map<Utf8, IndexedRecord> map0 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, IndexedRecord> mapReuse0 = null;
-            if ((reuse) instanceof Map) {
-                mapReuse0 = ((Map)(reuse));
-            }
-            if (mapReuse0 != (null)) {
-                mapReuse0 .clear();
-                map0 = mapReuse0;
-            } else {
-                map0 = new HashMap<Utf8, IndexedRecord>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
-                    map0 .put(key0, deserializerecord0(null, (decoder)));
+                    map0 .put(key0, deserializerecord0(null, (decoder), (customization)));
                 }
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            map0 = new HashMap<Utf8, IndexedRecord>(0);
+            map0 = ((Map)(customization).getNewMapOverrideFunc().apply((reuse), 0));
         }
         return map0;
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_1341667615_1341667615.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_1341667615_1341667615.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.generated.avro.MyEnumV1;
 import com.linkedin.avro.fastserde.generated.avro.MyEnumV2;
 import com.linkedin.avroutil1.Enums;
@@ -19,13 +20,13 @@ public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_1341667615
         this.readerSchema = readerSchema;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserialize(com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder));
+        return deserializeUnionOfRecordsWithSameNameEnumField0((reuse), (decoder), (customization));
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField deserializeUnionOfRecordsWithSameNameEnumField0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.UnionOfRecordsWithSameNameEnumField UnionOfRecordsWithSameNameEnumField;
@@ -36,10 +37,10 @@ public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_1341667615
         }
         int unionIndex0 = (decoder.readIndex());
         if (unionIndex0 == 0) {
-            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+            UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV10(UnionOfRecordsWithSameNameEnumField.get(0), (decoder), (customization)));
         } else {
             if (unionIndex0 == 1) {
-                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder)));
+                UnionOfRecordsWithSameNameEnumField.put(0, deserializeMyRecordV20(UnionOfRecordsWithSameNameEnumField.get(0), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
             }
@@ -47,7 +48,7 @@ public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_1341667615
         return UnionOfRecordsWithSameNameEnumField;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV1 deserializeMyRecordV10(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.MyRecordV1 MyRecordV1;
@@ -60,7 +61,7 @@ public class UnionOfRecordsWithSameNameEnumField_SpecificDeserializer_1341667615
         return MyRecordV1;
     }
 
-    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder)
+    public com.linkedin.avro.fastserde.generated.avro.MyRecordV2 deserializeMyRecordV20(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         com.linkedin.avro.fastserde.generated.avro.MyRecordV2 MyRecordV2;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/recordName_GenericDeserializer_1743054079_1743054079.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/recordName_GenericDeserializer_1743054079_1743054079.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -20,13 +21,13 @@ public class recordName_GenericDeserializer_1743054079_1743054079
         this.unionField0 = readerSchema.getField("unionField").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecordName0((reuse), (decoder));
+        return deserializerecordName0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecordName0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecordName0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord recordName;
@@ -43,11 +44,11 @@ public class recordName_GenericDeserializer_1743054079_1743054079
             charSequence0 = (decoder).readString(null);
         }
         recordName.put(0, charSequence0);
-        populate_recordName0((recordName), (decoder));
+        populate_recordName0((recordName), (customization), (decoder));
         return recordName;
     }
 
-    private void populate_recordName0(IndexedRecord recordName, Decoder decoder)
+    private void populate_recordName0(IndexedRecord recordName, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -56,7 +57,7 @@ public class recordName_GenericDeserializer_1743054079_1743054079
             recordName.put(1, null);
         } else {
             if (unionIndex0 == 1) {
-                recordName.put(1, deserializerecordName0(recordName.get(1), (decoder)));
+                recordName.put(1, deserializerecordName0(recordName.get(1), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'unionField': "+ unionIndex0));
             }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1025741720_1557256887.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1025741720_1557256887.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +23,13 @@ public class record_GenericDeserializer_1025741720_1557256887
         this.someInts0 = readerSchema.getField("someInts").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;
@@ -46,17 +46,7 @@ public class record_GenericDeserializer_1025741720_1557256887
                 Map<Utf8, Integer> someIntsOption0 = null;
                 long chunkLen0 = (decoder.readMapStart());
                 if (chunkLen0 > 0) {
-                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
-                    Object oldMap0 = record.get(0);
-                    if (oldMap0 instanceof Map) {
-                        someIntsOptionReuse0 = ((Map) oldMap0);
-                    }
-                    if (someIntsOptionReuse0 != (null)) {
-                        someIntsOptionReuse0 .clear();
-                        someIntsOption0 = someIntsOptionReuse0;
-                    } else {
-                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                    }
+                    someIntsOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), ((int) chunkLen0)));
                     do {
                         for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -74,7 +64,7 @@ public class record_GenericDeserializer_1025741720_1557256887
                         chunkLen0 = (decoder.mapNext());
                     } while (chunkLen0 > 0);
                 } else {
-                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                    someIntsOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), 0));
                 }
                 record.put(0, someIntsOption0);
             } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1126840752_2099305627.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1126840752_2099305627.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -18,13 +19,13 @@ public class record_GenericDeserializer_1126840752_2099305627
         this.readerSchema = readerSchema;
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1191367445_653449771.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1191367445_653449771.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
@@ -22,13 +23,13 @@ public class record_GenericDeserializer_1191367445_653449771
         this.someInts0 = readerSchema.getField("someInts").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1373882843_1971822364.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1373882843_1971822364.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -17,13 +18,13 @@ public class record_GenericDeserializer_1373882843_1971822364
         this.readerSchema = readerSchema;
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1556659421_711533897.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1556659421_711533897.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -20,13 +21,13 @@ public class record_GenericDeserializer_1556659421_711533897
         this.subRecord0 = readerSchema.getField("subRecord").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;
@@ -40,7 +41,7 @@ public class record_GenericDeserializer_1556659421_711533897
             throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"subRecord\",\"namespace\":\"com.linkedin.avro.fastserde.generated.avro\",\"doc\":\"subRecord\",\"fields\":[{\"name\":\"someInt1\",\"type\":\"int\",\"doc\":\"\"},{\"name\":\"someInt2\",\"type\":\"int\",\"doc\":\"\"}]}");
         } else {
             if (unionIndex0 == 1) {
-                record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+                record.put(0, deserializesubRecord0(record.get(0), (decoder), (customization)));
             } else {
                 throw new RuntimeException(("Illegal union index for 'subRecord': "+ unionIndex0));
             }
@@ -48,7 +49,7 @@ public class record_GenericDeserializer_1556659421_711533897
         return record;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -58,11 +59,11 @@ public class record_GenericDeserializer_1556659421_711533897
             subRecord = new org.apache.avro.generic.GenericData.Record(subRecord0);
         }
         subRecord.put(0, (decoder.readInt()));
-        populate_subRecord0((subRecord), (decoder));
+        populate_subRecord0((subRecord), (customization), (decoder));
         return subRecord;
     }
 
-    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord0(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         subRecord.put(1, (decoder.readInt()));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1557256887_1025741720.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1557256887_1025741720.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -26,13 +26,13 @@ public class record_GenericDeserializer_1557256887_1025741720
         this.someIntsMapValueSchema0 = someIntsMapSchema0 .getValueType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;
@@ -44,17 +44,7 @@ public class record_GenericDeserializer_1557256887_1025741720
         Map<Utf8, Integer> someInts1 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, Integer> someIntsReuse0 = null;
-            Object oldMap0 = record.get(0);
-            if (oldMap0 instanceof Map) {
-                someIntsReuse0 = ((Map) oldMap0);
-            }
-            if (someIntsReuse0 != (null)) {
-                someIntsReuse0 .clear();
-                someInts1 = someIntsReuse0;
-            } else {
-                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            someInts1 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
@@ -63,7 +53,7 @@ public class record_GenericDeserializer_1557256887_1025741720
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            someInts1 = new HashMap<Utf8, Integer>(0);
+            someInts1 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), 0));
         }
         record.put(0, someInts1);
         return record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1557256887_753570467.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1557256887_753570467.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +24,13 @@ public class record_GenericDeserializer_1557256887_753570467
         this.someIntsMapSchema0 = someInts0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;
@@ -42,17 +42,7 @@ public class record_GenericDeserializer_1557256887_753570467
         Map<Utf8, Integer> someInts1 = null;
         long chunkLen0 = (decoder.readMapStart());
         if (chunkLen0 > 0) {
-            Map<Utf8, Integer> someIntsReuse0 = null;
-            Object oldMap0 = record.get(0);
-            if (oldMap0 instanceof Map) {
-                someIntsReuse0 = ((Map) oldMap0);
-            }
-            if (someIntsReuse0 != (null)) {
-                someIntsReuse0 .clear();
-                someInts1 = someIntsReuse0;
-            } else {
-                someInts1 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-            }
+            someInts1 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), ((int) chunkLen0)));
             do {
                 for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                     Utf8 key0 = (decoder.readString(null));
@@ -61,7 +51,7 @@ public class record_GenericDeserializer_1557256887_753570467
                 chunkLen0 = (decoder.mapNext());
             } while (chunkLen0 > 0);
         } else {
-            someInts1 = new HashMap<Utf8, Integer>(0);
+            someInts1 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), 0));
         }
         record.put(0, someInts1);
         return record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1672473580_1971822364.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1672473580_1971822364.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -18,7 +19,7 @@ public class record_GenericDeserializer_1672473580_1971822364
         this.readerSchema = readerSchema;
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         int unionIndex0 = (decoder.readIndex());
@@ -26,14 +27,14 @@ public class record_GenericDeserializer_1672473580_1971822364
             throw new AvroTypeException("Found \"null\", expecting {\"type\":\"record\",\"name\":\"record\",\"namespace\":\"com.linkedin.avro.fastserde.generated.avro\",\"doc\":\"record\",\"fields\":[{\"name\":\"someInt\",\"type\":\"int\",\"doc\":\"\"}]}");
         } else {
             if (unionIndex0 == 1) {
-                return deserializerecord0((reuse), (decoder));
+                return deserializerecord0((reuse), (decoder), (customization));
             } else {
                 throw new RuntimeException(("Illegal union index for 'union': "+ unionIndex0));
             }
         }
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1971822364_1373882843.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_1971822364_1373882843.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -19,13 +20,13 @@ public class record_GenericDeserializer_1971822364_1373882843
         this.someInt0 = readerSchema.getField("someInt").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_653449771_1191367445.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_653449771_1191367445.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +24,13 @@ public class record_GenericDeserializer_653449771_1191367445
         this.someIntsArraySchema0 = someInts0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_653449771_813379571.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_653449771_813379571.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -24,13 +25,13 @@ public class record_GenericDeserializer_653449771_813379571
         this.someIntsArrayElemSchema0 = someIntsArraySchema0 .getElementType();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_711533897_1556659421.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_711533897_1556659421.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
@@ -21,13 +22,13 @@ public class record_GenericDeserializer_711533897_1556659421
         this.subRecordRecordSchema0 = subRecord0 .getTypes().get(1);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;
@@ -36,11 +37,11 @@ public class record_GenericDeserializer_711533897_1556659421
         } else {
             record = new org.apache.avro.generic.GenericData.Record(readerSchema);
         }
-        record.put(0, deserializesubRecord0(record.get(0), (decoder)));
+        record.put(0, deserializesubRecord0(record.get(0), (decoder), (customization)));
         return record;
     }
 
-    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializesubRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord subRecord;
@@ -50,11 +51,11 @@ public class record_GenericDeserializer_711533897_1556659421
             subRecord = new org.apache.avro.generic.GenericData.Record(subRecordRecordSchema0);
         }
         subRecord.put(0, (decoder.readInt()));
-        populate_subRecord0((subRecord), (decoder));
+        populate_subRecord0((subRecord), (customization), (decoder));
         return subRecord;
     }
 
-    private void populate_subRecord0(IndexedRecord subRecord, Decoder decoder)
+    private void populate_subRecord0(IndexedRecord subRecord, DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         subRecord.put(1, (decoder.readInt()));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_753570467_1557256887.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_753570467_1557256887.java
@@ -2,9 +2,9 @@
 package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -23,13 +23,13 @@ public class record_GenericDeserializer_753570467_1557256887
         this.someInts0 = readerSchema.getField("someInts").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;
@@ -46,17 +46,7 @@ public class record_GenericDeserializer_753570467_1557256887
                 Map<Utf8, Integer> someIntsOption0 = null;
                 long chunkLen0 = (decoder.readMapStart());
                 if (chunkLen0 > 0) {
-                    Map<Utf8, Integer> someIntsOptionReuse0 = null;
-                    Object oldMap0 = record.get(0);
-                    if (oldMap0 instanceof Map) {
-                        someIntsOptionReuse0 = ((Map) oldMap0);
-                    }
-                    if (someIntsOptionReuse0 != (null)) {
-                        someIntsOptionReuse0 .clear();
-                        someIntsOption0 = someIntsOptionReuse0;
-                    } else {
-                        someIntsOption0 = new HashMap<Utf8, Integer>(((int)(((chunkLen0 * 4)+ 2)/ 3)));
-                    }
+                    someIntsOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), ((int) chunkLen0)));
                     do {
                         for (int counter0 = 0; (counter0 <chunkLen0); counter0 ++) {
                             Utf8 key0 = (decoder.readString(null));
@@ -65,7 +55,7 @@ public class record_GenericDeserializer_753570467_1557256887
                         chunkLen0 = (decoder.mapNext());
                     } while (chunkLen0 > 0);
                 } else {
-                    someIntsOption0 = new HashMap<Utf8, Integer>(0);
+                    someIntsOption0 = ((Map)(customization).getNewMapOverrideFunc().apply(record.get(0), 0));
                 }
                 record.put(0, someIntsOption0);
             } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_813379571_653449771.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/record_GenericDeserializer_813379571_653449771.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
 import java.io.IOException;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
@@ -23,13 +24,13 @@ public class record_GenericDeserializer_813379571_653449771
         this.someInts0 = readerSchema.getField("someInts").schema();
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializerecord0((reuse), (decoder));
+        return deserializerecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializerecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord record;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/testRecord_GenericDeserializer_1146484089_1256982207.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/testRecord_GenericDeserializer_1146484089_1256982207.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -30,13 +31,13 @@ public class testRecord_GenericDeserializer_1146484089_1256982207
         this.enumMappingtestEnum0 = Collections.unmodifiableMap(tempEnumMapping0);
     }
 
-    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder)
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
-        return deserializetestRecord0((reuse), (decoder));
+        return deserializetestRecord0((reuse), (decoder), (customization));
     }
 
-    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder)
+    public IndexedRecord deserializetestRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
         throws IOException
     {
         IndexedRecord testRecord;

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_BOOLEAN_GenericSerializer_869749973.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_BOOLEAN_GenericSerializer_869749973.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveBooleanList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.io.Encoder;
 
 public class Array_of_BOOLEAN_GenericSerializer_869749973
@@ -12,7 +13,7 @@ public class Array_of_BOOLEAN_GenericSerializer_869749973
 {
 
 
-    public void serialize(List<Boolean> data, Encoder encoder)
+    public void serialize(List<Boolean> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_DOUBLE_GenericSerializer_18760307.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_DOUBLE_GenericSerializer_18760307.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveDoubleList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.io.Encoder;
 
 public class Array_of_DOUBLE_GenericSerializer_18760307
@@ -12,7 +13,7 @@ public class Array_of_DOUBLE_GenericSerializer_18760307
 {
 
 
-    public void serialize(List<Double> data, Encoder encoder)
+    public void serialize(List<Double> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_FLOAT_GenericSerializer_1012670397.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_FLOAT_GenericSerializer_1012670397.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.io.Encoder;
 
 public class Array_of_FLOAT_GenericSerializer_1012670397
@@ -13,7 +14,7 @@ public class Array_of_FLOAT_GenericSerializer_1012670397
 {
 
 
-    public void serialize(List<Float> data, Encoder encoder)
+    public void serialize(List<Float> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_INT_GenericSerializer_1012089072.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_INT_GenericSerializer_1012089072.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.io.Encoder;
 
 public class Array_of_INT_GenericSerializer_1012089072
@@ -12,7 +13,7 @@ public class Array_of_INT_GenericSerializer_1012089072
 {
 
 
-    public void serialize(List<Integer> data, Encoder encoder)
+    public void serialize(List<Integer> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_LONG_GenericSerializer_325099267.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_LONG_GenericSerializer_325099267.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.api.PrimitiveLongList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.io.Encoder;
 
 public class Array_of_LONG_GenericSerializer_325099267
@@ -12,7 +13,7 @@ public class Array_of_LONG_GenericSerializer_325099267
 {
 
 
-    public void serialize(List<Long> data, Encoder encoder)
+    public void serialize(List<Long> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_UNION_GenericSerializer_777827233.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_UNION_GenericSerializer_777827233.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -13,7 +14,7 @@ public class Array_of_UNION_GenericSerializer_777827233
 {
 
 
-    public void serialize(List<IndexedRecord> data, Encoder encoder)
+    public void serialize(List<IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();
@@ -31,7 +32,7 @@ public class Array_of_UNION_GenericSerializer_777827233
                 } else {
                     if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializeRecord0(((IndexedRecord) union0), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder), (customization));
                     }
                 }
             }
@@ -40,7 +41,7 @@ public class Array_of_UNION_GenericSerializer_777827233
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence field0 = ((CharSequence) data.get(0));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_record_GenericSerializer_477614132.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_record_GenericSerializer_477614132.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -13,7 +14,7 @@ public class Array_of_record_GenericSerializer_477614132
 {
 
 
-    public void serialize(List<IndexedRecord> data, Encoder encoder)
+    public void serialize(List<IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeArrayStart();
@@ -25,14 +26,14 @@ public class Array_of_record_GenericSerializer_477614132
                 (encoder).startItem();
                 IndexedRecord record0 = null;
                 record0 = ((List<IndexedRecord> ) data).get(counter0);
-                serializeRecord0(record0, (encoder));
+                serializeRecord0(record0, (encoder), (customization));
             }
         }
         (encoder).writeArrayEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence field0 = ((CharSequence) data.get(0));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_GenericSerializer_312360713.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_GenericSerializer_312360713.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 
@@ -11,521 +12,521 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord1(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord2(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord3(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord4(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord5(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord6(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord7(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord8(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord9(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord10(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord11(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord12(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord13(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord14(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord15(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord16(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord17(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord18(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord19(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord20(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord21(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord22(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord23(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord24(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord25(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord26(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord27(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord28(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord29(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord30(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord31(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord32(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord33(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord34(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord35(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord36(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord37(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord38(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord39(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord40(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord41(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord42(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord43(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord44(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord45(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord46(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord47(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord48(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord49(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord50(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord51(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord52(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord53(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord54(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord55(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord56(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord57(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord58(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord59(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord60(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord61(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord62(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord63(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord64(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord65(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord66(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord67(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord68(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord69(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord70(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord71(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord72(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord73(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord74(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord75(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord76(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord77(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord78(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord79(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord80(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord81(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord82(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord83(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord84(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord85(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord86(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord87(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord88(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord89(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord90(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord91(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord92(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord93(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord94(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord95(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord96(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord97(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord98(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord99(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord100(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord101(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord102(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord103(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord104(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord105(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord106(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord107(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord108(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord109(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord110(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord111(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord112(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord113(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord114(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord115(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord116(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord117(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord118(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord119(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord120(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord121(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord122(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord123(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord124(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord125(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord126(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord127(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord128(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord129(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord130(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord131(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord132(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord133(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord134(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord135(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord136(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord137(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord138(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord139(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord140(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord141(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord142(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord143(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord144(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord145(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord146(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord147(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord148(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord149(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord150(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord151(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord152(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord153(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord154(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord155(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord156(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord157(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord158(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord159(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord160(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord161(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord162(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord163(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord164(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord165(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord166(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord167(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord168(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord169(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord170(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord171(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord172(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord173(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord174(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord175(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord176(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord177(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord178(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord179(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord180(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord181(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord182(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord183(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord184(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord185(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord186(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord187(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord188(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord189(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord190(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord191(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord192(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord193(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord194(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord195(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord196(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord197(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord198(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord199(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord200(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord201(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord202(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord203(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord204(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord205(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord206(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord207(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord208(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord209(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord210(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord211(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord212(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord213(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord214(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord215(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord216(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord217(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord218(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord219(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord220(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord221(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord222(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord223(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord224(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord225(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord226(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord227(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord228(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord229(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord230(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord231(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord232(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord233(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord234(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord235(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord236(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord237(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord238(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord239(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord240(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord241(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord242(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord243(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord244(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord245(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord246(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord247(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord248(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord249(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord250(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord251(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord252(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord253(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord254(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord255(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord256(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord257(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord258(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord259(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord260(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord261(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord262(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord263(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord264(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord265(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord266(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord267(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord268(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord269(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord270(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord271(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord272(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord273(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord274(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord275(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord276(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord277(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord278(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord279(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord280(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord281(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord282(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord283(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord284(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord285(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord286(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord287(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord288(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord289(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord290(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord291(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord292(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord293(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord294(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord295(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord296(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord297(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord298(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord299(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord300(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord301(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord302(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord303(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord304(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord305(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord306(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord307(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord308(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord309(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord310(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord311(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord312(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord313(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord314(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord315(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord316(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord317(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord318(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord319(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord320(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord321(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord322(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord323(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord324(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord325(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord326(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord327(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord328(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord329(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord330(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord331(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord332(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord333(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord334(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord335(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord336(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord337(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord338(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord339(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord340(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord341(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord342(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord343(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord344(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord345(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord346(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord347(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord348(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord349(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord350(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord351(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord352(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord353(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord354(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord355(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord356(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord357(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord358(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord359(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord360(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord361(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord362(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord363(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord364(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord365(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord366(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord367(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord368(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord369(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord370(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord371(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord372(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord373(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord374(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord375(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord376(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord377(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord378(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord379(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord380(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord381(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord382(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord383(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord384(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord385(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord386(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord387(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord388(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord389(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord390(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord391(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord392(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord393(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord394(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord395(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord396(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord397(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord398(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord399(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord400(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord401(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord402(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord403(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord404(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord405(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord406(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord407(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord408(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord409(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord410(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord411(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord412(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord413(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord414(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord415(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord416(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord417(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord418(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord419(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord420(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord421(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord422(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord423(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord424(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord425(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord426(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord427(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord428(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord429(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord430(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord431(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord432(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord433(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord434(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord435(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord436(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord437(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord438(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord439(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord440(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord441(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord442(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord443(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord444(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord445(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord446(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord447(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord448(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord449(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord450(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord451(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord452(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord453(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord454(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord455(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord456(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord457(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord458(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord459(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord460(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord461(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord462(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord463(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord464(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord465(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord466(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord467(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord468(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord469(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord470(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord471(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord472(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord473(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord474(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord475(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord476(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord477(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord478(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord479(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord480(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord481(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord482(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord483(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord484(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord485(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord486(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord487(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord488(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord489(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord490(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord491(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord492(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord493(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord494(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord495(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord496(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord497(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord498(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord499(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord1(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord2(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord3(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord4(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord5(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord6(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord7(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord8(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord9(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord10(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord11(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord12(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord13(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord14(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord15(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord16(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord17(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord18(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord19(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord20(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord21(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord22(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord23(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord24(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord25(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord26(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord27(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord28(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord29(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord30(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord31(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord32(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord33(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord34(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord35(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord36(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord37(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord38(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord39(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord40(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord41(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord42(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord43(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord44(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord45(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord46(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord47(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord48(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord49(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord50(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord51(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord52(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord53(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord54(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord55(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord56(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord57(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord58(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord59(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord60(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord61(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord62(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord63(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord64(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord65(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord66(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord67(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord68(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord69(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord70(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord71(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord72(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord73(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord74(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord75(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord76(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord77(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord78(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord79(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord80(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord81(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord82(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord83(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord84(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord85(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord86(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord87(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord88(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord89(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord90(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord91(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord92(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord93(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord94(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord95(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord96(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord97(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord98(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord99(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord100(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord101(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord102(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord103(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord104(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord105(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord106(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord107(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord108(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord109(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord110(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord111(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord112(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord113(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord114(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord115(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord116(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord117(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord118(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord119(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord120(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord121(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord122(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord123(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord124(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord125(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord126(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord127(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord128(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord129(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord130(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord131(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord132(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord133(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord134(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord135(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord136(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord137(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord138(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord139(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord140(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord141(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord142(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord143(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord144(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord145(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord146(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord147(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord148(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord149(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord150(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord151(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord152(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord153(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord154(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord155(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord156(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord157(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord158(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord159(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord160(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord161(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord162(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord163(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord164(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord165(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord166(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord167(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord168(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord169(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord170(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord171(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord172(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord173(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord174(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord175(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord176(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord177(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord178(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord179(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord180(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord181(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord182(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord183(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord184(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord185(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord186(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord187(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord188(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord189(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord190(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord191(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord192(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord193(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord194(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord195(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord196(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord197(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord198(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord199(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord200(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord201(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord202(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord203(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord204(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord205(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord206(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord207(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord208(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord209(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord210(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord211(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord212(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord213(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord214(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord215(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord216(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord217(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord218(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord219(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord220(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord221(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord222(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord223(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord224(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord225(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord226(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord227(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord228(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord229(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord230(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord231(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord232(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord233(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord234(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord235(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord236(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord237(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord238(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord239(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord240(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord241(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord242(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord243(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord244(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord245(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord246(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord247(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord248(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord249(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord250(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord251(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord252(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord253(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord254(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord255(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord256(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord257(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord258(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord259(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord260(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord261(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord262(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord263(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord264(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord265(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord266(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord267(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord268(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord269(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord270(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord271(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord272(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord273(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord274(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord275(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord276(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord277(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord278(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord279(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord280(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord281(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord282(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord283(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord284(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord285(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord286(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord287(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord288(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord289(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord290(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord291(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord292(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord293(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord294(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord295(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord296(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord297(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord298(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord299(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord300(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord301(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord302(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord303(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord304(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord305(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord306(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord307(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord308(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord309(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord310(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord311(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord312(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord313(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord314(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord315(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord316(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord317(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord318(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord319(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord320(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord321(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord322(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord323(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord324(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord325(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord326(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord327(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord328(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord329(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord330(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord331(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord332(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord333(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord334(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord335(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord336(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord337(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord338(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord339(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord340(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord341(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord342(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord343(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord344(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord345(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord346(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord347(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord348(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord349(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord350(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord351(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord352(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord353(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord354(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord355(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord356(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord357(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord358(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord359(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord360(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord361(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord362(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord363(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord364(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord365(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord366(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord367(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord368(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord369(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord370(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord371(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord372(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord373(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord374(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord375(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord376(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord377(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord378(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord379(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord380(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord381(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord382(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord383(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord384(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord385(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord386(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord387(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord388(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord389(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord390(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord391(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord392(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord393(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord394(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord395(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord396(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord397(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord398(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord399(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord400(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord401(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord402(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord403(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord404(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord405(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord406(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord407(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord408(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord409(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord410(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord411(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord412(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord413(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord414(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord415(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord416(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord417(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord418(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord419(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord420(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord421(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord422(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord423(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord424(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord425(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord426(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord427(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord428(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord429(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord430(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord431(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord432(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord433(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord434(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord435(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord436(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord437(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord438(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord439(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord440(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord441(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord442(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord443(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord444(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord445(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord446(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord447(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord448(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord449(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord450(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord451(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord452(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord453(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord454(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord455(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord456(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord457(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord458(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord459(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord460(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord461(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord462(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord463(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord464(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord465(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord466(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord467(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord468(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord469(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord470(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord471(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord472(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord473(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord474(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord475(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord476(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord477(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord478(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord479(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord480(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord481(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord482(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord483(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord484(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord485(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord486(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord487(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord488(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord489(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord490(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord491(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord492(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord493(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord494(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord495(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord496(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord497(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord498(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord499(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(1)));
@@ -533,7 +534,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(3)));
@@ -541,7 +542,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord2(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord2(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(5)));
@@ -549,7 +550,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord3(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord3(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(7)));
@@ -557,7 +558,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord4(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord4(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(9)));
@@ -565,7 +566,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord5(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord5(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(11)));
@@ -573,7 +574,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord6(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord6(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(13)));
@@ -581,7 +582,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord7(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord7(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(15)));
@@ -589,7 +590,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord8(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord8(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(17)));
@@ -597,7 +598,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord9(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord9(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(19)));
@@ -605,7 +606,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord10(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord10(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(21)));
@@ -613,7 +614,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord11(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord11(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(23)));
@@ -621,7 +622,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord12(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord12(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(25)));
@@ -629,7 +630,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord13(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord13(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(27)));
@@ -637,7 +638,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord14(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord14(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(29)));
@@ -645,7 +646,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord15(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord15(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(31)));
@@ -653,7 +654,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord16(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord16(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(33)));
@@ -661,7 +662,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord17(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord17(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(35)));
@@ -669,7 +670,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord18(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord18(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(37)));
@@ -677,7 +678,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord19(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord19(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(39)));
@@ -685,7 +686,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord20(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord20(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(41)));
@@ -693,7 +694,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord21(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord21(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(43)));
@@ -701,7 +702,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord22(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord22(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(45)));
@@ -709,7 +710,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord23(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord23(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(47)));
@@ -717,7 +718,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord24(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord24(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(49)));
@@ -725,7 +726,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord25(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord25(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(51)));
@@ -733,7 +734,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord26(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord26(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(53)));
@@ -741,7 +742,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord27(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord27(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(55)));
@@ -749,7 +750,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord28(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord28(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(57)));
@@ -757,7 +758,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord29(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord29(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(59)));
@@ -765,7 +766,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord30(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord30(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(61)));
@@ -773,7 +774,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord31(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord31(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(63)));
@@ -781,7 +782,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord32(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord32(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(65)));
@@ -789,7 +790,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord33(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord33(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(67)));
@@ -797,7 +798,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord34(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord34(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(69)));
@@ -805,7 +806,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord35(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord35(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(71)));
@@ -813,7 +814,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord36(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord36(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(73)));
@@ -821,7 +822,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord37(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord37(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(75)));
@@ -829,7 +830,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord38(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord38(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(77)));
@@ -837,7 +838,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord39(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord39(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(79)));
@@ -845,7 +846,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord40(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord40(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(81)));
@@ -853,7 +854,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord41(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord41(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(83)));
@@ -861,7 +862,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord42(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord42(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(85)));
@@ -869,7 +870,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord43(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord43(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(87)));
@@ -877,7 +878,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord44(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord44(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(89)));
@@ -885,7 +886,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord45(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord45(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(91)));
@@ -893,7 +894,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord46(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord46(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(93)));
@@ -901,7 +902,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord47(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord47(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(95)));
@@ -909,7 +910,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord48(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord48(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(97)));
@@ -917,7 +918,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord49(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord49(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(99)));
@@ -925,7 +926,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord50(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord50(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(101)));
@@ -933,7 +934,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord51(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord51(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(103)));
@@ -941,7 +942,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord52(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord52(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(105)));
@@ -949,7 +950,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord53(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord53(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(107)));
@@ -957,7 +958,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord54(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord54(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(109)));
@@ -965,7 +966,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord55(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord55(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(111)));
@@ -973,7 +974,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord56(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord56(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(113)));
@@ -981,7 +982,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord57(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord57(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(115)));
@@ -989,7 +990,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord58(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord58(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(117)));
@@ -997,7 +998,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord59(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord59(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(119)));
@@ -1005,7 +1006,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord60(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord60(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(121)));
@@ -1013,7 +1014,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord61(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord61(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(123)));
@@ -1021,7 +1022,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord62(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord62(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(125)));
@@ -1029,7 +1030,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord63(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord63(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(127)));
@@ -1037,7 +1038,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord64(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord64(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(129)));
@@ -1045,7 +1046,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord65(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord65(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(131)));
@@ -1053,7 +1054,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord66(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord66(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(133)));
@@ -1061,7 +1062,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord67(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord67(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(135)));
@@ -1069,7 +1070,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord68(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord68(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(137)));
@@ -1077,7 +1078,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord69(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord69(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(139)));
@@ -1085,7 +1086,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord70(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord70(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(141)));
@@ -1093,7 +1094,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord71(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord71(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(143)));
@@ -1101,7 +1102,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord72(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord72(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(145)));
@@ -1109,7 +1110,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord73(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord73(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(147)));
@@ -1117,7 +1118,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord74(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord74(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(149)));
@@ -1125,7 +1126,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord75(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord75(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(151)));
@@ -1133,7 +1134,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord76(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord76(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(153)));
@@ -1141,7 +1142,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord77(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord77(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(155)));
@@ -1149,7 +1150,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord78(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord78(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(157)));
@@ -1157,7 +1158,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord79(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord79(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(159)));
@@ -1165,7 +1166,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord80(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord80(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(161)));
@@ -1173,7 +1174,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord81(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord81(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(163)));
@@ -1181,7 +1182,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord82(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord82(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(165)));
@@ -1189,7 +1190,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord83(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord83(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(167)));
@@ -1197,7 +1198,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord84(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord84(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(169)));
@@ -1205,7 +1206,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord85(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord85(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(171)));
@@ -1213,7 +1214,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord86(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord86(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(173)));
@@ -1221,7 +1222,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord87(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord87(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(175)));
@@ -1229,7 +1230,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord88(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord88(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(177)));
@@ -1237,7 +1238,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord89(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord89(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(179)));
@@ -1245,7 +1246,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord90(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord90(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(181)));
@@ -1253,7 +1254,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord91(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord91(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(183)));
@@ -1261,7 +1262,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord92(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord92(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(185)));
@@ -1269,7 +1270,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord93(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord93(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(187)));
@@ -1277,7 +1278,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord94(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord94(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(189)));
@@ -1285,7 +1286,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord95(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord95(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(191)));
@@ -1293,7 +1294,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord96(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord96(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(193)));
@@ -1301,7 +1302,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord97(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord97(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(195)));
@@ -1309,7 +1310,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord98(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord98(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(197)));
@@ -1317,7 +1318,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord99(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord99(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(199)));
@@ -1325,7 +1326,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord100(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord100(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(201)));
@@ -1333,7 +1334,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord101(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord101(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(203)));
@@ -1341,7 +1342,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord102(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord102(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(205)));
@@ -1349,7 +1350,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord103(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord103(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(207)));
@@ -1357,7 +1358,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord104(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord104(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(209)));
@@ -1365,7 +1366,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord105(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord105(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(211)));
@@ -1373,7 +1374,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord106(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord106(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(213)));
@@ -1381,7 +1382,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord107(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord107(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(215)));
@@ -1389,7 +1390,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord108(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord108(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(217)));
@@ -1397,7 +1398,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord109(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord109(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(219)));
@@ -1405,7 +1406,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord110(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord110(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(221)));
@@ -1413,7 +1414,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord111(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord111(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(223)));
@@ -1421,7 +1422,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord112(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord112(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(225)));
@@ -1429,7 +1430,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord113(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord113(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(227)));
@@ -1437,7 +1438,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord114(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord114(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(229)));
@@ -1445,7 +1446,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord115(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord115(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(231)));
@@ -1453,7 +1454,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord116(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord116(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(233)));
@@ -1461,7 +1462,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord117(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord117(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(235)));
@@ -1469,7 +1470,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord118(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord118(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(237)));
@@ -1477,7 +1478,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord119(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord119(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(239)));
@@ -1485,7 +1486,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord120(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord120(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(241)));
@@ -1493,7 +1494,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord121(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord121(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(243)));
@@ -1501,7 +1502,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord122(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord122(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(245)));
@@ -1509,7 +1510,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord123(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord123(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(247)));
@@ -1517,7 +1518,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord124(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord124(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(249)));
@@ -1525,7 +1526,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord125(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord125(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(251)));
@@ -1533,7 +1534,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord126(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord126(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(253)));
@@ -1541,7 +1542,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord127(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord127(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(255)));
@@ -1549,7 +1550,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord128(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord128(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(257)));
@@ -1557,7 +1558,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord129(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord129(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(259)));
@@ -1565,7 +1566,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord130(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord130(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(261)));
@@ -1573,7 +1574,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord131(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord131(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(263)));
@@ -1581,7 +1582,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord132(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord132(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(265)));
@@ -1589,7 +1590,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord133(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord133(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(267)));
@@ -1597,7 +1598,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord134(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord134(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(269)));
@@ -1605,7 +1606,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord135(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord135(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(271)));
@@ -1613,7 +1614,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord136(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord136(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(273)));
@@ -1621,7 +1622,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord137(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord137(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(275)));
@@ -1629,7 +1630,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord138(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord138(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(277)));
@@ -1637,7 +1638,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord139(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord139(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(279)));
@@ -1645,7 +1646,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord140(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord140(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(281)));
@@ -1653,7 +1654,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord141(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord141(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(283)));
@@ -1661,7 +1662,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord142(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord142(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(285)));
@@ -1669,7 +1670,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord143(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord143(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(287)));
@@ -1677,7 +1678,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord144(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord144(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(289)));
@@ -1685,7 +1686,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord145(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord145(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(291)));
@@ -1693,7 +1694,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord146(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord146(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(293)));
@@ -1701,7 +1702,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord147(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord147(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(295)));
@@ -1709,7 +1710,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord148(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord148(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(297)));
@@ -1717,7 +1718,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord149(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord149(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(299)));
@@ -1725,7 +1726,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord150(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord150(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(301)));
@@ -1733,7 +1734,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord151(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord151(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(303)));
@@ -1741,7 +1742,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord152(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord152(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(305)));
@@ -1749,7 +1750,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord153(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord153(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(307)));
@@ -1757,7 +1758,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord154(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord154(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(309)));
@@ -1765,7 +1766,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord155(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord155(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(311)));
@@ -1773,7 +1774,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord156(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord156(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(313)));
@@ -1781,7 +1782,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord157(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord157(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(315)));
@@ -1789,7 +1790,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord158(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord158(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(317)));
@@ -1797,7 +1798,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord159(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord159(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(319)));
@@ -1805,7 +1806,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord160(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord160(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(321)));
@@ -1813,7 +1814,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord161(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord161(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(323)));
@@ -1821,7 +1822,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord162(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord162(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(325)));
@@ -1829,7 +1830,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord163(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord163(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(327)));
@@ -1837,7 +1838,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord164(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord164(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(329)));
@@ -1845,7 +1846,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord165(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord165(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(331)));
@@ -1853,7 +1854,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord166(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord166(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(333)));
@@ -1861,7 +1862,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord167(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord167(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(335)));
@@ -1869,7 +1870,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord168(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord168(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(337)));
@@ -1877,7 +1878,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord169(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord169(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(339)));
@@ -1885,7 +1886,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord170(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord170(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(341)));
@@ -1893,7 +1894,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord171(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord171(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(343)));
@@ -1901,7 +1902,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord172(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord172(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(345)));
@@ -1909,7 +1910,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord173(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord173(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(347)));
@@ -1917,7 +1918,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord174(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord174(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(349)));
@@ -1925,7 +1926,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord175(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord175(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(351)));
@@ -1933,7 +1934,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord176(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord176(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(353)));
@@ -1941,7 +1942,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord177(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord177(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(355)));
@@ -1949,7 +1950,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord178(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord178(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(357)));
@@ -1957,7 +1958,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord179(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord179(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(359)));
@@ -1965,7 +1966,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord180(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord180(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(361)));
@@ -1973,7 +1974,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord181(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord181(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(363)));
@@ -1981,7 +1982,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord182(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord182(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(365)));
@@ -1989,7 +1990,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord183(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord183(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(367)));
@@ -1997,7 +1998,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord184(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord184(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(369)));
@@ -2005,7 +2006,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord185(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord185(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(371)));
@@ -2013,7 +2014,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord186(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord186(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(373)));
@@ -2021,7 +2022,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord187(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord187(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(375)));
@@ -2029,7 +2030,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord188(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord188(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(377)));
@@ -2037,7 +2038,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord189(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord189(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(379)));
@@ -2045,7 +2046,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord190(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord190(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(381)));
@@ -2053,7 +2054,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord191(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord191(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(383)));
@@ -2061,7 +2062,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord192(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord192(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(385)));
@@ -2069,7 +2070,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord193(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord193(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(387)));
@@ -2077,7 +2078,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord194(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord194(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(389)));
@@ -2085,7 +2086,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord195(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord195(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(391)));
@@ -2093,7 +2094,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord196(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord196(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(393)));
@@ -2101,7 +2102,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord197(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord197(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(395)));
@@ -2109,7 +2110,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord198(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord198(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(397)));
@@ -2117,7 +2118,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord199(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord199(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(399)));
@@ -2125,7 +2126,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord200(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord200(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(401)));
@@ -2133,7 +2134,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord201(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord201(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(403)));
@@ -2141,7 +2142,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord202(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord202(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(405)));
@@ -2149,7 +2150,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord203(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord203(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(407)));
@@ -2157,7 +2158,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord204(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord204(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(409)));
@@ -2165,7 +2166,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord205(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord205(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(411)));
@@ -2173,7 +2174,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord206(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord206(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(413)));
@@ -2181,7 +2182,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord207(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord207(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(415)));
@@ -2189,7 +2190,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord208(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord208(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(417)));
@@ -2197,7 +2198,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord209(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord209(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(419)));
@@ -2205,7 +2206,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord210(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord210(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(421)));
@@ -2213,7 +2214,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord211(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord211(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(423)));
@@ -2221,7 +2222,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord212(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord212(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(425)));
@@ -2229,7 +2230,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord213(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord213(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(427)));
@@ -2237,7 +2238,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord214(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord214(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(429)));
@@ -2245,7 +2246,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord215(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord215(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(431)));
@@ -2253,7 +2254,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord216(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord216(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(433)));
@@ -2261,7 +2262,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord217(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord217(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(435)));
@@ -2269,7 +2270,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord218(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord218(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(437)));
@@ -2277,7 +2278,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord219(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord219(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(439)));
@@ -2285,7 +2286,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord220(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord220(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(441)));
@@ -2293,7 +2294,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord221(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord221(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(443)));
@@ -2301,7 +2302,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord222(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord222(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(445)));
@@ -2309,7 +2310,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord223(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord223(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(447)));
@@ -2317,7 +2318,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord224(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord224(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(449)));
@@ -2325,7 +2326,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord225(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord225(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(451)));
@@ -2333,7 +2334,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord226(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord226(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(453)));
@@ -2341,7 +2342,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord227(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord227(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(455)));
@@ -2349,7 +2350,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord228(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord228(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(457)));
@@ -2357,7 +2358,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord229(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord229(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(459)));
@@ -2365,7 +2366,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord230(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord230(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(461)));
@@ -2373,7 +2374,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord231(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord231(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(463)));
@@ -2381,7 +2382,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord232(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord232(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(465)));
@@ -2389,7 +2390,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord233(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord233(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(467)));
@@ -2397,7 +2398,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord234(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord234(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(469)));
@@ -2405,7 +2406,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord235(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord235(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(471)));
@@ -2413,7 +2414,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord236(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord236(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(473)));
@@ -2421,7 +2422,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord237(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord237(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(475)));
@@ -2429,7 +2430,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord238(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord238(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(477)));
@@ -2437,7 +2438,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord239(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord239(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(479)));
@@ -2445,7 +2446,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord240(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord240(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(481)));
@@ -2453,7 +2454,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord241(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord241(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(483)));
@@ -2461,7 +2462,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord242(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord242(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(485)));
@@ -2469,7 +2470,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord243(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord243(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(487)));
@@ -2477,7 +2478,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord244(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord244(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(489)));
@@ -2485,7 +2486,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord245(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord245(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(491)));
@@ -2493,7 +2494,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord246(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord246(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(493)));
@@ -2501,7 +2502,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord247(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord247(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(495)));
@@ -2509,7 +2510,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord248(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord248(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(497)));
@@ -2517,7 +2518,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord249(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord249(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(499)));
@@ -2525,7 +2526,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord250(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord250(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(501)));
@@ -2533,7 +2534,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord251(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord251(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(503)));
@@ -2541,7 +2542,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord252(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord252(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(505)));
@@ -2549,7 +2550,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord253(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord253(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(507)));
@@ -2557,7 +2558,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord254(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord254(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(509)));
@@ -2565,7 +2566,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord255(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord255(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(511)));
@@ -2573,7 +2574,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord256(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord256(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(513)));
@@ -2581,7 +2582,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord257(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord257(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(515)));
@@ -2589,7 +2590,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord258(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord258(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(517)));
@@ -2597,7 +2598,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord259(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord259(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(519)));
@@ -2605,7 +2606,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord260(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord260(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(521)));
@@ -2613,7 +2614,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord261(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord261(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(523)));
@@ -2621,7 +2622,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord262(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord262(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(525)));
@@ -2629,7 +2630,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord263(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord263(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(527)));
@@ -2637,7 +2638,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord264(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord264(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(529)));
@@ -2645,7 +2646,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord265(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord265(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(531)));
@@ -2653,7 +2654,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord266(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord266(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(533)));
@@ -2661,7 +2662,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord267(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord267(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(535)));
@@ -2669,7 +2670,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord268(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord268(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(537)));
@@ -2677,7 +2678,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord269(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord269(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(539)));
@@ -2685,7 +2686,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord270(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord270(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(541)));
@@ -2693,7 +2694,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord271(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord271(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(543)));
@@ -2701,7 +2702,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord272(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord272(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(545)));
@@ -2709,7 +2710,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord273(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord273(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(547)));
@@ -2717,7 +2718,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord274(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord274(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(549)));
@@ -2725,7 +2726,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord275(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord275(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(551)));
@@ -2733,7 +2734,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord276(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord276(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(553)));
@@ -2741,7 +2742,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord277(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord277(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(555)));
@@ -2749,7 +2750,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord278(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord278(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(557)));
@@ -2757,7 +2758,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord279(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord279(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(559)));
@@ -2765,7 +2766,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord280(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord280(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(561)));
@@ -2773,7 +2774,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord281(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord281(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(563)));
@@ -2781,7 +2782,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord282(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord282(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(565)));
@@ -2789,7 +2790,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord283(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord283(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(567)));
@@ -2797,7 +2798,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord284(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord284(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(569)));
@@ -2805,7 +2806,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord285(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord285(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(571)));
@@ -2813,7 +2814,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord286(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord286(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(573)));
@@ -2821,7 +2822,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord287(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord287(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(575)));
@@ -2829,7 +2830,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord288(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord288(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(577)));
@@ -2837,7 +2838,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord289(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord289(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(579)));
@@ -2845,7 +2846,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord290(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord290(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(581)));
@@ -2853,7 +2854,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord291(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord291(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(583)));
@@ -2861,7 +2862,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord292(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord292(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(585)));
@@ -2869,7 +2870,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord293(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord293(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(587)));
@@ -2877,7 +2878,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord294(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord294(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(589)));
@@ -2885,7 +2886,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord295(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord295(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(591)));
@@ -2893,7 +2894,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord296(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord296(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(593)));
@@ -2901,7 +2902,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord297(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord297(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(595)));
@@ -2909,7 +2910,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord298(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord298(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(597)));
@@ -2917,7 +2918,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord299(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord299(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(599)));
@@ -2925,7 +2926,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord300(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord300(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(601)));
@@ -2933,7 +2934,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord301(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord301(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(603)));
@@ -2941,7 +2942,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord302(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord302(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(605)));
@@ -2949,7 +2950,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord303(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord303(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(607)));
@@ -2957,7 +2958,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord304(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord304(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(609)));
@@ -2965,7 +2966,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord305(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord305(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(611)));
@@ -2973,7 +2974,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord306(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord306(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(613)));
@@ -2981,7 +2982,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord307(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord307(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(615)));
@@ -2989,7 +2990,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord308(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord308(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(617)));
@@ -2997,7 +2998,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord309(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord309(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(619)));
@@ -3005,7 +3006,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord310(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord310(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(621)));
@@ -3013,7 +3014,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord311(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord311(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(623)));
@@ -3021,7 +3022,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord312(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord312(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(625)));
@@ -3029,7 +3030,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord313(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord313(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(627)));
@@ -3037,7 +3038,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord314(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord314(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(629)));
@@ -3045,7 +3046,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord315(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord315(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(631)));
@@ -3053,7 +3054,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord316(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord316(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(633)));
@@ -3061,7 +3062,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord317(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord317(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(635)));
@@ -3069,7 +3070,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord318(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord318(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(637)));
@@ -3077,7 +3078,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord319(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord319(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(639)));
@@ -3085,7 +3086,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord320(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord320(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(641)));
@@ -3093,7 +3094,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord321(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord321(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(643)));
@@ -3101,7 +3102,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord322(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord322(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(645)));
@@ -3109,7 +3110,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord323(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord323(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(647)));
@@ -3117,7 +3118,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord324(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord324(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(649)));
@@ -3125,7 +3126,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord325(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord325(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(651)));
@@ -3133,7 +3134,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord326(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord326(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(653)));
@@ -3141,7 +3142,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord327(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord327(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(655)));
@@ -3149,7 +3150,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord328(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord328(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(657)));
@@ -3157,7 +3158,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord329(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord329(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(659)));
@@ -3165,7 +3166,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord330(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord330(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(661)));
@@ -3173,7 +3174,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord331(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord331(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(663)));
@@ -3181,7 +3182,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord332(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord332(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(665)));
@@ -3189,7 +3190,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord333(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord333(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(667)));
@@ -3197,7 +3198,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord334(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord334(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(669)));
@@ -3205,7 +3206,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord335(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord335(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(671)));
@@ -3213,7 +3214,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord336(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord336(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(673)));
@@ -3221,7 +3222,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord337(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord337(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(675)));
@@ -3229,7 +3230,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord338(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord338(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(677)));
@@ -3237,7 +3238,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord339(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord339(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(679)));
@@ -3245,7 +3246,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord340(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord340(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(681)));
@@ -3253,7 +3254,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord341(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord341(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(683)));
@@ -3261,7 +3262,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord342(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord342(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(685)));
@@ -3269,7 +3270,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord343(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord343(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(687)));
@@ -3277,7 +3278,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord344(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord344(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(689)));
@@ -3285,7 +3286,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord345(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord345(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(691)));
@@ -3293,7 +3294,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord346(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord346(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(693)));
@@ -3301,7 +3302,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord347(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord347(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(695)));
@@ -3309,7 +3310,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord348(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord348(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(697)));
@@ -3317,7 +3318,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord349(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord349(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(699)));
@@ -3325,7 +3326,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord350(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord350(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(701)));
@@ -3333,7 +3334,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord351(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord351(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(703)));
@@ -3341,7 +3342,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord352(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord352(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(705)));
@@ -3349,7 +3350,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord353(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord353(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(707)));
@@ -3357,7 +3358,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord354(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord354(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(709)));
@@ -3365,7 +3366,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord355(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord355(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(711)));
@@ -3373,7 +3374,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord356(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord356(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(713)));
@@ -3381,7 +3382,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord357(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord357(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(715)));
@@ -3389,7 +3390,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord358(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord358(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(717)));
@@ -3397,7 +3398,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord359(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord359(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(719)));
@@ -3405,7 +3406,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord360(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord360(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(721)));
@@ -3413,7 +3414,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord361(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord361(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(723)));
@@ -3421,7 +3422,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord362(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord362(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(725)));
@@ -3429,7 +3430,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord363(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord363(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(727)));
@@ -3437,7 +3438,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord364(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord364(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(729)));
@@ -3445,7 +3446,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord365(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord365(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(731)));
@@ -3453,7 +3454,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord366(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord366(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(733)));
@@ -3461,7 +3462,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord367(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord367(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(735)));
@@ -3469,7 +3470,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord368(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord368(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(737)));
@@ -3477,7 +3478,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord369(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord369(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(739)));
@@ -3485,7 +3486,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord370(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord370(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(741)));
@@ -3493,7 +3494,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord371(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord371(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(743)));
@@ -3501,7 +3502,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord372(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord372(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(745)));
@@ -3509,7 +3510,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord373(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord373(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(747)));
@@ -3517,7 +3518,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord374(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord374(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(749)));
@@ -3525,7 +3526,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord375(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord375(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(751)));
@@ -3533,7 +3534,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord376(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord376(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(753)));
@@ -3541,7 +3542,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord377(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord377(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(755)));
@@ -3549,7 +3550,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord378(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord378(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(757)));
@@ -3557,7 +3558,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord379(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord379(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(759)));
@@ -3565,7 +3566,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord380(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord380(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(761)));
@@ -3573,7 +3574,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord381(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord381(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(763)));
@@ -3581,7 +3582,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord382(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord382(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(765)));
@@ -3589,7 +3590,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord383(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord383(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(767)));
@@ -3597,7 +3598,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord384(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord384(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(769)));
@@ -3605,7 +3606,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord385(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord385(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(771)));
@@ -3613,7 +3614,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord386(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord386(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(773)));
@@ -3621,7 +3622,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord387(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord387(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(775)));
@@ -3629,7 +3630,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord388(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord388(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(777)));
@@ -3637,7 +3638,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord389(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord389(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(779)));
@@ -3645,7 +3646,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord390(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord390(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(781)));
@@ -3653,7 +3654,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord391(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord391(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(783)));
@@ -3661,7 +3662,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord392(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord392(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(785)));
@@ -3669,7 +3670,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord393(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord393(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(787)));
@@ -3677,7 +3678,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord394(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord394(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(789)));
@@ -3685,7 +3686,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord395(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord395(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(791)));
@@ -3693,7 +3694,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord396(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord396(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(793)));
@@ -3701,7 +3702,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord397(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord397(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(795)));
@@ -3709,7 +3710,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord398(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord398(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(797)));
@@ -3717,7 +3718,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord399(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord399(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(799)));
@@ -3725,7 +3726,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord400(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord400(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(801)));
@@ -3733,7 +3734,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord401(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord401(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(803)));
@@ -3741,7 +3742,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord402(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord402(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(805)));
@@ -3749,7 +3750,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord403(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord403(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(807)));
@@ -3757,7 +3758,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord404(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord404(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(809)));
@@ -3765,7 +3766,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord405(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord405(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(811)));
@@ -3773,7 +3774,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord406(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord406(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(813)));
@@ -3781,7 +3782,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord407(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord407(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(815)));
@@ -3789,7 +3790,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord408(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord408(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(817)));
@@ -3797,7 +3798,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord409(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord409(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(819)));
@@ -3805,7 +3806,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord410(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord410(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(821)));
@@ -3813,7 +3814,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord411(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord411(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(823)));
@@ -3821,7 +3822,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord412(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord412(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(825)));
@@ -3829,7 +3830,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord413(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord413(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(827)));
@@ -3837,7 +3838,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord414(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord414(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(829)));
@@ -3845,7 +3846,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord415(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord415(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(831)));
@@ -3853,7 +3854,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord416(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord416(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(833)));
@@ -3861,7 +3862,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord417(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord417(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(835)));
@@ -3869,7 +3870,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord418(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord418(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(837)));
@@ -3877,7 +3878,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord419(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord419(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(839)));
@@ -3885,7 +3886,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord420(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord420(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(841)));
@@ -3893,7 +3894,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord421(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord421(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(843)));
@@ -3901,7 +3902,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord422(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord422(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(845)));
@@ -3909,7 +3910,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord423(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord423(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(847)));
@@ -3917,7 +3918,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord424(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord424(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(849)));
@@ -3925,7 +3926,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord425(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord425(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(851)));
@@ -3933,7 +3934,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord426(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord426(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(853)));
@@ -3941,7 +3942,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord427(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord427(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(855)));
@@ -3949,7 +3950,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord428(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord428(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(857)));
@@ -3957,7 +3958,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord429(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord429(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(859)));
@@ -3965,7 +3966,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord430(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord430(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(861)));
@@ -3973,7 +3974,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord431(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord431(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(863)));
@@ -3981,7 +3982,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord432(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord432(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(865)));
@@ -3989,7 +3990,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord433(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord433(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(867)));
@@ -3997,7 +3998,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord434(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord434(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(869)));
@@ -4005,7 +4006,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord435(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord435(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(871)));
@@ -4013,7 +4014,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord436(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord436(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(873)));
@@ -4021,7 +4022,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord437(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord437(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(875)));
@@ -4029,7 +4030,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord438(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord438(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(877)));
@@ -4037,7 +4038,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord439(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord439(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(879)));
@@ -4045,7 +4046,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord440(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord440(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(881)));
@@ -4053,7 +4054,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord441(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord441(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(883)));
@@ -4061,7 +4062,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord442(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord442(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(885)));
@@ -4069,7 +4070,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord443(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord443(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(887)));
@@ -4077,7 +4078,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord444(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord444(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(889)));
@@ -4085,7 +4086,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord445(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord445(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(891)));
@@ -4093,7 +4094,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord446(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord446(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(893)));
@@ -4101,7 +4102,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord447(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord447(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(895)));
@@ -4109,7 +4110,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord448(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord448(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(897)));
@@ -4117,7 +4118,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord449(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord449(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(899)));
@@ -4125,7 +4126,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord450(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord450(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(901)));
@@ -4133,7 +4134,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord451(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord451(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(903)));
@@ -4141,7 +4142,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord452(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord452(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(905)));
@@ -4149,7 +4150,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord453(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord453(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(907)));
@@ -4157,7 +4158,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord454(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord454(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(909)));
@@ -4165,7 +4166,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord455(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord455(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(911)));
@@ -4173,7 +4174,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord456(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord456(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(913)));
@@ -4181,7 +4182,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord457(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord457(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(915)));
@@ -4189,7 +4190,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord458(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord458(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(917)));
@@ -4197,7 +4198,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord459(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord459(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(919)));
@@ -4205,7 +4206,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord460(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord460(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(921)));
@@ -4213,7 +4214,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord461(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord461(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(923)));
@@ -4221,7 +4222,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord462(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord462(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(925)));
@@ -4229,7 +4230,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord463(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord463(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(927)));
@@ -4237,7 +4238,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord464(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord464(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(929)));
@@ -4245,7 +4246,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord465(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord465(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(931)));
@@ -4253,7 +4254,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord466(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord466(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(933)));
@@ -4261,7 +4262,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord467(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord467(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(935)));
@@ -4269,7 +4270,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord468(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord468(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(937)));
@@ -4277,7 +4278,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord469(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord469(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(939)));
@@ -4285,7 +4286,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord470(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord470(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(941)));
@@ -4293,7 +4294,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord471(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord471(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(943)));
@@ -4301,7 +4302,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord472(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord472(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(945)));
@@ -4309,7 +4310,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord473(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord473(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(947)));
@@ -4317,7 +4318,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord474(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord474(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(949)));
@@ -4325,7 +4326,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord475(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord475(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(951)));
@@ -4333,7 +4334,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord476(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord476(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(953)));
@@ -4341,7 +4342,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord477(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord477(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(955)));
@@ -4349,7 +4350,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord478(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord478(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(957)));
@@ -4357,7 +4358,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord479(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord479(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(959)));
@@ -4365,7 +4366,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord480(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord480(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(961)));
@@ -4373,7 +4374,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord481(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord481(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(963)));
@@ -4381,7 +4382,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord482(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord482(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(965)));
@@ -4389,7 +4390,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord483(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord483(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(967)));
@@ -4397,7 +4398,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord484(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord484(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(969)));
@@ -4405,7 +4406,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord485(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord485(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(971)));
@@ -4413,7 +4414,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord486(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord486(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(973)));
@@ -4421,7 +4422,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord487(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord487(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(975)));
@@ -4429,7 +4430,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord488(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord488(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(977)));
@@ -4437,7 +4438,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord489(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord489(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(979)));
@@ -4445,7 +4446,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord490(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord490(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(981)));
@@ -4453,7 +4454,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord491(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord491(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(983)));
@@ -4461,7 +4462,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord492(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord492(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(985)));
@@ -4469,7 +4470,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord493(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord493(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(987)));
@@ -4477,7 +4478,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord494(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord494(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(989)));
@@ -4485,7 +4486,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord495(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord495(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(991)));
@@ -4493,7 +4494,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord496(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord496(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(993)));
@@ -4501,7 +4502,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord497(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord497(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(995)));
@@ -4509,7 +4510,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord498(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord498(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(997)));
@@ -4517,7 +4518,7 @@ public class FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord_Gener
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord499(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldSerializeLargeRecord499(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(999)));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums_GenericSerializer_496788239.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums_GenericSerializer_496788239.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
@@ -13,14 +14,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnum
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         int valueToWrite0;
@@ -31,12 +32,12 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnum
             valueToWrite0 = ((org.apache.avro.generic.GenericData.EnumSymbol) enumValue0).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) enumValue0).toString());
         }
         (encoder).writeEnum(valueToWrite0);
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums1(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         GenericEnumSymbol testEnumUnion0 = ((GenericEnumSymbol) data.get(1));
@@ -78,7 +79,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnum
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<GenericEnumSymbol> testEnumUnionArray0 = ((List<GenericEnumSymbol> ) data.get(3));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed_GenericSerializer_1473954146.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed_GenericSerializer_1473954146.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
@@ -13,23 +14,23 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixe
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeFixed(((GenericFixed) data.get(0)).bytes());
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed1(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         GenericFixed testFixedUnion0 = ((GenericFixed) data.get(1));
@@ -57,7 +58,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixe
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<GenericFixed> testFixedUnionArray0 = ((List<GenericFixed> ) data.get(3));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_1076995050.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_GenericSerializer_1076995050.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -12,14 +13,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object union0 = ((Object) data.get(0));
@@ -29,7 +30,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
         } else {
             if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializeSubRecord0(((IndexedRecord) union0), (encoder));
+                serializeSubRecord0(((IndexedRecord) union0), (encoder), (customization));
             } else {
                 if (union0 instanceof CharSequence) {
                     (encoder).writeIndex(2);
@@ -49,7 +50,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteMultipleChoiceUnion_G
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence subField0 = ((CharSequence) data.get(0));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_538850553.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSerializer_538850553.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -13,28 +14,28 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives1(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives2(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives3(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives4(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives5(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives6(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives0(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives1(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives2(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives3(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives4(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives5(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives6(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Integer testIntUnion0 = ((Integer) data.get(1));
@@ -56,7 +57,7 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         if (((CharSequence) data.get(3)) instanceof Utf8) {
@@ -79,7 +80,7 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives2(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives2(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeLong(((Long) data.get(5)));
@@ -94,7 +95,7 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives3(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives3(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeDouble(((Double) data.get(7)));
@@ -109,7 +110,7 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives4(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives4(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeFloat(((Float) data.get(9)));
@@ -124,7 +125,7 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives5(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives5(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeBoolean(((Boolean) data.get(11)));
@@ -139,7 +140,7 @@ public class FastGenericSerializerGeneratorTest_shouldWritePrimitives_GenericSer
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives6(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWritePrimitives6(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeBytes(((ByteBuffer) data.get(13)));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_31578414.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_GenericSerializer_31578414.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -12,14 +13,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object union_field0 = ((Object) data.get(0));
@@ -29,18 +30,18 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
         } else {
             if ((union_field0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record1".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializeRecord10(((IndexedRecord) union_field0), (encoder));
+                serializeRecord10(((IndexedRecord) union_field0), (encoder), (customization));
             } else {
                 if ((union_field0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record2".equals(((IndexedRecord) union_field0).getSchema().getFullName())) {
                     (encoder).writeIndex(2);
-                    serializeRecord20(((IndexedRecord) union_field0), (encoder));
+                    serializeRecord20(((IndexedRecord) union_field0), (encoder), (customization));
                 }
             }
         }
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeRecord10(IndexedRecord data, Encoder encoder)
+    public void serializeRecord10(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         if (((CharSequence) data.get(0)) instanceof Utf8) {
@@ -51,7 +52,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteRightUnionIndex_Gener
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeRecord20(IndexedRecord data, Encoder encoder)
+    public void serializeRecord20(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         if (((CharSequence) data.get(0)) instanceof Utf8) {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_1348736347.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_1348736347.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,14 +15,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<IndexedRecord> recordsArray0 = ((List<IndexedRecord> ) data.get(0));
@@ -34,16 +35,16 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                 (encoder).startItem();
                 IndexedRecord subRecord0 = null;
                 subRecord0 = ((List<IndexedRecord> ) recordsArray0).get(counter0);
-                serializeSubRecord0(subRecord0, (encoder));
+                serializeSubRecord0(subRecord0, (encoder), (customization));
             }
         }
         (encoder).writeArrayEnd();
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField1(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence subField0 = ((CharSequence) data.get(0));
@@ -61,10 +62,11 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, IndexedRecord> recordsMap0 = ((Map<CharSequence, IndexedRecord> ) data.get(1));
+        (customization).getCheckMapTypeFunction().apply(recordsMap0);
         (encoder).writeMapStart();
         if ((recordsMap0 == null)||recordsMap0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -75,7 +77,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                 (encoder).writeString(key0);
                 IndexedRecord subRecord1 = null;
                 subRecord1 = ((Map<CharSequence, IndexedRecord> ) recordsMap0).get(key0);
-                serializeSubRecord0(subRecord1, (encoder));
+                serializeSubRecord0(subRecord1, (encoder), (customization));
             }
         }
         (encoder).writeMapEnd();
@@ -101,7 +103,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                         } else {
                             if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder), (customization));
                             }
                         }
                     }
@@ -112,7 +114,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, IndexedRecord> recordsMapUnion0 = ((Map<CharSequence, IndexedRecord> ) data.get(3));
@@ -122,6 +124,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
         } else {
             if (recordsMapUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
+                (customization).getCheckMapTypeFunction().apply(((Map<CharSequence, IndexedRecord> ) recordsMapUnion0));
                 (encoder).writeMapStart();
                 if ((((Map<CharSequence, IndexedRecord> ) recordsMapUnion0) == null)||((Map<CharSequence, IndexedRecord> ) recordsMapUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
@@ -138,7 +141,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                         } else {
                             if ((union1 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder), (customization));
                             }
                         }
                     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_1813582373.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_1813582373.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,14 +15,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<Map<CharSequence, IndexedRecord>> recordsArrayMap0 = ((List<Map<CharSequence, IndexedRecord>> ) data.get(0));
@@ -34,6 +35,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                 (encoder).startItem();
                 Map<CharSequence, IndexedRecord> map0 = null;
                 map0 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).get(counter0);
+                (customization).getCheckMapTypeFunction().apply(map0);
                 (encoder).writeMapStart();
                 if ((map0 == null)||map0 .isEmpty()) {
                     (encoder).setItemCount(0);
@@ -50,7 +52,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                         } else {
                             if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union0), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union0), (encoder), (customization));
                             }
                         }
                     }
@@ -59,12 +61,12 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             }
         }
         (encoder).writeArrayEnd();
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder));
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField1(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(data, (encoder), (customization));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence subField0 = ((CharSequence) data.get(0));
@@ -82,10 +84,11 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, List<IndexedRecord>> recordsMapArray0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(1));
+        (customization).getCheckMapTypeFunction().apply(recordsMapArray0);
         (encoder).writeMapStart();
         if ((recordsMapArray0 == null)||recordsMapArray0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -111,7 +114,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                         } else {
                             if ((union1 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union1), (encoder));
+                                serializeSubRecord0(((IndexedRecord) union1), (encoder), (customization));
                             }
                         }
                     }
@@ -136,6 +139,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                         (encoder).startItem();
                         Map<CharSequence, IndexedRecord> map1 = null;
                         map1 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).get(counter2);
+                        (customization).getCheckMapTypeFunction().apply(map1);
                         (encoder).writeMapStart();
                         if ((map1 == null)||map1 .isEmpty()) {
                             (encoder).setItemCount(0);
@@ -152,7 +156,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                                 } else {
                                     if ((union2 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union2).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializeSubRecord0(((IndexedRecord) union2), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union2), (encoder), (customization));
                                     }
                                 }
                             }
@@ -166,7 +170,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, List<IndexedRecord>> recordsMapArrayUnion0 = ((Map<CharSequence, List<IndexedRecord>> ) data.get(3));
@@ -176,6 +180,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
         } else {
             if (recordsMapArrayUnion0 instanceof Map) {
                 (encoder).writeIndex(1);
+                (customization).getCheckMapTypeFunction().apply(((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0));
                 (encoder).writeMapStart();
                 if ((((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0) == null)||((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0).isEmpty()) {
                     (encoder).setItemCount(0);
@@ -201,7 +206,7 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                                 } else {
                                     if ((union3 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union3).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializeSubRecord0(((IndexedRecord) union3), (encoder));
+                                        serializeSubRecord0(((IndexedRecord) union3), (encoder), (customization));
                                     }
                                 }
                             }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_652769027.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_GenericSerializer_652769027.java
@@ -3,6 +3,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 
 import java.io.IOException;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -12,14 +13,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder));
+        serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder)
+    public void serializeFastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         IndexedRecord record0 = ((IndexedRecord) data.get(0));
@@ -29,14 +30,14 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
         } else {
             if ((record0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) record0).getSchema().getFullName())) {
                 (encoder).writeIndex(1);
-                serializeSubRecord0(((IndexedRecord) record0), (encoder));
+                serializeSubRecord0(((IndexedRecord) record0), (encoder), (customization));
             }
         }
-        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder));
+        serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeSubRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeSubRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence subField0 = ((CharSequence) data.get(0));
@@ -54,11 +55,11 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordField_Generi
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastGenericSerializerGeneratorTest_shouldWriteSubRecordField0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         IndexedRecord record10 = ((IndexedRecord) data.get(1));
-        serializeSubRecord0(record10, (encoder));
+        serializeSubRecord0(record10, (encoder), (customization));
         CharSequence field0 = ((CharSequence) data.get(2));
         if (field0 == null) {
             (encoder).writeIndex(0);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeEnums_GenericSerializer_957378572.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeEnums_GenericSerializer_957378572.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
@@ -14,14 +15,14 @@ public class FastSerdeEnums_GenericSerializer_957378572
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeEnums0(data, (encoder));
+        serializeFastSerdeEnums0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeEnums0(IndexedRecord data, Encoder encoder)
+    public void serializeFastSerdeEnums0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         int valueToWrite0;
@@ -32,11 +33,11 @@ public class FastSerdeEnums_GenericSerializer_957378572
             valueToWrite0 = ((org.apache.avro.generic.GenericData.EnumSymbol) enumValue0).getSchema().getEnumOrdinal(((org.apache.avro.generic.GenericData.EnumSymbol) enumValue0).toString());
         }
         (encoder).writeEnum(valueToWrite0);
-        serialize_FastSerdeEnums0(data, (encoder));
+        serialize_FastSerdeEnums0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeEnums0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeEnums0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<GenericEnumSymbol> arrayOfEnums0 = ((List<GenericEnumSymbol> ) data.get(1));
@@ -67,6 +68,7 @@ public class FastSerdeEnums_GenericSerializer_957378572
             }
         }
         Map<CharSequence, GenericEnumSymbol> mapOfEnums0 = ((Map<CharSequence, GenericEnumSymbol> ) data.get(2));
+        (customization).getCheckMapTypeFunction().apply(mapOfEnums0);
         (encoder).writeMapStart();
         if ((mapOfEnums0 == null)||mapOfEnums0 .isEmpty()) {
             (encoder).setItemCount(0);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeFixed_GenericSerializer_504108934.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeFixed_GenericSerializer_504108934.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
@@ -14,22 +15,22 @@ public class FastSerdeFixed_GenericSerializer_504108934
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeFixed0(data, (encoder));
+        serializeFastSerdeFixed0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeFixed0(IndexedRecord data, Encoder encoder)
+    public void serializeFastSerdeFixed0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeFixed(((GenericFixed) data.get(0)).bytes());
-        serialize_FastSerdeFixed0(data, (encoder));
+        serialize_FastSerdeFixed0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeFixed0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeFixed0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<GenericFixed> arrayOfFixed0 = ((List<GenericFixed> ) data.get(1));
@@ -53,6 +54,7 @@ public class FastSerdeFixed_GenericSerializer_504108934
             }
         }
         Map<CharSequence, GenericFixed> mapOfFixed0 = ((Map<CharSequence, GenericFixed> ) data.get(2));
+        (customization).getCheckMapTypeFunction().apply(mapOfFixed0);
         (encoder).writeMapStart();
         if ((mapOfFixed0 == null)||mapOfFixed0 .isEmpty()) {
             (encoder).setItemCount(0);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_GenericSerializer_229156053.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_GenericSerializer_229156053.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -22,24 +23,24 @@ public class FastSerdeLogicalTypesDefined_GenericSerializer_229156053
     private final Schema logicalTypeSchema__59052268 = Schema.parse("{\"type\":\"int\",\"logicalType\":\"date\"}");
     private final Schema logicalTypeSchema_1074306973 = Schema.parse("{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}");
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeLogicalTypesDefined0(data, (encoder));
+        serializeFastSerdeLogicalTypesDefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeLogicalTypesDefined0(IndexedRecord data, Encoder encoder)
+    public void serializeFastSerdeLogicalTypesDefined0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue0 = data.get(0);
         convertedValue0 = Conversions.convertToRawType(convertedValue0, this.logicalTypeSchema__419105534, this.logicalTypeSchema__419105534 .getLogicalType(), this.conversion_time_millis);
         (encoder).writeInt(((Integer) convertedValue0));
-        serialize_FastSerdeLogicalTypesDefined0(data, (encoder));
+        serialize_FastSerdeLogicalTypesDefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesDefined0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesDefined0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue1 = data.get(1);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_SpecificSerializer_229156053.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_SpecificSerializer_229156053.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesDefined;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
@@ -22,24 +23,24 @@ public class FastSerdeLogicalTypesDefined_SpecificSerializer_229156053
     private final Schema logicalTypeSchema__59052268 = Schema.parse("{\"type\":\"int\",\"logicalType\":\"date\"}");
     private final Schema logicalTypeSchema_1074306973 = Schema.parse("{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}");
 
-    public void serialize(FastSerdeLogicalTypesDefined data, Encoder encoder)
+    public void serialize(FastSerdeLogicalTypesDefined data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeLogicalTypesDefined0(data, (encoder));
+        serializeFastSerdeLogicalTypesDefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeLogicalTypesDefined0(FastSerdeLogicalTypesDefined data, Encoder encoder)
+    public void serializeFastSerdeLogicalTypesDefined0(FastSerdeLogicalTypesDefined data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue0 = data.get(0);
         convertedValue0 = Conversions.convertToRawType(convertedValue0, this.logicalTypeSchema__419105534, this.logicalTypeSchema__419105534 .getLogicalType(), this.conversion_time_millis);
         (encoder).writeInt(((Integer) convertedValue0));
-        serialize_FastSerdeLogicalTypesDefined0(data, (encoder));
+        serialize_FastSerdeLogicalTypesDefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesDefined0(FastSerdeLogicalTypesDefined data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesDefined0(FastSerdeLogicalTypesDefined data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue1 = data.get(1);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_GenericSerializer_1007574890.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_GenericSerializer_1007574890.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
@@ -39,14 +40,14 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     private final Schema logicalTypeSchema__1515894331 = Schema.parse("{\"type\":\"long\",\"logicalType\":\"time-micros\"}");
     private final Schema logicalTypeSchema__250645780 = Schema.parse("{\"type\":\"long\",\"logicalType\":\"local-timestamp-millis\"}");
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeLogicalTypesTest10(data, (encoder));
+        serializeFastSerdeLogicalTypesTest10(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeLogicalTypesTest10(IndexedRecord data, Encoder encoder)
+    public void serializeFastSerdeLogicalTypesTest10(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object unionOfArrayAndMap0 = ((Object) data.get(0));
@@ -79,6 +80,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
         } else {
             if (unionOfArrayAndMap0 instanceof Map) {
                 (encoder).writeIndex(1);
+                (customization).getCheckMapTypeFunction().apply(((Map<CharSequence, LocalDate> ) unionOfArrayAndMap0));
                 (encoder).writeMapStart();
                 if ((((Map<CharSequence, LocalDate> ) unionOfArrayAndMap0) == null)||((Map<CharSequence, LocalDate> ) unionOfArrayAndMap0).isEmpty()) {
                     (encoder).setItemCount(0);
@@ -95,19 +97,20 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
                 (encoder).writeMapEnd();
             }
         }
-        serialize_FastSerdeLogicalTypesTest10(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest11(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest12(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest13(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest14(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest15(data, (encoder));
+        serialize_FastSerdeLogicalTypesTest10(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest11(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest12(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest13(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest14(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest15(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest10(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest10(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, Object> mapOfUnionsOfDateAndTimestampMillis0 = ((Map<CharSequence, Object> ) data.get(1));
+        (customization).getCheckMapTypeFunction().apply(mapOfUnionsOfDateAndTimestampMillis0);
         (encoder).writeMapStart();
         if ((mapOfUnionsOfDateAndTimestampMillis0 == null)||mapOfUnionsOfDateAndTimestampMillis0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -135,6 +138,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
         }
         (encoder).writeMapEnd();
         Map<CharSequence, Instant> timestampMillisMap0 = ((Map<CharSequence, Instant> ) data.get(2));
+        (customization).getCheckMapTypeFunction().apply(timestampMillisMap0);
         (encoder).writeMapStart();
         if ((timestampMillisMap0 == null)||timestampMillisMap0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -152,7 +156,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest11(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest11(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<LocalDate> nullableArrayOfDates0 = ((List<LocalDate> ) data.get(3));
@@ -216,7 +220,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest12(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest12(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object unionOfDecimalOrDate0 = ((Object) data.get(5));
@@ -243,7 +247,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest13(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest13(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue13 = data.get(7);
@@ -255,7 +259,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest14(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest14(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue15 = data.get(9);
@@ -267,29 +271,29 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest15(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest15(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue17 = data.get(11);
         convertedValue17 = Conversions.convertToRawType(convertedValue17, this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date);
         (encoder).writeInt(((Integer) convertedValue17));
         IndexedRecord nestedLocalTimestampMillis0 = ((IndexedRecord) data.get(12));
-        serializeLocalTimestampRecord0(nestedLocalTimestampMillis0, (encoder));
+        serializeLocalTimestampRecord0(nestedLocalTimestampMillis0, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeLocalTimestampRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeLocalTimestampRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue18 = data.get(0);
         convertedValue18 = Conversions.convertToRawType(convertedValue18, this.logicalTypeSchema__250645780, this.logicalTypeSchema__250645780 .getLogicalType(), this.conversion_local_timestamp_millis);
         (encoder).writeLong(((Long) convertedValue18));
-        serialize_LocalTimestampRecord0(data, (encoder));
-        serialize_LocalTimestampRecord1(data, (encoder));
+        serialize_LocalTimestampRecord0(data, (encoder), (customization));
+        serialize_LocalTimestampRecord1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_LocalTimestampRecord0(IndexedRecord data, Encoder encoder)
+    private void serialize_LocalTimestampRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         LocalDateTime nullableNestedTimestamp0 = ((LocalDateTime) data.get(1));
@@ -324,7 +328,7 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_LocalTimestampRecord1(IndexedRecord data, Encoder encoder)
+    private void serialize_LocalTimestampRecord1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object unionOfDateAndLocalTimestamp0 = ((Object) data.get(3));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.api.PrimitiveIntList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesTest1;
 import com.linkedin.avro.fastserde.generated.avro.LocalTimestampRecord;
 import org.apache.avro.Conversions;
@@ -40,14 +41,14 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     private final Schema logicalTypeSchema__1515894331 = Schema.parse("{\"type\":\"long\",\"logicalType\":\"time-micros\"}");
     private final Schema logicalTypeSchema__250645780 = Schema.parse("{\"type\":\"long\",\"logicalType\":\"local-timestamp-millis\"}");
 
-    public void serialize(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    public void serialize(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeLogicalTypesTest10(data, (encoder));
+        serializeFastSerdeLogicalTypesTest10(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeLogicalTypesTest10(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    public void serializeFastSerdeLogicalTypesTest10(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object unionOfArrayAndMap0 = ((Object) data.get(0));
@@ -80,6 +81,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
         } else {
             if (unionOfArrayAndMap0 instanceof Map) {
                 (encoder).writeIndex(1);
+                (customization).getCheckMapTypeFunction().apply(((Map<CharSequence, LocalDate> ) unionOfArrayAndMap0));
                 (encoder).writeMapStart();
                 if ((((Map<CharSequence, LocalDate> ) unionOfArrayAndMap0) == null)||((Map<CharSequence, LocalDate> ) unionOfArrayAndMap0).isEmpty()) {
                     (encoder).setItemCount(0);
@@ -96,19 +98,20 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
                 (encoder).writeMapEnd();
             }
         }
-        serialize_FastSerdeLogicalTypesTest10(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest11(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest12(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest13(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest14(data, (encoder));
-        serialize_FastSerdeLogicalTypesTest15(data, (encoder));
+        serialize_FastSerdeLogicalTypesTest10(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest11(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest12(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest13(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest14(data, (encoder), (customization));
+        serialize_FastSerdeLogicalTypesTest15(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest10(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest10(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, Object> mapOfUnionsOfDateAndTimestampMillis0 = ((Map<CharSequence, Object> ) data.get(1));
+        (customization).getCheckMapTypeFunction().apply(mapOfUnionsOfDateAndTimestampMillis0);
         (encoder).writeMapStart();
         if ((mapOfUnionsOfDateAndTimestampMillis0 == null)||mapOfUnionsOfDateAndTimestampMillis0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -136,6 +139,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
         }
         (encoder).writeMapEnd();
         Map<CharSequence, Instant> timestampMillisMap0 = ((Map<CharSequence, Instant> ) data.get(2));
+        (customization).getCheckMapTypeFunction().apply(timestampMillisMap0);
         (encoder).writeMapStart();
         if ((timestampMillisMap0 == null)||timestampMillisMap0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -153,7 +157,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest11(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest11(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<LocalDate> nullableArrayOfDates0 = ((List<LocalDate> ) data.get(3));
@@ -217,7 +221,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest12(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest12(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object unionOfDecimalOrDate0 = ((Object) data.get(5));
@@ -244,7 +248,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest13(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest13(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue13 = data.get(7);
@@ -256,7 +260,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest14(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest14(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue15 = data.get(9);
@@ -268,29 +272,29 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesTest15(FastSerdeLogicalTypesTest1 data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesTest15(FastSerdeLogicalTypesTest1 data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue17 = data.get(11);
         convertedValue17 = Conversions.convertToRawType(convertedValue17, this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date);
         (encoder).writeInt(((Integer) convertedValue17));
         LocalTimestampRecord nestedLocalTimestampMillis0 = ((LocalTimestampRecord) data.get(12));
-        serializeLocalTimestampRecord0(nestedLocalTimestampMillis0, (encoder));
+        serializeLocalTimestampRecord0(nestedLocalTimestampMillis0, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeLocalTimestampRecord0(LocalTimestampRecord data, Encoder encoder)
+    public void serializeLocalTimestampRecord0(LocalTimestampRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object convertedValue18 = data.get(0);
         convertedValue18 = Conversions.convertToRawType(convertedValue18, this.logicalTypeSchema__250645780, this.logicalTypeSchema__250645780 .getLogicalType(), this.conversion_local_timestamp_millis);
         (encoder).writeLong(((Long) convertedValue18));
-        serialize_LocalTimestampRecord0(data, (encoder));
-        serialize_LocalTimestampRecord1(data, (encoder));
+        serialize_LocalTimestampRecord0(data, (encoder), (customization));
+        serialize_LocalTimestampRecord1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_LocalTimestampRecord0(LocalTimestampRecord data, Encoder encoder)
+    private void serialize_LocalTimestampRecord0(LocalTimestampRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         LocalDateTime nullableNestedTimestamp0 = ((LocalDateTime) data.get(1));
@@ -325,7 +329,7 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_LocalTimestampRecord1(LocalTimestampRecord data, Encoder encoder)
+    private void serialize_LocalTimestampRecord1(LocalTimestampRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object unionOfDateAndLocalTimestamp0 = ((Object) data.get(3));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_GenericSerializer_1982763418.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_GenericSerializer_1982763418.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 
@@ -12,22 +13,22 @@ public class FastSerdeLogicalTypesUndefined_GenericSerializer_1982763418
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeLogicalTypesUndefined0(data, (encoder));
+        serializeFastSerdeLogicalTypesUndefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeLogicalTypesUndefined0(IndexedRecord data, Encoder encoder)
+    public void serializeFastSerdeLogicalTypesUndefined0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        serialize_FastSerdeLogicalTypesUndefined0(data, (encoder));
+        serialize_FastSerdeLogicalTypesUndefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesUndefined0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesUndefined0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(1)));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_SpecificSerializer_1982763418.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_SpecificSerializer_1982763418.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import com.linkedin.avro.fastserde.generated.avro.FastSerdeLogicalTypesUndefined;
 import org.apache.avro.io.Encoder;
 
@@ -12,22 +13,22 @@ public class FastSerdeLogicalTypesUndefined_SpecificSerializer_1982763418
 {
 
 
-    public void serialize(FastSerdeLogicalTypesUndefined data, Encoder encoder)
+    public void serialize(FastSerdeLogicalTypesUndefined data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastSerdeLogicalTypesUndefined0(data, (encoder));
+        serializeFastSerdeLogicalTypesUndefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastSerdeLogicalTypesUndefined0(FastSerdeLogicalTypesUndefined data, Encoder encoder)
+    public void serializeFastSerdeLogicalTypesUndefined0(FastSerdeLogicalTypesUndefined data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(0)));
-        serialize_FastSerdeLogicalTypesUndefined0(data, (encoder));
+        serialize_FastSerdeLogicalTypesUndefined0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastSerdeLogicalTypesUndefined0(FastSerdeLogicalTypesUndefined data, Encoder encoder)
+    private void serialize_FastSerdeLogicalTypesUndefined0(FastSerdeLogicalTypesUndefined data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeInt(((Integer) data.get(1)));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericSerializer_205569.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericSerializer_205569.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,14 +15,14 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericSeri
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(data, (encoder));
+        serializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord data, Encoder encoder)
+    public void serializeFastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         if (((CharSequence) data.get(0)) instanceof Utf8) {
@@ -29,12 +30,12 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericSeri
         } else {
             (encoder).writeString(((CharSequence) data.get(0)).toString());
         }
-        serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest0(data, (encoder));
-        serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest1(data, (encoder));
+        serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest0(data, (encoder), (customization));
+        serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence testUnionString0 = ((CharSequence) data.get(1));
@@ -68,10 +69,11 @@ public class FastStringableTest_javaStringPropertyInReaderSchemaTest_GenericSeri
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastStringableTest_javaStringPropertyInReaderSchemaTest1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, CharSequence> testStringMap0 = ((Map<CharSequence, CharSequence> ) data.get(3));
+        (customization).getCheckMapTypeFunction().apply(testStringMap0);
         (encoder).writeMapStart();
         if ((testStringMap0 == null)||testStringMap0 .isEmpty()) {
             (encoder).setItemCount(0);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastStringableTest_javaStringPropertyTest_GenericSerializer_1110978985.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastStringableTest_javaStringPropertyTest_GenericSerializer_1110978985.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -14,14 +15,14 @@ public class FastStringableTest_javaStringPropertyTest_GenericSerializer_1110978
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeFastStringableTest_javaStringPropertyTest0(data, (encoder));
+        serializeFastStringableTest_javaStringPropertyTest0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeFastStringableTest_javaStringPropertyTest0(IndexedRecord data, Encoder encoder)
+    public void serializeFastStringableTest_javaStringPropertyTest0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         if (((CharSequence) data.get(0)) instanceof Utf8) {
@@ -29,12 +30,12 @@ public class FastStringableTest_javaStringPropertyTest_GenericSerializer_1110978
         } else {
             (encoder).writeString(((CharSequence) data.get(0)).toString());
         }
-        serialize_FastStringableTest_javaStringPropertyTest0(data, (encoder));
-        serialize_FastStringableTest_javaStringPropertyTest1(data, (encoder));
+        serialize_FastStringableTest_javaStringPropertyTest0(data, (encoder), (customization));
+        serialize_FastStringableTest_javaStringPropertyTest1(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastStringableTest_javaStringPropertyTest0(IndexedRecord data, Encoder encoder)
+    private void serialize_FastStringableTest_javaStringPropertyTest0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence testUnionString0 = ((CharSequence) data.get(1));
@@ -68,10 +69,11 @@ public class FastStringableTest_javaStringPropertyTest_GenericSerializer_1110978
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_FastStringableTest_javaStringPropertyTest1(IndexedRecord data, Encoder encoder)
+    private void serialize_FastStringableTest_javaStringPropertyTest1(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Map<CharSequence, CharSequence> testStringMap0 = ((Map<CharSequence, CharSequence> ) data.get(3));
+        (customization).getCheckMapTypeFunction().apply(testStringMap0);
         (encoder).writeMapStart();
         if ((testStringMap0 == null)||testStringMap0 .isEmpty()) {
             (encoder).setItemCount(0);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_UNION_GenericSerializer_2140000109.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_UNION_GenericSerializer_2140000109.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -13,9 +14,10 @@ public class Map_of_UNION_GenericSerializer_2140000109
 {
 
 
-    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
+        (customization).getCheckMapTypeFunction().apply(data);
         (encoder).writeMapStart();
         if ((data == null)||data.isEmpty()) {
             (encoder).setItemCount(0);
@@ -32,7 +34,7 @@ public class Map_of_UNION_GenericSerializer_2140000109
                 } else {
                     if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializeRecord0(((IndexedRecord) union0), (encoder));
+                        serializeRecord0(((IndexedRecord) union0), (encoder), (customization));
                     }
                 }
             }
@@ -41,7 +43,7 @@ public class Map_of_UNION_GenericSerializer_2140000109
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence field0 = ((CharSequence) data.get(0));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_record_GenericSerializer_1677529043.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_record_GenericSerializer_1677529043.java
@@ -4,6 +4,7 @@ package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 import java.io.IOException;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
@@ -13,9 +14,10 @@ public class Map_of_record_GenericSerializer_1677529043
 {
 
 
-    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder)
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
+        (customization).getCheckMapTypeFunction().apply(data);
         (encoder).writeMapStart();
         if ((data == null)||data.isEmpty()) {
             (encoder).setItemCount(0);
@@ -26,14 +28,14 @@ public class Map_of_record_GenericSerializer_1677529043
                 (encoder).writeString(key0);
                 IndexedRecord record0 = null;
                 record0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
-                serializeRecord0(record0, (encoder));
+                serializeRecord0(record0, (encoder), (customization));
             }
         }
         (encoder).writeMapEnd();
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeRecord0(IndexedRecord data, Encoder encoder)
+    public void serializeRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         CharSequence field0 = ((CharSequence) data.get(0));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/StringableRecord_SpecificSerializer_842267318.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/StringableRecord_SpecificSerializer_842267318.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import com.linkedin.avro.fastserde.generated.avro.AnotherSubRecord;
 import com.linkedin.avro.fastserde.generated.avro.StringableRecord;
 import com.linkedin.avro.fastserde.generated.avro.StringableSubRecord;
@@ -21,26 +22,26 @@ public class StringableRecord_SpecificSerializer_842267318
 {
 
 
-    public void serialize(StringableRecord data, Encoder encoder)
+    public void serialize(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeStringableRecord0(data, (encoder));
+        serializeStringableRecord0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeStringableRecord0(StringableRecord data, Encoder encoder)
+    public void serializeStringableRecord0(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeString(((BigInteger) data.get(0)).toString());
-        serialize_StringableRecord0(data, (encoder));
-        serialize_StringableRecord1(data, (encoder));
-        serialize_StringableRecord2(data, (encoder));
-        serialize_StringableRecord3(data, (encoder));
-        serialize_StringableRecord4(data, (encoder));
+        serialize_StringableRecord0(data, (encoder), (customization));
+        serialize_StringableRecord1(data, (encoder), (customization));
+        serialize_StringableRecord2(data, (encoder), (customization));
+        serialize_StringableRecord3(data, (encoder), (customization));
+        serialize_StringableRecord4(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_StringableRecord0(StringableRecord data, Encoder encoder)
+    private void serialize_StringableRecord0(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeString(((BigDecimal) data.get(1)).toString());
@@ -48,7 +49,7 @@ public class StringableRecord_SpecificSerializer_842267318
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_StringableRecord1(StringableRecord data, Encoder encoder)
+    private void serialize_StringableRecord1(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeString(((URL) data.get(3)).toString());
@@ -56,7 +57,7 @@ public class StringableRecord_SpecificSerializer_842267318
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_StringableRecord2(StringableRecord data, Encoder encoder)
+    private void serialize_StringableRecord2(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<URL> urlArray0 = ((List<URL> ) data.get(5));
@@ -72,6 +73,7 @@ public class StringableRecord_SpecificSerializer_842267318
         }
         (encoder).writeArrayEnd();
         Map<URL, BigInteger> urlMap0 = ((Map<URL, BigInteger> ) data.get(6));
+        (customization).getCheckMapTypeFunction().apply(urlMap0);
         (encoder).writeMapStart();
         if ((urlMap0 == null)||urlMap0 .isEmpty()) {
             (encoder).setItemCount(0);
@@ -88,25 +90,25 @@ public class StringableRecord_SpecificSerializer_842267318
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_StringableRecord3(StringableRecord data, Encoder encoder)
+    private void serialize_StringableRecord3(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         StringableSubRecord subRecord0 = ((StringableSubRecord) data.get(7));
-        serializeStringableSubRecord0(subRecord0, (encoder));
+        serializeStringableSubRecord0(subRecord0, (encoder), (customization));
         AnotherSubRecord subRecordWithSubRecord0 = ((AnotherSubRecord) data.get(8));
-        serializeAnotherSubRecord0(subRecordWithSubRecord0, (encoder));
+        serializeAnotherSubRecord0(subRecordWithSubRecord0, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeStringableSubRecord0(StringableSubRecord data, Encoder encoder)
+    public void serializeStringableSubRecord0(StringableSubRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         (encoder).writeString(((URI) data.get(0)).toString());
-        serialize_StringableSubRecord0(data, (encoder));
+        serialize_StringableSubRecord0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_StringableSubRecord0(StringableSubRecord data, Encoder encoder)
+    private void serialize_StringableSubRecord0(StringableSubRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         Object nullStringIntUnion0 = ((Object) data.get(1));
@@ -131,15 +133,15 @@ public class StringableRecord_SpecificSerializer_842267318
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeAnotherSubRecord0(AnotherSubRecord data, Encoder encoder)
+    public void serializeAnotherSubRecord0(AnotherSubRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         StringableSubRecord subRecord1 = ((StringableSubRecord) data.get(0));
-        serializeStringableSubRecord0(subRecord1, (encoder));
+        serializeStringableSubRecord0(subRecord1, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    private void serialize_StringableRecord4(StringableRecord data, Encoder encoder)
+    private void serialize_StringableRecord4(StringableRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         String stringUnion0 = ((String) data.get(9));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/TestArrayOfFloats_GenericSerializer_1408566797.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/TestArrayOfFloats_GenericSerializer_1408566797.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.linkedin.avro.api.PrimitiveFloatList;
 import com.linkedin.avro.fastserde.BufferBackedPrimitiveFloatList;
 import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 
@@ -14,14 +15,14 @@ public class TestArrayOfFloats_GenericSerializer_1408566797
 {
 
 
-    public void serialize(IndexedRecord data, Encoder encoder)
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        serializeTestArrayOfFloats0(data, (encoder));
+        serializeTestArrayOfFloats0(data, (encoder), (customization));
     }
 
     @SuppressWarnings("unchecked")
-    public void serializeTestArrayOfFloats0(IndexedRecord data, Encoder encoder)
+    public void serializeTestArrayOfFloats0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
         List<Float> array_of_float0 = ((List<Float> ) data.get(0));

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastClassStatus.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastClassStatus.java
@@ -1,0 +1,27 @@
+package com.linkedin.avro.fastserde;
+
+public interface FastClassStatus {
+  /**
+   * Whether it is implemented by the runtime-generated class or not.
+   */
+  default boolean isBackedByGeneratedClass() {
+    return true;
+  }
+
+  /**
+   * Tell the user, specifically {@link FastGenericDatumReader}/{@link FastSpecificDatumReader} or
+   * {@link FastGenericDatumWriter}/{@link FastSpecificDatumWriter} that
+   * whether runtime class generation is done or not.
+   * There will be two outcomes:
+   * 1. Fast class is backed by the class generated at runtime.
+   * 2. Vanilla Avro based implementation when runtime class generation fails.
+   *
+   * For both cases, {@link FastGenericDatumReader}/{@link FastSpecificDatumReader} or
+   * {@link FastGenericDatumWriter}/{@link FastSpecificDatumWriter}can stop polling
+   * the runtime class generation status.
+   */
+  default boolean hasDynamicClassGenerationDone() {
+    return true;
+  }
+
+}

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializer.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializer.java
@@ -1,14 +1,23 @@
 package com.linkedin.avro.fastserde;
 
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.avro.io.Decoder;
 
+import static com.linkedin.avro.fastserde.customized.DatumReaderCustomization.*;
 
-public interface FastDeserializer<T> {
+
+public interface FastDeserializer<T> extends FastClassStatus {
 
   default T deserialize(Decoder d) throws IOException {
     return deserialize(null, d);
   }
 
-  T deserialize(T reuse, Decoder d) throws IOException;
+  default T deserialize(T reuse, Decoder d) throws IOException {
+    return deserialize(reuse, d, DEFAULT_DATUM_READER_CUSTOMIZATION);
+  }
+
+  T deserialize(T reuse, Decoder d, DatumReaderCustomization customization) throws IOException;
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
@@ -1,5 +1,6 @@
 package com.linkedin.avro.fastserde;
 
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -19,8 +20,11 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
 
   private Schema writerSchema;
   private Schema readerSchema;
-  private final FastSerdeCache cache;
+  protected final FastSerdeCache cache;
   private final GenericData modelData;
+  private final DatumReaderCustomization customization;
+
+  private final FastDeserializer<T> coldDeserializer;
 
   private final AtomicReference<FastDeserializer<T>> cachedFastDeserializer = new AtomicReference<>();
 
@@ -45,13 +49,19 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
   }
 
   public FastGenericDatumReader(Schema writerSchema, Schema readerSchema, FastSerdeCache cache, GenericData modelData) {
+    this(writerSchema, readerSchema, cache, modelData, null);
+  }
+
+  public FastGenericDatumReader(Schema writerSchema, Schema readerSchema, FastSerdeCache cache, GenericData modelData, DatumReaderCustomization customization) {
     this.writerSchema = writerSchema;
     this.readerSchema = readerSchema;
     this.cache = cache != null ? cache : FastSerdeCache.getDefaultInstance();
     this.modelData = modelData;
+    this.customization = customization == null ? DatumReaderCustomization.DEFAULT_DATUM_READER_CUSTOMIZATION : customization;
+    this.coldDeserializer = getRegularAvroImpl(writerSchema, readerSchema, modelData, this.customization);
 
     if (!Utils.isSupportedAvroVersionsForDeserializer()) {
-      this.cachedFastDeserializer.set(getRegularAvroImpl(writerSchema, readerSchema, modelData));
+      this.cachedFastDeserializer.set(coldDeserializer);
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(
             "Current avro version: " + Utils.getRuntimeAvroVersion() + " is not supported, and only the following"
@@ -60,7 +70,7 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
       }
     } else if (!FastSerdeCache.isSupportedForFastDeserializer(readerSchema.getType())) {
       // For unsupported schema type, we won't try to fetch it from FastSerdeCache since it is inefficient.
-      this.cachedFastDeserializer.set(getRegularAvroImpl(writerSchema, readerSchema, modelData));
+      this.cachedFastDeserializer.set(coldDeserializer);
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Skip the FastGenericDeserializer generation since read schema type: " + readerSchema.getType()
             + " is not supported");
@@ -86,41 +96,62 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
     if (cachedFastDeserializer.get() != null) {
       fastDeserializer = cachedFastDeserializer.get();
     } else {
-      fastDeserializer = getFastDeserializerFromCache(cache, writerSchema, readerSchema, modelData);
-      if (FastSerdeCache.isFastDeserializer(fastDeserializer)) {
-        cachedFastDeserializer.compareAndSet(null, fastDeserializer);
-        if (LOGGER.isDebugEnabled()) {
-          LOGGER.debug("FastGenericDeserializer was generated and cached for reader schema: ["
-              + readerSchema + "], writer schema: [" + writerSchema + "]");
+      fastDeserializer = getFastDeserializerFromCache(cache, writerSchema, readerSchema, modelData, customization);
+      if (fastDeserializer.hasDynamicClassGenerationDone()) {
+        if (fastDeserializer.isBackedByGeneratedClass()) {
+          /**
+           * Runtime class generation is done successfully, so cache it.
+            */
+          cachedFastDeserializer.compareAndSet(null, fastDeserializer);
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("FastGenericDeserializer was generated and cached for reader schema: ["
+                + readerSchema + "], writer schema: [" + writerSchema + "]");
+          }
+        } else {
+          /**
+           * Runtime class generation fails, so this class will cache a newly generated cold deserializer, which will
+           * honer {@link FastSerdeCache#isFailFast()}.
+            */
+          cachedFastDeserializer.compareAndSet(null,
+              getRegularAvroImplWhenGenerationFail(writerSchema, readerSchema, modelData, customization));
+          LOGGER.warn("FastGenericDeserializer generation fails, and will cache cold deserializer "
+              + "for reader schema: [" + readerSchema + "], writer schema: [" + writerSchema + "]");
         }
+        fastDeserializer = cachedFastDeserializer.get();
+      } else {
+        fastDeserializer = coldDeserializer;
       }
     }
 
-    return fastDeserializer.deserialize(reuse, in);
+    return fastDeserializer.deserialize(reuse, in, customization);
   }
 
   public CompletableFuture<FastDeserializer<T>> getFastDeserializer() {
     return cachedFastDeserializer.get() != null ? CompletableFuture.completedFuture(cachedFastDeserializer.get())
-        : getFastDeserializer(cache, writerSchema, readerSchema, modelData).thenApply(d -> {
+        : getFastDeserializer(cache, writerSchema, readerSchema, modelData, customization).thenApply(d -> {
           cachedFastDeserializer.compareAndSet(null, d);
           return d;
         });
   }
 
   protected CompletableFuture<FastDeserializer<T>> getFastDeserializer(FastSerdeCache fastSerdeCache,
-      Schema writerSchema, Schema readerSchema, GenericData modelData) {
-    return fastSerdeCache.getFastGenericDeserializerAsync(writerSchema, readerSchema, modelData)
+      Schema writerSchema, Schema readerSchema, GenericData modelData, DatumReaderCustomization customization) {
+    return fastSerdeCache.getFastGenericDeserializerAsync(writerSchema, readerSchema, modelData, customization)
         .thenApply(d -> (FastDeserializer<T>) d);
   }
 
   @SuppressWarnings("unchecked")
   protected FastDeserializer<T> getFastDeserializerFromCache(FastSerdeCache fastSerdeCache, Schema writerSchema,
-      Schema readerSchema, GenericData modelData) {
-    return (FastDeserializer<T>) fastSerdeCache.getFastGenericDeserializer(writerSchema, readerSchema, modelData);
+      Schema readerSchema, GenericData modelData, DatumReaderCustomization customization) {
+    return (FastDeserializer<T>) fastSerdeCache.getFastGenericDeserializer(writerSchema, readerSchema, modelData, customization);
   }
 
-  protected FastDeserializer<T> getRegularAvroImpl(Schema writerSchema, Schema readerSchema, GenericData modelData) {
-    return new FastSerdeCache.FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, modelData);
+  protected FastDeserializer<T> getRegularAvroImpl(Schema writerSchema, Schema readerSchema, GenericData modelData, DatumReaderCustomization customization) {
+    return new FastSerdeUtils.FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, modelData, customization, false);
+  }
+
+  protected FastDeserializer<T> getRegularAvroImplWhenGenerationFail(Schema writerSchema, Schema readerSchema, GenericData modelData, DatumReaderCustomization customization) {
+    return new FastSerdeUtils.FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, modelData, customization, cache.isFailFast(), true);
   }
 
   /**
@@ -129,6 +160,6 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
    */
   public boolean isFastDeserializerUsed() {
     FastDeserializer<T> fastDeserializer = cachedFastDeserializer.get();
-    return fastDeserializer != null && FastSerdeCache.isFastDeserializer(fastDeserializer);
+    return fastDeserializer != null && fastDeserializer.isBackedByGeneratedClass();
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeCache.java
@@ -3,6 +3,8 @@ package com.linkedin.avro.fastserde;
 import static com.linkedin.avro.fastserde.Utils.getSchemaFingerprint;
 import static com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper.getSchemaFullName;
 
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
@@ -20,22 +22,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.ColdGenericDatumReader;
-import org.apache.avro.generic.ColdSpecificDatumReader;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DatumWriter;
-import org.apache.avro.io.Decoder;
-import org.apache.avro.io.Encoder;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
-
 
 /**
  * Fast avro serializer/deserializer cache. Stores generated and already compiled instances of serializers and
@@ -191,8 +184,7 @@ public final class FastSerdeCache {
   }
 
   public static boolean isFastDeserializer(FastDeserializer deserializer) {
-    return !(deserializer instanceof FastDeserializerWithAvroSpecificImpl
-        || deserializer instanceof FastDeserializerWithAvroGenericImpl);
+    return deserializer.isBackedByGeneratedClass();
   }
 
   /**
@@ -200,6 +192,10 @@ public final class FastSerdeCache {
    */
   public FastDeserializer<?> getFastSpecificDeserializer(Schema writerSchema, Schema readerSchema) {
     return getFastSpecificDeserializer(writerSchema, readerSchema, null);
+  }
+
+  public FastDeserializer<?> getFastSpecificDeserializer(Schema writerSchema, Schema readerSchema, SpecificData modelData) {
+    return getFastSpecificDeserializer(writerSchema, readerSchema, modelData, null);
   }
 
   /**
@@ -211,9 +207,12 @@ public final class FastSerdeCache {
    *            {@link Schema} intended to be used during deserialization
    * @param modelData
    *            Provides additional information not available in the schema, e.g. conversion classes
+   * @param customization
+   *            Provides customized logic during de-serialization
    * @return specific-class aware avro {@link FastDeserializer}
    */
-  public FastDeserializer<?> getFastSpecificDeserializer(Schema writerSchema, Schema readerSchema, SpecificData modelData) {
+  public FastDeserializer<?> getFastSpecificDeserializer(Schema writerSchema, Schema readerSchema,
+      SpecificData modelData, DatumReaderCustomization customization) {
     String schemaKey = getSchemaKey(writerSchema, readerSchema);
     FastDeserializer<?> deserializer = fastSpecificRecordDeserializersCache.get(schemaKey);
 
@@ -223,11 +222,11 @@ public final class FastSerdeCache {
           schemaKey,
           k -> {
             fastDeserializerMissingInCache.set(true);
-            return new FastDeserializerWithAvroSpecificImpl<>(writerSchema, readerSchema, modelData);
+            return new FastSerdeUtils.FastDeserializerWithAvroSpecificImpl<>(writerSchema, readerSchema, modelData, customization, false);
           });
 
       if (fastDeserializerMissingInCache.get()) {
-        CompletableFuture.supplyAsync(() -> buildSpecificDeserializer(writerSchema, readerSchema, modelData), executor)
+        CompletableFuture.supplyAsync(() -> buildSpecificDeserializer(writerSchema, readerSchema, modelData, customization), executor)
             .thenAccept(d -> fastSpecificRecordDeserializersCache.put(schemaKey, d));
       }
     }
@@ -242,6 +241,10 @@ public final class FastSerdeCache {
     return getFastGenericDeserializer(writerSchema, readerSchema, null);
   }
 
+  public FastDeserializer<?> getFastGenericDeserializer(Schema writerSchema, Schema readerSchema, GenericData modelData) {
+    return getFastGenericDeserializer(writerSchema, readerSchema, modelData, null);
+  }
+
   /**
    * Generates if needed and returns generic-class aware avro {@link FastDeserializer}.
    *
@@ -251,9 +254,12 @@ public final class FastSerdeCache {
    *            {@link Schema} intended to be used during deserialization
    * @param modelData
    *            Provides additional information not available in the schema, e.g. conversion classes
+   * @param customization
+   *            Provides customized logic during de-serialization
    * @return generic-class aware avro {@link FastDeserializer}
    */
-  public FastDeserializer<?> getFastGenericDeserializer(Schema writerSchema, Schema readerSchema, GenericData modelData) {
+  public FastDeserializer<?> getFastGenericDeserializer(Schema writerSchema, Schema readerSchema,
+      GenericData modelData, DatumReaderCustomization customization) {
     String schemaKey = getSchemaKey(writerSchema, readerSchema);
     FastDeserializer<?> deserializer = fastGenericRecordDeserializersCache.get(schemaKey);
 
@@ -263,22 +269,22 @@ public final class FastSerdeCache {
           schemaKey,
           k -> {
             fastDeserializerMissingInCache.set(true);
-            return new FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, modelData);
+            return new FastSerdeUtils.FastDeserializerWithAvroGenericImpl<>(writerSchema, readerSchema, modelData, customization, false);
           });
 
       if (fastDeserializerMissingInCache.get()) {
-        CompletableFuture.supplyAsync(() -> buildGenericDeserializer(writerSchema, readerSchema, modelData), executor)
+        CompletableFuture.supplyAsync(() -> buildGenericDeserializer(writerSchema, readerSchema, modelData, customization), executor)
             .thenAccept(d -> fastGenericRecordDeserializersCache.put(schemaKey, d));
       }
     }
     return deserializer;
   }
-  
+
   /**
-   * @see #getFastSpecificSerializer(Schema, SpecificData)
+   * @see #getFastSpecificSerializer(Schema, SpecificData, DatumWriterCustomization)
    */
   public FastSerializer<?> getFastSpecificSerializer(Schema schema) {
-    return getFastSpecificSerializer(schema, null);
+    return getFastSpecificSerializer(schema, null, null);
   }
 
   /**
@@ -288,9 +294,11 @@ public final class FastSerdeCache {
    *            {@link Schema} of data to write
    * @param modelData
    *            Provides additional information not available in the schema, e.g. conversion classes
+   * @param customization
+   *            Provides customized logic during serialization
    * @return specific-class aware avro {@link FastSerializer}
    */
-  public FastSerializer<?> getFastSpecificSerializer(Schema schema, SpecificData modelData) {
+  public FastSerializer<?> getFastSpecificSerializer(Schema schema, SpecificData modelData, DatumWriterCustomization customization) {
     String schemaKey = getSchemaKey(schema, schema);
     FastSerializer<?> serializer = fastSpecificRecordSerializersCache.get(schemaKey);
 
@@ -300,11 +308,11 @@ public final class FastSerdeCache {
           schemaKey,
           k -> {
             fastSerializerMissingInCache.set(true);
-            return new FastSerializerWithAvroSpecificImpl<>(schema, modelData);
+            return new FastSerdeUtils.FastSerializerWithAvroSpecificImpl<>(schema, modelData, customization, false);
           });
 
       if (fastSerializerMissingInCache.get()) {
-        CompletableFuture.supplyAsync(() -> buildSpecificSerializer(schema, modelData), executor)
+        CompletableFuture.supplyAsync(() -> buildSpecificSerializer(schema, modelData, customization), executor)
             .thenAccept(s -> fastSpecificRecordSerializersCache.put(schemaKey, s));
       }
     }
@@ -313,10 +321,10 @@ public final class FastSerdeCache {
   }
 
   /**
-   * @see #getFastGenericSerializer(Schema, GenericData)
+   * @see #getFastGenericSerializer(Schema, GenericData, DatumWriterCustomization)
    */
   public FastSerializer<?> getFastGenericSerializer(Schema schema) {
-    return getFastGenericSerializer(schema, null);
+    return getFastGenericSerializer(schema, null, null);
   }
 
   /**
@@ -326,9 +334,11 @@ public final class FastSerdeCache {
    *            {@link Schema} of data to write
    * @param modelData
    *            Passes additional information e.g. conversion classes not available in the schema
+   * @param customization
+   *            Provides customized logic during serialization
    * @return generic-class aware avro {@link FastSerializer}
    */
-  public FastSerializer<?> getFastGenericSerializer(Schema schema, GenericData modelData) {
+  public FastSerializer<?> getFastGenericSerializer(Schema schema, GenericData modelData, DatumWriterCustomization customization) {
     String schemaKey = getSchemaKey(schema, schema);
     FastSerializer<?> serializer = fastGenericRecordSerializersCache.get(schemaKey);
 
@@ -338,11 +348,11 @@ public final class FastSerdeCache {
           schemaKey,
           k -> {
             fastSerializerMissingInCache.set(true);
-            return new FastSerializerWithAvroGenericImpl<>(schema, modelData);
+            return new FastSerdeUtils.FastSerializerWithAvroGenericImpl<>(schema, modelData, customization, false);
           });
 
       if (fastSerializerMissingInCache.get()) {
-        CompletableFuture.supplyAsync(() -> buildGenericSerializer(schema, modelData), executor)
+        CompletableFuture.supplyAsync(() -> buildGenericSerializer(schema, modelData, customization), executor)
             .thenAccept(s -> fastGenericRecordSerializersCache.put(schemaKey, s));
       }
     }
@@ -351,10 +361,10 @@ public final class FastSerdeCache {
   }
 
   /**
-   * @see #getFastSpecificDeserializerAsync(Schema, Schema, SpecificData)
+   * @see #getFastSpecificDeserializerAsync(Schema, Schema, SpecificData, DatumReaderCustomization)
    */
   public CompletableFuture<FastDeserializer<?>> getFastSpecificDeserializerAsync(Schema writerSchema, Schema readerSchema) {
-    return getFastSpecificDeserializerAsync(writerSchema, readerSchema, null);
+    return getFastSpecificDeserializerAsync(writerSchema, readerSchema, null, null);
   }
 
   /**
@@ -363,18 +373,20 @@ public final class FastSerdeCache {
    * @param writerSchema {@link Schema} of written data
    * @param readerSchema {@link Schema} intended to be used during deserialization
    * @param modelData Passes additional information e.g. conversion classes not available in the schema
+   * @param customization Provides customized logic during de-serialization
    * @return {@link CompletableFuture} which contains specific-class aware avro {@link FastDeserializer}
    */
-  public CompletableFuture<FastDeserializer<?>> getFastSpecificDeserializerAsync(Schema writerSchema, Schema readerSchema, SpecificData modelData) {
+  public CompletableFuture<FastDeserializer<?>> getFastSpecificDeserializerAsync(Schema writerSchema,
+      Schema readerSchema, SpecificData modelData, DatumReaderCustomization customization) {
     return getFastDeserializerAsync(writerSchema, readerSchema, fastSpecificRecordDeserializersCache,
-        () -> buildSpecificDeserializer(writerSchema, readerSchema, modelData));
+        () -> buildSpecificDeserializer(writerSchema, readerSchema, modelData, customization));
   }
 
   /**
-   * @see #getFastGenericDeserializerAsync(Schema, Schema, GenericData)
+   * @see #getFastGenericDeserializerAsync(Schema, Schema, GenericData, DatumReaderCustomization)
    */
   public CompletableFuture<FastDeserializer<?>> getFastGenericDeserializerAsync(Schema writerSchema, Schema readerSchema) {
-    return getFastGenericDeserializerAsync(writerSchema, readerSchema, null);
+    return getFastGenericDeserializerAsync(writerSchema, readerSchema, null, null);
   }
 
   /**
@@ -383,11 +395,13 @@ public final class FastSerdeCache {
    * @param writerSchema {@link Schema} of written data
    * @param readerSchema {@link Schema} intended to be used during deserialization
    * @param modelData Passes additional information e.g. conversion classes not available in the schema
+   * @param customization Provides customized logic during de-serialization
    * @return {@link CompletableFuture} which contains generic-class aware avro {@link FastDeserializer}
    */
-  public CompletableFuture<FastDeserializer<?>> getFastGenericDeserializerAsync(Schema writerSchema, Schema readerSchema, GenericData modelData) {
+  public CompletableFuture<FastDeserializer<?>> getFastGenericDeserializerAsync(Schema writerSchema, Schema readerSchema,
+      GenericData modelData, DatumReaderCustomization customization) {
     return getFastDeserializerAsync(writerSchema, readerSchema, fastGenericRecordDeserializersCache,
-        () -> buildGenericDeserializer(writerSchema, readerSchema, modelData));
+        () -> buildGenericDeserializer(writerSchema, readerSchema, modelData, customization));
   }
 
   private CompletableFuture<FastDeserializer<?>> getFastDeserializerAsync(Schema writerSchema, Schema readerSchema,
@@ -451,7 +465,8 @@ public final class FastSerdeCache {
    *            Provides additional information not available in the schema, e.g. conversion classes
    * @return
    */
-  private FastDeserializer<?> buildSpecificDeserializer(Schema writerSchema, Schema readerSchema, SpecificData modelData) {
+  private FastDeserializer<?> buildSpecificDeserializer(Schema writerSchema, Schema readerSchema,
+      SpecificData modelData, DatumReaderCustomization customization) {
     try {
       return buildFastSpecificDeserializer(writerSchema, readerSchema, modelData);
     } catch (FastDeserializerGeneratorException e) {
@@ -461,17 +476,7 @@ public final class FastSerdeCache {
       LOGGER.error("Deserializer class instantiation exception", e);
     }
 
-    return new FastDeserializer<Object>() {
-      private DatumReader datumReader = AvroCompatibilityHelper.newSpecificDatumReader(writerSchema, readerSchema, modelData);
-
-      @Override
-      public Object deserialize(Object reuse, Decoder d) throws IOException {
-        if (failFast) {
-          throw new UnsupportedOperationException("Fast specific deserializer could not be generated.");
-        }
-        return datumReader.read(reuse, d);
-      }
-    };
+    return new FastSerdeUtils.FastDeserializerWithAvroSpecificImpl(writerSchema, readerSchema, modelData, customization, failFast, true);
   }
 
   /**
@@ -490,7 +495,8 @@ public final class FastSerdeCache {
    * @param modelData Provides additional information not available in the schema, e.g. conversion classes
    * @return a fast deserializer
    */
-  public FastDeserializer<?> buildFastGenericDeserializer(Schema writerSchema, Schema readerSchema, GenericData modelData) {
+  public FastDeserializer<?> buildFastGenericDeserializer(Schema writerSchema, Schema readerSchema,
+      GenericData modelData) {
     FastGenericDeserializerGenerator<?> generator =
         new FastGenericDeserializerGenerator<>(writerSchema, readerSchema, classesDir, classLoader, compileClassPath, modelData);
 
@@ -519,7 +525,8 @@ public final class FastSerdeCache {
    * @param modelData Provides additional information not available in the schema, e.g. conversion classes
    * @return
    */
-  private FastDeserializer<?> buildGenericDeserializer(Schema writerSchema, Schema readerSchema, GenericData modelData) {
+  private FastDeserializer<?> buildGenericDeserializer(Schema writerSchema, Schema readerSchema,
+      GenericData modelData, DatumReaderCustomization customization) {
     try {
       return buildFastGenericDeserializer(writerSchema, readerSchema, modelData);
     } catch (FastDeserializerGeneratorException e) {
@@ -529,21 +536,7 @@ public final class FastSerdeCache {
       LOGGER.error("Deserializer class instantiation exception:", e);
     }
 
-    return new FastDeserializer<Object>() {
-      private DatumReader datumReader = AvroCompatibilityHelper.newGenericDatumReader(writerSchema, readerSchema, modelData);
-
-      @Override
-      public Object deserialize(Object reuse, Decoder d) throws IOException {
-        if (failFast) {
-          throw new UnsupportedOperationException("Fast generic deserializer could not be generated.");
-        }
-        return datumReader.read(reuse, d);
-      }
-    };
-  }
-
-  public FastSerializer<?> buildFastSpecificSerializer(Schema schema) {
-    return buildFastSpecificSerializer(schema, null);
+    return new FastSerdeUtils.FastDeserializerWithAvroGenericImpl(writerSchema, readerSchema, modelData, customization, failFast, true);
   }
 
   public FastSerializer<?> buildFastSpecificSerializer(Schema schema, SpecificData modelData) {
@@ -567,7 +560,7 @@ public final class FastSerdeCache {
     return generator.generateSerializer();
   }
 
-  private FastSerializer<?> buildSpecificSerializer(Schema schema, SpecificData modelData) {
+  private FastSerializer<?> buildSpecificSerializer(Schema schema, SpecificData modelData, DatumWriterCustomization customization) {
     if (Utils.isSupportedAvroVersionsForSerializer()) {
       // Only build fast specific serializer for supported Avro versions.
       try {
@@ -580,18 +573,7 @@ public final class FastSerdeCache {
       }
     }
 
-    return new FastSerializer<Object>() {
-      private final DatumWriter datumWriter = AvroCompatibilityHelper.newSpecificDatumWriter(schema,
-              modelData != null ? modelData : SpecificData.get());
-
-      @Override
-      public void serialize(Object data, Encoder e) throws IOException {
-        if (failFast) {
-          throw new UnsupportedOperationException("Fast specific serializer could not be generated.");
-        }
-        datumWriter.write(data, e);
-      }
-    };
+    return new FastSerdeUtils.FastSerializerWithAvroSpecificImpl<>(schema, modelData, customization, failFast, true);
   }
 
   public FastSerializer<?> buildFastGenericSerializer(Schema schema) {
@@ -619,7 +601,7 @@ public final class FastSerdeCache {
     return generator.generateSerializer();
   }
 
-  private FastSerializer<?> buildGenericSerializer(Schema schema, GenericData modelData) {
+  private FastSerializer<?> buildGenericSerializer(Schema schema, GenericData modelData, DatumWriterCustomization customization) {
     if (Utils.isSupportedAvroVersionsForSerializer()) {
       // Only build fast generic serializer for supported Avro versions.
       try {
@@ -632,18 +614,11 @@ public final class FastSerdeCache {
       }
     }
 
-    return new FastSerializer<Object>() {
-      private final DatumWriter datumWriter = AvroCompatibilityHelper.newGenericDatumWriter(schema,
-              modelData != null ? modelData : GenericData.get());
+    return new FastSerdeUtils.FastSerializerWithAvroGenericImpl<>(schema, modelData, customization, failFast, true);
+  }
 
-      @Override
-      public void serialize(Object data, Encoder e) throws IOException {
-        if (failFast) {
-          throw new UnsupportedOperationException("Fast generic serializer could not be generated.");
-        }
-        datumWriter.write(data, e);
-      }
-    };
+  public boolean isFailFast() {
+    return failFast;
   }
 
   private Executor getDefaultExecutor() {
@@ -658,63 +633,5 @@ public final class FastSerdeCache {
         return thread;
       }
     });
-  }
-
-  public static class FastDeserializerWithAvroSpecificImpl<V> implements FastDeserializer<V> {
-    private final SpecificDatumReader<V> datumReader;
-
-    public FastDeserializerWithAvroSpecificImpl(Schema writerSchema, Schema readerSchema, SpecificData modelData) {
-      this.datumReader = ColdSpecificDatumReader.of(writerSchema, readerSchema, modelData);
-    }
-
-    @Override
-    public V deserialize(V reuse, Decoder d) throws IOException {
-      return datumReader.read(reuse, d);
-    }
-  }
-
-  public static class FastDeserializerWithAvroGenericImpl<V> implements FastDeserializer<V> {
-    private final GenericDatumReader<V> datumReader;
-
-    public FastDeserializerWithAvroGenericImpl(Schema writerSchema, Schema readerSchema, GenericData modelData) {
-      this.datumReader = ColdGenericDatumReader.of(writerSchema, readerSchema, modelData);
-    }
-
-    @Override
-    public V deserialize(V reuse, Decoder d) throws IOException {
-      return datumReader.read(reuse, d);
-    }
-  }
-
-  public static class FastSerializerWithAvroSpecificImpl<V> implements FastSerializer<V> {
-    private final DatumWriter<V> datumWriter;
-
-    public FastSerializerWithAvroSpecificImpl(Schema schema) {
-      this(schema, null);
-    }
-
-    public FastSerializerWithAvroSpecificImpl(Schema schema, SpecificData modelData) {
-      this.datumWriter = AvroCompatibilityHelper.newSpecificDatumWriter(schema,
-              modelData != null ? modelData : SpecificData.get());
-    }
-
-    @Override
-    public void serialize(V data, Encoder e) throws IOException {
-      datumWriter.write(data, e);
-    }
-  }
-
-  public static class FastSerializerWithAvroGenericImpl<V> implements FastSerializer<V> {
-    private final DatumWriter<V> datumWriter;
-
-    public FastSerializerWithAvroGenericImpl(Schema schema, GenericData modelData) {
-      this.datumWriter = AvroCompatibilityHelper.newGenericDatumWriter(schema,
-              modelData != null ? modelData : GenericData.get());
-    }
-
-    @Override
-    public void serialize(V data, Encoder e) throws IOException {
-      datumWriter.write(data, e);
-    }
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeUtils.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerdeUtils.java
@@ -1,0 +1,217 @@
+package com.linkedin.avro.fastserde;
+
+import org.apache.avro.generic.CustomizedGenericDatumReader;
+import org.apache.avro.generic.CustomizedGenericDatumReaderForAvro14;
+import org.apache.avro.generic.CustomizedGenericDatumWriter;
+import org.apache.avro.generic.CustomizedSpecificDatumReader;
+import org.apache.avro.generic.CustomizedSpecificDatumReaderForAvro14;
+import org.apache.avro.generic.CustomizedSpecificDatumWriter;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.ColdGenericDatumReader;
+import org.apache.avro.generic.ColdSpecificDatumReader;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+
+
+/**
+ * This utility class includes several vanilla Avro based {@link FastDeserializer} and {@link FastSerializer} for the following scenarios:
+ * 1. Before fast class generation is completed, and the class defined here will be used with flag: runtimeClassGenerationDone to be `false`.
+ * 2. The same set of class will be used with flag: runtimeClassGenerationDone to be `true` when class generation fails.
+ * For #1, Fast Datum Reader/Writer will keep polling fast classes and for #2, it will stop polling since it will
+ * know the fast class generation fails, and it is useless to keep polling.
+ */
+public class FastSerdeUtils {
+  public static class FastDeserializerWithAvroSpecificImpl<V> implements FastDeserializer<V> {
+    private final SpecificDatumReader<V> customizedDatumReader;
+    private final DatumReaderCustomization customization;
+    private final boolean failFast;
+    private final boolean runtimeClassGenerationDone;
+
+    public FastDeserializerWithAvroSpecificImpl(Schema writerSchema, Schema readerSchema, SpecificData modelData,
+        boolean runtimeClassGenerationDone) {
+      this(writerSchema, readerSchema, modelData, null, false, runtimeClassGenerationDone);
+    }
+
+    public FastDeserializerWithAvroSpecificImpl(Schema writerSchema, Schema readerSchema, SpecificData modelData
+        , DatumReaderCustomization customization, boolean runtimeClassGenerationDone) {
+      this(writerSchema, readerSchema, modelData, customization, false, runtimeClassGenerationDone);
+    }
+
+    public FastDeserializerWithAvroSpecificImpl(Schema writerSchema, Schema readerSchema,
+        SpecificData modelData, DatumReaderCustomization customization, boolean failFast, boolean runtimeClassGenerationDone) {
+      this.customization = customization == null ? DatumReaderCustomization.DEFAULT_DATUM_READER_CUSTOMIZATION : customization;
+      this.customizedDatumReader = Utils.isAvro14() ?
+          new CustomizedSpecificDatumReaderForAvro14(writerSchema, readerSchema, this.customization) :
+          new CustomizedSpecificDatumReader<>(writerSchema, readerSchema, modelData, this.customization);
+      this.failFast = failFast;
+      this.runtimeClassGenerationDone = runtimeClassGenerationDone;
+    }
+
+    @Override
+    public V deserialize(V reuse, Decoder d, DatumReaderCustomization customization) throws IOException {
+      if (failFast) {
+        throw new UnsupportedOperationException("Fast specific deserializer could not be generated.");
+      }
+      if (this.customization != customization) {
+        throw new IllegalArgumentException(
+            "The provided 'customization' doesn't equal to the param passed in the constructor");
+      }
+      return this.customizedDatumReader.read(reuse, d);
+    }
+
+
+    @Override
+    public boolean hasDynamicClassGenerationDone() {
+      return runtimeClassGenerationDone;
+    }
+
+    @Override
+    public boolean isBackedByGeneratedClass() {
+      return false;
+    }
+  }
+
+  public static class FastDeserializerWithAvroGenericImpl<V> implements FastDeserializer<V> {
+    private final GenericDatumReader<V> customizedDatumReader;
+    private final DatumReaderCustomization customization;
+    private final boolean failFast;
+    private final boolean runtimeClassGenerationDone;
+
+    public FastDeserializerWithAvroGenericImpl(Schema writerSchema, Schema readerSchema,
+        GenericData modelData, boolean runtimeClassGenerationDone) {
+      this(writerSchema, readerSchema, modelData, null, false, runtimeClassGenerationDone);
+    }
+
+    public FastDeserializerWithAvroGenericImpl(Schema writerSchema, Schema readerSchema, GenericData modelData,
+        DatumReaderCustomization customization, boolean runtimeClassGenerationDone) {
+      this(writerSchema, readerSchema, modelData, customization, false, runtimeClassGenerationDone);
+    }
+
+    public FastDeserializerWithAvroGenericImpl(Schema writerSchema, Schema readerSchema,
+        GenericData modelData, DatumReaderCustomization customization, boolean failFast, boolean runtimeClassGenerationDone) {
+      this.customization = customization == null ? DatumReaderCustomization.DEFAULT_DATUM_READER_CUSTOMIZATION : customization;
+      this.customizedDatumReader = Utils.isAvro14() ?
+          new CustomizedGenericDatumReaderForAvro14(writerSchema, readerSchema, this.customization) :
+          new CustomizedGenericDatumReader<>(writerSchema, readerSchema, modelData, this.customization);
+
+      this.failFast = failFast;
+      this.runtimeClassGenerationDone = runtimeClassGenerationDone;
+    }
+
+    @Override
+    public V deserialize(V reuse, Decoder d, DatumReaderCustomization customization) throws IOException {
+      if (failFast) {
+        throw new UnsupportedOperationException("Fast generic deserializer could not be generated.");
+      }
+      if (this.customization != customization) {
+        throw new IllegalArgumentException("The provided 'customization' doesn't equal to the param passed in the constructor");
+      }
+      return this.customizedDatumReader.read(reuse, d);
+    }
+
+    @Override
+    public boolean hasDynamicClassGenerationDone() {
+      return runtimeClassGenerationDone;
+    }
+
+    @Override
+    public boolean isBackedByGeneratedClass() {
+      return false;
+    }
+  }
+
+  public static class FastSerializerWithAvroSpecificImpl<V> implements FastSerializer<V> {
+    private final CustomizedSpecificDatumWriter<V> customizedDatumWriter;
+    private final DatumWriterCustomization customization;
+    private final boolean failFast;
+    private final boolean runtimeClassGenerationDone;
+
+    public FastSerializerWithAvroSpecificImpl(Schema schema, SpecificData modelData,
+        DatumWriterCustomization customization, boolean runtimeClassGenerationDone) {
+      this(schema, modelData, customization, false, runtimeClassGenerationDone);
+    }
+
+    public FastSerializerWithAvroSpecificImpl(Schema schema, SpecificData modelData,
+        DatumWriterCustomization customization, boolean failFast, boolean runtimeClassGenerationDone) {
+      modelData = modelData != null ? modelData : SpecificData.get();
+      this.customization = customization == null ? DatumWriterCustomization.DEFAULT_DATUM_WRITER_CUSTOMIZATION : customization;
+      this.customizedDatumWriter = new CustomizedSpecificDatumWriter<>(schema, modelData, this.customization);
+      this.failFast = failFast;
+      this.runtimeClassGenerationDone = runtimeClassGenerationDone;
+    }
+
+    @Override
+    public void serialize(V data, Encoder e, DatumWriterCustomization customization) throws IOException {
+      if (failFast) {
+        throw new UnsupportedOperationException("Fast specific serializer could not be generated.");
+      }
+
+      if (this.customization != customization) {
+        throw new IllegalArgumentException("The provided 'customization' doesn't equal to the param passed in the constructor");
+      }
+      customizedDatumWriter.write(data, e);
+    }
+
+    @Override
+    public boolean hasDynamicClassGenerationDone() {
+      return runtimeClassGenerationDone;
+    }
+
+    @Override
+    public boolean isBackedByGeneratedClass() {
+      return false;
+    }
+  }
+
+  public static class FastSerializerWithAvroGenericImpl<V> implements FastSerializer<V> {
+    private final CustomizedGenericDatumWriter<V> customizedDatumWriter;
+    private final DatumWriterCustomization customization;
+    private final boolean failFast;
+    private final boolean runtimeClassGenerationDone;
+
+    public FastSerializerWithAvroGenericImpl(Schema schema, GenericData modelData,
+        DatumWriterCustomization customization, boolean runtimeClassGenerationDone) {
+      this(schema, modelData, customization, false, runtimeClassGenerationDone);
+    }
+
+    public FastSerializerWithAvroGenericImpl(Schema schema, GenericData modelData,
+        DatumWriterCustomization customization, boolean failFast, boolean runtimeClassGenerationDone) {
+      modelData = modelData != null ? modelData : GenericData.get();
+      this.customization = customization == null ? DatumWriterCustomization.DEFAULT_DATUM_WRITER_CUSTOMIZATION : customization;
+      this.customizedDatumWriter = new CustomizedGenericDatumWriter<>(schema, modelData, this.customization);
+      this.failFast = failFast;
+      this.runtimeClassGenerationDone = runtimeClassGenerationDone;
+    }
+
+    @Override
+    public void serialize(V data, Encoder e, DatumWriterCustomization customization) throws IOException {
+      if (failFast) {
+        throw new UnsupportedOperationException("Fast generic serializer could not be generated.");
+      }
+      if (this.customization != customization) {
+        throw new IllegalArgumentException("The provided 'customization' doesn't equal to the param passed in the constructor");
+      }
+      customizedDatumWriter.write(data, e);
+    }
+
+    @Override
+    public boolean hasDynamicClassGenerationDone() {
+      return runtimeClassGenerationDone;
+    }
+
+    @Override
+    public boolean isBackedByGeneratedClass() {
+      return false;
+    }
+
+  }
+}

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializer.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializer.java
@@ -1,10 +1,17 @@
 package com.linkedin.avro.fastserde;
 
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import java.io.IOException;
 import org.apache.avro.io.Encoder;
 
+import static com.linkedin.avro.fastserde.customized.DatumWriterCustomization.*;
 
-public interface FastSerializer<T> {
 
-  void serialize(T data, Encoder e) throws IOException;
+public interface FastSerializer<T>  extends FastClassStatus {
+
+  default void serialize(T data, Encoder e) throws IOException {
+    serialize(data, e, DEFAULT_DATUM_WRITER_CUSTOMIZATION);
+  }
+
+  void serialize(T data, Encoder e, DatumWriterCustomization customization) throws IOException;
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSpecificDatumWriter.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSpecificDatumWriter.java
@@ -1,5 +1,6 @@
 package com.linkedin.avro.fastserde;
 
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.specific.SpecificData;
@@ -25,15 +26,26 @@ public class FastSpecificDatumWriter<T> extends FastGenericDatumWriter<T> {
   public FastSpecificDatumWriter(Schema schema, SpecificData modelData, FastSerdeCache cache) {
     super(schema, modelData, cache);
   }
+  public FastSpecificDatumWriter(Schema schema, SpecificData modelData, FastSerdeCache cache,
+      DatumWriterCustomization customization) {
+    super(schema, modelData, cache, customization);
+  }
 
   @SuppressWarnings("unchecked")
   @Override
-  protected FastSerializer<T> getFastSerializerFromCache(FastSerdeCache fastSerdeCache, Schema schema, GenericData specificData) {
-    return (FastSerializer<T>) fastSerdeCache.getFastSpecificSerializer(schema, (SpecificData) specificData);
+  protected FastSerializer<T> getFastSerializerFromCache(FastSerdeCache fastSerdeCache, Schema schema,
+      GenericData specificData, DatumWriterCustomization customization) {
+    return (FastSerializer<T>) fastSerdeCache.getFastSpecificSerializer(schema, (SpecificData) specificData, customization);
   }
 
   @Override
-  protected FastSerializer<T> getRegularAvroImpl(Schema schema, GenericData specificData) {
-    return new FastSerdeCache.FastSerializerWithAvroSpecificImpl<>(schema, (SpecificData) specificData);
+  protected FastSerializer<T> getRegularAvroImpl(Schema schema, GenericData specificData,
+      DatumWriterCustomization customization) {
+    return new FastSerdeUtils.FastSerializerWithAvroSpecificImpl<>(schema, (SpecificData) specificData, customization, false);
+  }
+
+  protected FastSerializer<T> getRegularAvroImplWhenGenerationFail(Schema schema, GenericData modelData,
+      DatumWriterCustomization customization) {
+    return new FastSerdeUtils.FastSerializerWithAvroSpecificImpl<>(schema, (SpecificData) modelData, customization, cache.isFailFast(), true);
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/customized/DatumReaderCustomization.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/customized/DatumReaderCustomization.java
@@ -45,8 +45,6 @@ public class DatumReaderCustomization {
         Map retMap = null;
         if (old instanceof Map) {
           retMap = (Map)old;
-        }
-        if (retMap != null) {
           retMap.clear();
         } else {
           /**

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/customized/DatumReaderCustomization.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/customized/DatumReaderCustomization.java
@@ -1,0 +1,61 @@
+package com.linkedin.avro.fastserde.customized;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Customization for de-serialization.
+ * This class is expandable.
+ */
+public class DatumReaderCustomization {
+
+  public interface NewMapOverrideFunction {
+    Object apply(Object old, int size);
+  }
+
+  private NewMapOverrideFunction newMapOverrideFunc;
+
+
+  private DatumReaderCustomization(Builder builder) {
+    this.newMapOverrideFunc = builder.newMapOverrideFunc;
+  }
+
+  public NewMapOverrideFunction getNewMapOverrideFunc() {
+    return newMapOverrideFunc;
+  }
+
+  public static class Builder {
+    private NewMapOverrideFunction newMapOverrideFunc;
+
+    public Builder() {}
+
+    public Builder setNewMapOverrideFunc(NewMapOverrideFunction newMapOverrideFunc) {
+      this.newMapOverrideFunc = newMapOverrideFunc;
+      return this;
+    }
+
+    public DatumReaderCustomization build() {
+      return new DatumReaderCustomization(this);
+    }
+  }
+
+  public static final DatumReaderCustomization DEFAULT_DATUM_READER_CUSTOMIZATION = new DatumReaderCustomization.Builder()
+      .setNewMapOverrideFunc((old, size) -> {
+        Map retMap = null;
+        if (old instanceof Map) {
+          retMap = (Map)old;
+        }
+        if (retMap != null) {
+          retMap.clear();
+        } else {
+          /**
+           * Pure integer arithmetic equivalent of (int) Math.ceil(expectedSize / 0.75).
+           * The default load factor of HashMap is 0.75 and HashMap internally ensures size is always a power of two.
+           */
+          retMap = new HashMap<>((size * 4 + 2) / 3);
+        }
+        return retMap;
+      })
+      .build();
+}

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/customized/DatumWriterCustomization.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/customized/DatumWriterCustomization.java
@@ -1,0 +1,40 @@
+package com.linkedin.avro.fastserde.customized;
+
+/**
+ * Customization for serialization.
+ * This class is expandable.
+ */
+public class DatumWriterCustomization {
+  private CheckMapTypeFunction checkMapTypeFunction;
+
+  private DatumWriterCustomization(Builder builder) {
+    this.checkMapTypeFunction = builder.checkMapTypeFunction;
+  }
+
+  public CheckMapTypeFunction getCheckMapTypeFunction() {
+    return checkMapTypeFunction;
+  }
+
+  public interface CheckMapTypeFunction {
+    void apply(Object o);
+  }
+
+  public static class Builder {
+    private CheckMapTypeFunction checkMapTypeFunction;
+
+    public Builder() {}
+
+    public Builder setCheckMapTypeFunction(CheckMapTypeFunction checkMapTypeFunction) {
+      this.checkMapTypeFunction = checkMapTypeFunction;
+      return this;
+    }
+
+    public DatumWriterCustomization build() {
+      return new DatumWriterCustomization(this);
+    }
+  }
+
+  public static final DatumWriterCustomization DEFAULT_DATUM_WRITER_CUSTOMIZATION = new DatumWriterCustomization.Builder()
+      .setCheckMapTypeFunction( o -> {})
+      .build();
+}

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/ColdGenericDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/ColdGenericDatumReader.java
@@ -12,7 +12,6 @@ import com.linkedin.avro.fastserde.Utils;
  * This class needs to be in the org.apache.avro.generic package in order to access protected methods.
  */
 public class ColdGenericDatumReader<T> extends GenericDatumReader<T> implements ColdDatumReaderMixIn {
-
   public ColdGenericDatumReader(Schema writerSchema, Schema readerSchema, GenericData modelData) {
     super(writerSchema, readerSchema, modelData != null ? modelData : GenericData.get());
   }

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumReader.java
@@ -1,0 +1,44 @@
+package org.apache.avro.generic;
+
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.ColdDatumReaderMixIn;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+
+/**
+ * This class will apply {@link DatumReaderCustomization} at runtime.
+ */
+public class CustomizedGenericDatumReader<T> extends GenericDatumReader<T> implements ColdDatumReaderMixIn {
+  private final DatumReaderCustomization customization;
+
+  public CustomizedGenericDatumReader(Schema writerSchema, Schema readerSchema, GenericData modelData, DatumReaderCustomization customization) {
+    super(writerSchema, readerSchema, modelData != null ? modelData : GenericData.get());
+    if (customization == null) {
+      throw new IllegalArgumentException("'customization' param should not null when constructing " +  this.getClass().getName());
+    }
+    this.customization = customization;
+  }
+
+  public CustomizedGenericDatumReader(Schema writerSchema, Schema readerSchema, DatumReaderCustomization customization) {
+    super(writerSchema, readerSchema);
+    if (customization == null) {
+      throw new IllegalArgumentException("'customization' param should not null when constructing " +  this.getClass().getName());
+    }
+    this.customization = customization;
+  }
+
+
+  @Override
+  protected Object newMap(Object old, int size) {
+    if (customization.getNewMapOverrideFunc() != null) {
+      return customization.getNewMapOverrideFunc().apply(old, size);
+    }
+    return super.newMap(old, size);
+  }
+
+  @Override
+  protected Object newArray(Object old, int size, Schema schema) {
+    return newArray(old, size, schema, super::newArray);
+  }
+}

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumReader.java
@@ -2,9 +2,6 @@ package org.apache.avro.generic;
 
 import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.ColdDatumReaderMixIn;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumReader;
 
 /**
  * This class will apply {@link DatumReaderCustomization} at runtime.
@@ -31,10 +28,7 @@ public class CustomizedGenericDatumReader<T> extends GenericDatumReader<T> imple
 
   @Override
   protected Object newMap(Object old, int size) {
-    if (customization.getNewMapOverrideFunc() != null) {
-      return customization.getNewMapOverrideFunc().apply(old, size);
-    }
-    return super.newMap(old, size);
+    return customization.getNewMapOverrideFunc().apply(old, size);
   }
 
   @Override

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumReaderForAvro14.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumReaderForAvro14.java
@@ -1,0 +1,17 @@
+package org.apache.avro.generic;
+
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+
+
+/**
+ * In Avro-1.4, {@link org.apache.avro.generic.GenericDatumReader} doesn't have a constructor
+ * to take {@link org.apache.avro.generic.GenericData}.
+ */
+public class CustomizedGenericDatumReaderForAvro14<T> extends CustomizedGenericDatumReader<T> {
+
+  public CustomizedGenericDatumReaderForAvro14(Schema writerSchema, Schema readerSchema,
+      DatumReaderCustomization customization) {
+    super(writerSchema, readerSchema, customization);
+  }
+}

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumWriter.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumWriter.java
@@ -3,8 +3,6 @@ package org.apache.avro.generic;
 import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import java.io.IOException;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.Encoder;
 
 
@@ -17,15 +15,16 @@ public class CustomizedGenericDatumWriter<T> extends GenericDatumWriter<T> {
 
   public CustomizedGenericDatumWriter(Schema schema, GenericData modelData, DatumWriterCustomization customization) {
     super(schema, modelData);
+    if (customization == null) {
+      throw new IllegalArgumentException("'customization' param should not null when constructing " +  this.getClass().getName());
+    }
 
     this.customization = customization;
   }
 
   @Override
   protected void writeMap(Schema schema, Object datum, Encoder out) throws IOException {
-    if (customization != null && customization.getCheckMapTypeFunction() != null) {
-      customization.getCheckMapTypeFunction().apply(datum);
-    }
+    customization.getCheckMapTypeFunction().apply(datum);
     super.writeMap(schema, datum, out);
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumWriter.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedGenericDatumWriter.java
@@ -1,0 +1,31 @@
+package org.apache.avro.generic;
+
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.Encoder;
+
+
+/**
+ * This class will apply {@link DatumWriterCustomization} at runtime.
+ */
+public class CustomizedGenericDatumWriter<T> extends GenericDatumWriter<T> {
+
+  private final DatumWriterCustomization customization;
+
+  public CustomizedGenericDatumWriter(Schema schema, GenericData modelData, DatumWriterCustomization customization) {
+    super(schema, modelData);
+
+    this.customization = customization;
+  }
+
+  @Override
+  protected void writeMap(Schema schema, Object datum, Encoder out) throws IOException {
+    if (customization != null && customization.getCheckMapTypeFunction() != null) {
+      customization.getCheckMapTypeFunction().apply(datum);
+    }
+    super.writeMap(schema, datum, out);
+  }
+}

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumReader.java
@@ -1,0 +1,43 @@
+package org.apache.avro.generic;
+
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.ColdDatumReaderMixIn;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumReader;
+
+/**
+ * This class will apply {@link DatumReaderCustomization} at runtime.
+ */
+public class CustomizedSpecificDatumReader<T> extends SpecificDatumReader<T> implements ColdDatumReaderMixIn {
+  private final DatumReaderCustomization customization;
+
+  public CustomizedSpecificDatumReader(Schema writerSchema, Schema readerSchema, SpecificData modelData, DatumReaderCustomization customization) {
+    super(writerSchema, readerSchema, modelData != null ? modelData : SpecificData.get());
+    if (customization == null) {
+      throw new IllegalArgumentException("'customization' param should not null when constructing " +  this.getClass().getName());
+    }
+    this.customization = customization;
+  }
+
+  public CustomizedSpecificDatumReader(Schema writerSchema, Schema readerSchema, DatumReaderCustomization customization) {
+    super(writerSchema, readerSchema);
+    if (customization == null) {
+      throw new IllegalArgumentException("'customization' param should not null when constructing " +  this.getClass().getName());
+    }
+    this.customization = customization;
+  }
+
+  @Override
+  protected Object newMap(Object old, int size) {
+    if (customization.getNewMapOverrideFunc() != null) {
+      return customization.getNewMapOverrideFunc().apply(old, size);
+    }
+    return super.newMap(old, size);
+  }
+
+  @Override
+  protected Object newArray(Object old, int size, Schema schema) {
+    return newArray(old, size, schema, super::newArray);
+  }
+}

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumReader.java
@@ -2,7 +2,6 @@ package org.apache.avro.generic;
 
 import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.ColdDatumReaderMixIn;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 
@@ -30,10 +29,7 @@ public class CustomizedSpecificDatumReader<T> extends SpecificDatumReader<T> imp
 
   @Override
   protected Object newMap(Object old, int size) {
-    if (customization.getNewMapOverrideFunc() != null) {
-      return customization.getNewMapOverrideFunc().apply(old, size);
-    }
-    return super.newMap(old, size);
+    return customization.getNewMapOverrideFunc().apply(old, size);
   }
 
   @Override

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumReaderForAvro14.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumReaderForAvro14.java
@@ -1,0 +1,15 @@
+package org.apache.avro.generic;
+
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+
+/**
+ * In Avro-1.4, {@link org.apache.avro.specific.SpecificDatumReader} doesn't have a constructor
+ * to take {@link org.apache.avro.specific.SpecificData}.
+ */
+public class CustomizedSpecificDatumReaderForAvro14<T> extends CustomizedSpecificDatumReader<T> {
+  public CustomizedSpecificDatumReaderForAvro14(Schema writerSchema, Schema readerSchema,
+      DatumReaderCustomization customization) {
+    super(writerSchema, readerSchema, customization);
+  }
+}

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumWriter.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumWriter.java
@@ -16,15 +16,15 @@ public class CustomizedSpecificDatumWriter<T> extends SpecificDatumWriter<T> {
 
   public CustomizedSpecificDatumWriter(Schema schema, SpecificData modelData, DatumWriterCustomization customization) {
     super(schema, modelData);
-
+    if (customization == null) {
+      throw new IllegalArgumentException("'customization' param should not null when constructing " +  this.getClass().getName());
+    }
     this.customization = customization;
   }
 
   @Override
   protected void writeMap(Schema schema, Object datum, Encoder out) throws IOException {
-    if (customization != null && customization.getCheckMapTypeFunction() != null) {
-      customization.getCheckMapTypeFunction().apply(datum);
-    }
+    customization.getCheckMapTypeFunction().apply(datum);
     super.writeMap(schema, datum, out);
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumWriter.java
+++ b/fastserde/avro-fastserde/src/main/java/org/apache/avro/generic/CustomizedSpecificDatumWriter.java
@@ -1,0 +1,30 @@
+package org.apache.avro.generic;
+
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+/**
+ * This class will apply {@link DatumWriterCustomization} at runtime.
+ * @param <T>
+ */
+public class CustomizedSpecificDatumWriter<T> extends SpecificDatumWriter<T> {
+  private final DatumWriterCustomization customization;
+
+  public CustomizedSpecificDatumWriter(Schema schema, SpecificData modelData, DatumWriterCustomization customization) {
+    super(schema, modelData);
+
+    this.customization = customization;
+  }
+
+  @Override
+  protected void writeMap(Schema schema, Object datum, Encoder out) throws IOException {
+    if (customization != null && customization.getCheckMapTypeFunction() != null) {
+      customization.getCheckMapTypeFunction().apply(datum);
+    }
+    super.writeMap(schema, datum, out);
+  }
+}


### PR DESCRIPTION
We have the following requirements:
For serialization, we would like to validate whether all the map fields are using the desired map type.
For deserialization, we would like to deserialize the map type into a special map impelementation for later use.

These customized requirements are not supported in the past because of the following reasons:
1. Fast classes generated are shared, so it is possible different users of the same schema may have different requirement.
2. For the same process, for different schema, the requirements can be different too.
3. No way to specify customized logic/data type when generating fast classes.

This PR adds a new functionality to specify customized logic and it is expandable and backward compatible.
DatumReaderCustomization : customization for read
DatumWriterCustomization : customization for write

Currently, these classes only support the requirements mentioned at the beginning.

How it works internally?
1. Each Fast DatumReader/DatumWriter constructor will take a new param for customization.
2. Each Fast DatumReader/DatumWriter will keep a local vanilla-Avro based implementation with customization support since the shared vanilla-Avro based implementation is still the default implementation.
3. Each generated Fast class will have a new param for customization in serialize/deserialize APIs.
4. Fast DatumReader/DatumWriter will call this new API with customization param of Fast classes.
5. The read/write API in Fast DatumReader/DatumWriter doesn't change, so it is backward compatible.