### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -25,7 +25,7 @@ jobs:
       run: ./gradlew clean build javadoc --stacktrace --warning-mode all --no-daemon --parallel
     - name: Branch tag
       id: branch_tag
-      run: echo ::set-output name=RELEASE_TAG::${GITHUB_REF#refs/tags/}
+      run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
     - name: Publish to Jfrog
       env:
         JFROG_USER: ${{ secrets.JFROG_USER }}


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


