### PR TITLE
Decouple schema parsing from code generation

### DIFF
--- a/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/operations/OperationContext.java
+++ b/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/operations/OperationContext.java
@@ -10,8 +10,8 @@ import com.linkedin.avroutil1.model.AvroSchema;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Set;
-import org.apache.avro.Schema;
 
 
 /**
@@ -19,33 +19,21 @@ import org.apache.avro.Schema;
  */
 public class OperationContext {
   private final HashMap<String, Object> context;
-  private Set<File> avroFiles;
-  private Set<AvroSchema> avroSchemas;
+  private final Set<File> avroFiles;
+  private final Set<AvroSchema> avroSchemas;
+  private final SchemaSet lookupSchemaSet;
 
-  public OperationContext() {
+  public OperationContext(Set<AvroSchema> avroSchemas, Set<File> avroFiles, SchemaSet lookupSchemaSet) {
     this.context = new HashMap<>();
-  }
-
-  public void addParsedSchemas(Set<AvroSchema> avroSchemas, Set<File> avroFiles) {
-    if (this.avroFiles != null || this.avroSchemas != null) {
-      throw new IllegalStateException("Cannot initialize avro files twice");
-    }
-
-    this.avroFiles = Collections.unmodifiableSet(avroFiles);
-    this.avroSchemas = Collections.unmodifiableSet(avroSchemas);
-  }
-
-  public void addVanillaSchemas(Set<Schema> schemas, Set<File> avroFiles) {
-    addParsedSchemas(AvroSchemaUtils.schemasToAvroSchemas(schemas), avroFiles);
+    this.avroSchemas = Collections.unmodifiableSet(Objects.requireNonNull(avroSchemas));
+    this.avroFiles = Collections.unmodifiableSet(Objects.requireNonNull(avroFiles));
+    this.lookupSchemaSet = lookupSchemaSet;
   }
 
   /**
    * Returns an unmodifiable set of all input avro files.
    */
   public Set<File> getAvroFiles() {
-    if (this.avroFiles == null) {
-      throw new IllegalStateException("Avro files haven't been added yet.");
-    }
     return this.avroFiles;
   }
 
@@ -53,11 +41,14 @@ public class OperationContext {
    * Returns an unmodifiable set of all parsed avro schemas.
    */
   public Set<AvroSchema> getAvroSchemas() {
-    if (this.avroSchemas == null) {
-      throw new IllegalStateException("Avro schemas haven't been added yet.");
-    }
-
     return this.avroSchemas;
+  }
+
+  /**
+   * Returns the lookup schema set.
+   */
+  public SchemaSet getLookupSchemaSet() {
+    return this.lookupSchemaSet;
   }
 
   public void setConfigValue(String key, Object value) {

--- a/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/operations/SchemaSet.java
+++ b/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/operations/SchemaSet.java
@@ -4,7 +4,7 @@
  * See License in the project root for license information.
  */
 
-package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
+package com.linkedin.avroutil1.builder.operations;
 
 
 import java.util.List;

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContextBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/OperationContextBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.builder.operations.codegen;
+
+import com.linkedin.avroutil1.builder.operations.OperationContext;
+
+
+/**
+ * Builds operation context.
+ */
+public interface OperationContextBuilder {
+
+  /**
+   * Builds and returns the {@link OperationContext}.
+   */
+  OperationContext buildOperationContext(CodeGenOpConfig opConfig) throws Exception;
+}

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenPlugin.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilCodeGenPlugin.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2022 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.builder.operations.codegen.own;
+
+import com.linkedin.avroutil1.builder.operations.OperationContext;
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
+import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
+import com.linkedin.avroutil1.builder.plugins.BuilderPlugin;
+import com.linkedin.avroutil1.builder.plugins.BuilderPluginContext;
+import com.linkedin.avroutil1.codegen.SpecificRecordClassGenerator;
+import com.linkedin.avroutil1.codegen.SpecificRecordGenerationConfig;
+import com.linkedin.avroutil1.codegen.SpecificRecordGeneratorUtil;
+import com.linkedin.avroutil1.model.AvroJavaStringRepresentation;
+import com.linkedin.avroutil1.model.AvroNamedSchema;
+import com.linkedin.avroutil1.model.AvroType;
+import com.linkedin.avroutil1.model.AvroUnionSchema;
+import com.squareup.javapoet.JavaFile;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A code generation plugin using the avro-codegen module of avro-util
+ */
+public class AvroUtilCodeGenPlugin implements BuilderPlugin {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AvroUtilCodeGenPlugin.class);
+
+  private final CodeGenOpConfig config;
+
+  public AvroUtilCodeGenPlugin(CodeGenOpConfig config) {
+    this.config = config;
+  }
+
+  @Override
+  public Set<Integer> supportedApiVersions() {
+    return Collections.singleton(1);
+  }
+
+  @Override
+  public void createOperations(BuilderPluginContext context) {
+    context.add(this::generateCode);
+  }
+
+  private void generateCode(OperationContext opContext) {
+    //mkdir any output folders that don't exist
+    if (!config.getOutputSpecificRecordClassesRoot().exists() && !config.getOutputSpecificRecordClassesRoot()
+        .mkdirs()) {
+      throw new IllegalStateException(
+          "unable to create destination folder " + config.getOutputSpecificRecordClassesRoot());
+    }
+
+    final AtomicInteger schemaCounter = new AtomicInteger(0);
+    final int schemaChunkSize = 500;
+    Collection<List<AvroNamedSchema>> allNamedSchemaList = opContext.getAvroSchemas().stream().flatMap(schema -> {
+      if (schema instanceof AvroNamedSchema) {
+        return Stream.of((AvroNamedSchema) schema);
+      } else if (AvroType.UNION.equals(schema.type())) {
+        return ((AvroUnionSchema) schema).getTypes()
+            .stream()
+            .map(schemaOrRef -> (AvroNamedSchema) schemaOrRef.getSchema());
+      } else {
+        return Stream.empty();
+      }
+    }).collect(Collectors.groupingBy(it -> schemaCounter.getAndIncrement() / schemaChunkSize)).values();
+
+    long genStart = System.currentTimeMillis();
+
+    final SpecificRecordGenerationConfig generationConfig =
+        SpecificRecordGenerationConfig.getBroadCompatibilitySpecificRecordGenerationConfig(
+            AvroJavaStringRepresentation.fromJson(config.getStringRepresentation().toString()),
+            AvroJavaStringRepresentation.fromJson(config.getMethodStringRepresentation().toString()),
+            config.getMinAvroVersion(), config.isUtf8EncodingPutByIndexEnabled());
+
+    // Make sure the output folder exists
+    File outputFolder = config.getOutputSpecificRecordClassesRoot();
+    if (!outputFolder.exists() && !outputFolder.mkdirs()) {
+      throw new IllegalStateException("unable to create output folder " + outputFolder);
+    }
+    final Path outputDirectoryPath = outputFolder.toPath();
+    final SpecificRecordClassGenerator generator = new SpecificRecordClassGenerator();
+
+    int totalGeneratedClasses = allNamedSchemaList.parallelStream().map(allNamedSchemas -> {
+      HashSet<String> alreadyGeneratedSchemaNames = new HashSet<>();
+      List<JavaFile> generatedSpecificClasses = new ArrayList<>(allNamedSchemas.size());
+      for (AvroNamedSchema namedSchema : allNamedSchemas) {
+        try {
+          if (!alreadyGeneratedSchemaNames.contains(namedSchema.getFullName())) {
+            // skip codegen if schema is on classpath and config says to skip
+            if (config.shouldSkipCodegenIfSchemaOnClasspath() &&
+                doesSchemaExistOnClasspath(namedSchema, opContext.getLookupSchemaSet())) {
+              continue;
+            }
+
+            //top level schema
+            alreadyGeneratedSchemaNames.add(namedSchema.getFullName());
+            generatedSpecificClasses.add(generator.generateSpecificClass(namedSchema, generationConfig));
+
+            // generate internal schemas if not already present
+            List<AvroNamedSchema> internalSchemaList =
+                SpecificRecordGeneratorUtil.getNestedInternalSchemaList(namedSchema);
+            for (AvroNamedSchema namedInternalSchema : internalSchemaList) {
+              if (!alreadyGeneratedSchemaNames.contains(namedInternalSchema.getFullName())) {
+                // skip codegen for nested schemas if schema is on classpath and config says to skip
+                if (config.shouldSkipCodegenIfSchemaOnClasspath() &&
+                    doesSchemaExistOnClasspath(namedInternalSchema, opContext.getLookupSchemaSet())) {
+                  continue;
+                }
+
+                generatedSpecificClasses.add(generator.generateSpecificClass(namedInternalSchema, generationConfig));
+                alreadyGeneratedSchemaNames.add(namedInternalSchema.getFullName());
+              }
+            }
+          }
+        } catch (Exception e) {
+          throw new RuntimeException("failed to generate class for " + namedSchema.getFullName(), e);
+        }
+      }
+      writeJavaFilesToDisk(generatedSpecificClasses, outputDirectoryPath);
+      return generatedSpecificClasses.size();
+    }).reduce(0, Integer::sum);
+
+    long genEnd = System.currentTimeMillis();
+    LOGGER.info("Generated {} java source files in {} millis", totalGeneratedClasses, genEnd - genStart);
+  }
+
+  private boolean doesSchemaExistOnClasspath(AvroNamedSchema schema, SchemaSet schemaSet) {
+    if (schemaSet == null) {
+      return false;
+    }
+
+    return schemaSet.getByName(schema.getFullName()) != null;
+  }
+
+  private void writeJavaFilesToDisk(Collection<JavaFile> javaFiles, Path outputFolderPath) {
+
+    long writeStart = System.currentTimeMillis();
+
+    // write out the files we generated
+    int filesWritten = javaFiles.parallelStream().map(javaFile -> {
+      try {
+        javaFile.writeToPath(outputFolderPath);
+      } catch (Exception e) {
+        throw new IllegalStateException("while writing file " + javaFile.typeSpec.name, e);
+      }
+
+      return 1;
+    }).reduce(0, Integer::sum);
+
+    long writeEnd = System.currentTimeMillis();
+    LOGGER.info("wrote out {} generated java source files under {} in {} millis", filesWritten, outputFolderPath,
+        writeEnd - writeStart);
+  }
+}

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilOperationContextBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilOperationContextBuilder.java
@@ -1,29 +1,23 @@
 /*
- * Copyright 2022 LinkedIn Corp.
+ * Copyright 2024 LinkedIn Corp.
  * Licensed under the BSD 2-Clause License (the "License").
  * See License in the project root for license information.
  */
 
 package com.linkedin.avroutil1.builder.operations.codegen.own;
 
-import com.linkedin.avroutil1.builder.operations.Operation;
 import com.linkedin.avroutil1.builder.operations.OperationContext;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContextBuilder;
 import com.linkedin.avroutil1.builder.operations.codegen.util.AvscFileFinderUtil;
 import com.linkedin.avroutil1.builder.operations.codegen.vanilla.ClasspathSchemaSet;
 import com.linkedin.avroutil1.builder.operations.codegen.vanilla.ResolverPathSchemaSet;
-import com.linkedin.avroutil1.builder.operations.codegen.vanilla.SchemaSet;
-import com.linkedin.avroutil1.codegen.SpecificRecordClassGenerator;
-import com.linkedin.avroutil1.codegen.SpecificRecordGenerationConfig;
-import com.linkedin.avroutil1.codegen.SpecificRecordGeneratorUtil;
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
 import com.linkedin.avroutil1.compatibility.SchemaComparisonConfiguration;
-import com.linkedin.avroutil1.model.AvroJavaStringRepresentation;
 import com.linkedin.avroutil1.model.AvroNamedSchema;
 import com.linkedin.avroutil1.model.AvroSchema;
-import com.linkedin.avroutil1.model.AvroType;
-import com.linkedin.avroutil1.model.AvroUnionSchema;
 import com.linkedin.avroutil1.model.SchemaOrRef;
 import com.linkedin.avroutil1.parser.avsc.AvroParseContext;
 import com.linkedin.avroutil1.parser.avsc.AvscParseResult;
@@ -31,17 +25,13 @@ import com.linkedin.avroutil1.parser.avsc.AvscParser;
 import com.linkedin.avroutil1.util.ConfigurableAvroSchemaComparator;
 import com.linkedin.avroutil1.writer.avsc.AvscSchemaWriter;
 import com.linkedin.avroutil1.writer.avsc.AvscWriterConfig;
-import com.squareup.javapoet.JavaFile;
 import java.io.File;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.avro.Schema;
@@ -49,29 +39,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * a code generation operation using the avro-codegen module of avro-util
- */
-public class AvroUtilCodeGenOp implements Operation {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AvroUtilCodeGenOp.class);
+public class AvroUtilOperationContextBuilder implements OperationContextBuilder {
 
-  private final CodeGenOpConfig config;
-
-  public AvroUtilCodeGenOp(CodeGenOpConfig config) {
-    this.config = config;
-  }
+  private static final Logger LOGGER = LoggerFactory.getLogger(AvroUtilOperationContextBuilder.class);
 
   @Override
-  public void run(OperationContext opContext) throws Exception {
-    //mkdir any output folders that don't exist
-    if (!config.getOutputSpecificRecordClassesRoot().exists() && !config.getOutputSpecificRecordClassesRoot()
-        .mkdirs()) {
-      throw new IllegalStateException(
-          "unable to create destination folder " + config.getOutputSpecificRecordClassesRoot());
-    }
-
+  public OperationContext buildOperationContext(CodeGenOpConfig config) throws Exception {
     if (!config.isAvro702Handling()) {
-      LOGGER.warn("Avro-702 handling was disabled, however Avro-702 handling cannot be  disabled in AvroUtilCodeGenOp.");
+      LOGGER.warn("Avro-702 handling was disabled, however Avro-702 handling cannot be disabled.");
     }
 
     Set<File> avscFiles = new HashSet<>();
@@ -93,7 +68,7 @@ public class AvroUtilCodeGenOp implements Operation {
     int numFiles = avscFiles.size() + nonImportableFiles.size();
     if (numFiles == 0) {
       LOGGER.warn("no input schema files were found under roots " + config.getInputRoots());
-      return;
+      return new OperationContext(Collections.emptySet(), Collections.emptySet(), null);
     }
     LOGGER.info("found " + numFiles + " avsc schema files in " + (scanEnd - scanStart) + " millis");
 
@@ -163,21 +138,6 @@ public class AvroUtilCodeGenOp implements Operation {
 
     long parseEnd = System.currentTimeMillis();
 
-    final AtomicInteger schemaCounter = new AtomicInteger(0);
-    final int schemaChunkSize = 500;
-    Collection<List<AvroNamedSchema>> allNamedSchemaList = parsedFiles.stream().flatMap(parseResult -> {
-      AvroSchema schema = parseResult.getTopLevelSchema();
-      if (schema instanceof AvroNamedSchema) {
-        return Stream.of((AvroNamedSchema) parseResult.getTopLevelSchema());
-      } else if (AvroType.UNION.equals(schema.type())) {
-        return ((AvroUnionSchema) schema).getTypes()
-            .stream()
-            .map(schemaOrRef -> (AvroNamedSchema) schemaOrRef.getSchema());
-      } else {
-        return Stream.empty();
-      }
-    }).collect(Collectors.groupingBy(it -> schemaCounter.getAndIncrement() / schemaChunkSize)).values();
-
     // Handle duplicate schemas
     Map<String, List<AvscParseResult>> duplicates = context.getDuplicates();
     for (Map.Entry<String, List<AvscParseResult>> duplicateEntry : duplicates.entrySet()) {
@@ -226,9 +186,6 @@ public class AvroUtilCodeGenOp implements Operation {
       }
     }
 
-    LOGGER.info("parsed {} named schemas in {} millis, {} of which have duplicates", schemaCounter.get(),
-        parseEnd - scanEnd, duplicates.size());
-
     //TODO fail if any errors or dups (depending on config) are found
     if (context.hasExternalReferences()) {
       //TODO - better formatting
@@ -236,71 +193,19 @@ public class AvroUtilCodeGenOp implements Operation {
           "unresolved referenced to external schemas: " + context.getExternalReferences());
     }
 
-    long genStart = System.currentTimeMillis();
+    LOGGER.info("Parsed {} avsc files in {} millis, {} of which have duplicates", parsedFiles.size(),
+        parseEnd - scanEnd, duplicates.size());
 
-    final SpecificRecordGenerationConfig generationConfig =
-        SpecificRecordGenerationConfig.getBroadCompatibilitySpecificRecordGenerationConfig(
-            AvroJavaStringRepresentation.fromJson(config.getStringRepresentation().toString()),
-            AvroJavaStringRepresentation.fromJson(config.getMethodStringRepresentation().toString()),
-            config.getMinAvroVersion(), config.isUtf8EncodingPutByIndexEnabled());
+    long contextStart = System.currentTimeMillis();
+    Set<File> allAvroFiles = Stream.concat(avscFiles.stream(), nonImportableFiles.stream()).collect(Collectors.toSet());
+    Set<AvroSchema> allTopLevelSchemas =
+        parsedFiles.stream().map(AvscParseResult::getTopLevelSchema).collect(Collectors.toSet());
+    OperationContext operationContext = new OperationContext(allTopLevelSchemas, allAvroFiles, lookupSchemaSet);
+    long contextEnd = System.currentTimeMillis();
+    LOGGER.info("Added {} top-level schemas across {} files to context in {} millis", allTopLevelSchemas.size(),
+        allAvroFiles.size(), contextEnd - contextStart);
 
-    // Make sure the output folder exists
-    File outputFolder = config.getOutputSpecificRecordClassesRoot();
-    if (!outputFolder.exists() && !outputFolder.mkdirs()) {
-      throw new IllegalStateException("unable to create output folder " + outputFolder);
-    }
-    final Path outputDirectoryPath = outputFolder.toPath();
-    final SpecificRecordClassGenerator generator = new SpecificRecordClassGenerator();
-
-    int totalGeneratedClasses = allNamedSchemaList.parallelStream().map(allNamedSchemas -> {
-      HashSet<String> alreadyGeneratedSchemaNames = new HashSet<>();
-      List<JavaFile> generatedSpecificClasses = new ArrayList<>(allNamedSchemas.size());
-      for (AvroNamedSchema namedSchema : allNamedSchemas) {
-        try {
-          if (!alreadyGeneratedSchemaNames.contains(namedSchema.getFullName())) {
-            // skip codegen if schema is on classpath and config says to skip
-            if (config.shouldSkipCodegenIfSchemaOnClasspath() && doesSchemaExistOnClasspath(namedSchema, lookupSchemaSet)) {
-              continue;
-            }
-
-            //top level schema
-            alreadyGeneratedSchemaNames.add(namedSchema.getFullName());
-            generatedSpecificClasses.add(generator.generateSpecificClass(namedSchema, generationConfig));
-
-            // generate internal schemas if not already present
-            List<AvroNamedSchema> internalSchemaList =
-                SpecificRecordGeneratorUtil.getNestedInternalSchemaList(namedSchema);
-            for (AvroNamedSchema namedInternalSchema : internalSchemaList) {
-              if (!alreadyGeneratedSchemaNames.contains(namedInternalSchema.getFullName())) {
-                // skip codegen for nested schemas if schema is on classpath and config says to skip
-                if (config.shouldSkipCodegenIfSchemaOnClasspath() && doesSchemaExistOnClasspath(namedInternalSchema,
-                    lookupSchemaSet)) {
-                  continue;
-                }
-
-                generatedSpecificClasses.add(generator.generateSpecificClass(namedInternalSchema, generationConfig));
-                alreadyGeneratedSchemaNames.add(namedInternalSchema.getFullName());
-              }
-            }
-          }
-        } catch (Exception e) {
-          throw new RuntimeException("failed to generate class for " + namedSchema.getFullName(), e);
-        }
-      }
-      writeJavaFilesToDisk(generatedSpecificClasses, outputDirectoryPath);
-      return generatedSpecificClasses.size();
-    }).reduce(0, Integer::sum);
-
-    long genEnd = System.currentTimeMillis();
-    LOGGER.info("generated {} java source files in {} millis", totalGeneratedClasses, genEnd - genStart);
-
-    Set<File> allAvroFiles = new HashSet<>(avscFiles);
-    allAvroFiles.addAll(nonImportableFiles);
-    Set<AvroSchema> allTopLevelSchemas = new HashSet<>();
-    for (AvscParseResult parsedFile : parsedFiles) {
-      allTopLevelSchemas.add(parsedFile.getTopLevelSchema());
-    }
-    opContext.addParsedSchemas(allTopLevelSchemas, allAvroFiles);
+    return operationContext;
   }
 
   /**
@@ -322,37 +227,9 @@ public class AvroUtilCodeGenOp implements Operation {
       }
 
       context.add(fileParseResult, areFilesImportable);
-      // We skipp adding the referenced parse results to `parsedFiles`
+      // We skip adding the referenced parse results to `parsedFiles`
       parsedFiles.add(fileParseResult);
     }
     return parsedFiles;
-  }
-
-  private boolean doesSchemaExistOnClasspath(AvroNamedSchema schema, SchemaSet schemaSet) {
-    if (schemaSet == null) {
-      return false;
-    }
-
-    return schemaSet.getByName(schema.getFullName()) != null;
-  }
-
-  private void writeJavaFilesToDisk(Collection<JavaFile> javaFiles, Path outputFolderPath) {
-
-    long writeStart = System.currentTimeMillis();
-
-    // write out the files we generated
-    int filesWritten = javaFiles.parallelStream().map(javaFile -> {
-      try {
-        javaFile.writeToPath(outputFolderPath);
-      } catch (Exception e) {
-        throw new IllegalStateException("while writing file " + javaFile.typeSpec.name, e);
-      }
-
-      return 1;
-    }).reduce(0, Integer::sum);
-
-    long writeEnd = System.currentTimeMillis();
-    LOGGER.info("wrote out {} generated java source files under {} in {} millis", filesWritten, outputFolderPath,
-        writeEnd - writeStart);
   }
 }

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/ClasspathSchemaSet.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/ClasspathSchemaSet.java
@@ -6,6 +6,7 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/FileSystemSchemaSetProvider.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/FileSystemSchemaSetProvider.java
@@ -6,6 +6,7 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/ResolverPathSchemaSet.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/ResolverPathSchemaSet.java
@@ -6,6 +6,7 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
 import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
 import com.linkedin.avroutil1.compatibility.SchemaParseConfiguration;
 import java.io.File;

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/SchemaSetProvider.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/SchemaSetProvider.java
@@ -6,6 +6,9 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
+
+
 public interface SchemaSetProvider {
 
   @Deprecated //for backwards compatibility

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/SimpleSchemaSet.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/SimpleSchemaSet.java
@@ -6,6 +6,7 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 
+import com.linkedin.avroutil1.builder.operations.SchemaSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/vanilla/VanillaProcessedCodeGenOp.java
@@ -6,9 +6,10 @@
 
 package com.linkedin.avroutil1.builder.operations.codegen.vanilla;
 
+import com.linkedin.avroutil1.builder.operations.AvroSchemaUtils;
 import com.linkedin.avroutil1.builder.operations.OperationContext;
 import com.linkedin.avroutil1.builder.operations.codegen.CodeGenOpConfig;
-import com.linkedin.avroutil1.builder.operations.Operation;
+import com.linkedin.avroutil1.builder.operations.codegen.OperationContextBuilder;
 import com.linkedin.avroutil1.builder.operations.codegen.util.AvscFileFinderUtil;
 import com.linkedin.avroutil1.compatibility.Avro702Checker;
 import com.linkedin.avroutil1.compatibility.AvscGenerationConfig;
@@ -37,18 +38,12 @@ import org.slf4j.LoggerFactory;
 /**
  * a code generation operation using vanilla avro-compiler + helper post-processing
  */
-public class VanillaProcessedCodeGenOp implements Operation {
+public class VanillaProcessedCodeGenOp implements OperationContextBuilder {
   private static final Logger LOGGER = LoggerFactory.getLogger(VanillaProcessedCodeGenOp.class);
 
-  private final CodeGenOpConfig config;
-
-  public VanillaProcessedCodeGenOp(CodeGenOpConfig config) {
-    this.config = config;
-  }
-
   @Override
-  public void run(OperationContext opContext) throws Exception {
-    //mkdir any output folders that dont exist
+  public OperationContext buildOperationContext(CodeGenOpConfig config) throws Exception {
+    //mkdir any output folders that don't exist
     if (!config.getOutputSpecificRecordClassesRoot().exists() && !config.getOutputSpecificRecordClassesRoot().mkdirs()) {
       throw new IllegalStateException("unable to create destination folder " + config.getOutputSpecificRecordClassesRoot());
     }
@@ -173,9 +168,8 @@ public class VanillaProcessedCodeGenOp implements Operation {
       }
     }
 
-    opContext.addVanillaSchemas(new HashSet<>(schemas), avroFiles);
-
     LOGGER.info("Compilation complete.");
+    return new OperationContext(AvroSchemaUtils.schemasToAvroSchemas(new HashSet<>(schemas)), avroFiles, null);
   }
 
   private static String fqcnFromSchema(JSONObject schemaJson) throws JSONException { //works for both avsc and pdsc

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordGeneratorUtil.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordGeneratorUtil.java
@@ -199,8 +199,6 @@ public class SpecificRecordGeneratorUtil {
   /***
    * Get nested internal Named schemas for a given topLevel Record schema
    * Traverses through fields and catches their de-duped
-   * @param topLevelSchema
-   * @return
    */
   public static List<AvroNamedSchema> getNestedInternalSchemaList(AvroNamedSchema topLevelSchema) {
 
@@ -219,8 +217,6 @@ public class SpecificRecordGeneratorUtil {
   /***
    * Checks if field type can be treated as null union of the given type
    *
-   * @param type
-   * @param schema
    * @return True if type [null, type] or [type, null]
    */
   public static boolean isNullUnionOf(AvroType type, AvroSchema schema) {
@@ -241,7 +237,6 @@ public class SpecificRecordGeneratorUtil {
 
   /***
    * Handles list , union of list
-   * @param schema
    * @return true for List of String and List of Union of String
    */
   public static boolean isListTransformerApplicableForSchema(AvroSchema schema) {


### PR DESCRIPTION
Decouple schema parsing (fast) from code generation (slow) to be able to run avro codegen and plugins in parallel.
Remove dead code in SpecificRecordGenerator by following IDE warnings.