### PR TITLE
Streaming collectors for stable performance

### DIFF
--- a/avro-builder/builder-spi/build.gradle
+++ b/avro-builder/builder-spi/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-api:2.17.1"
     implementation "commons-io:commons-io:2.11.0"
     implementation "jakarta.json:jakarta.json-api:2.0.1"
+    implementation "com.pivovarit:parallel-collectors:2.5.0"
 
     testImplementation "org.apache.avro:avro:1.9.2"
 }

--- a/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/util/StreamUtil.java
+++ b/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/util/StreamUtil.java
@@ -1,0 +1,47 @@
+package com.linkedin.avroutil1.builder.util;
+
+import com.pivovarit.collectors.ParallelCollectors;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+
+
+/**
+ * Utilities for dealing with java streams.
+ */
+public final class StreamUtil {
+
+  /**
+   * An (effectively) unbounded {@link ExecutorService} used for parallel processing. This is kept unbounded to avoid
+   * deadlocks caused when using {@link #toParallelStream(Function, int)} recursively. Callers are supposed to set
+   * sane values for parallelism to avoid spawning a crazy number of concurrent threads.
+   */
+  private static final ExecutorService WORK_EXECUTOR =
+      new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+
+  private StreamUtil() {
+    // Disallow external instantiation.
+  }
+
+  /**
+   * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
+   * and returning a {@link Stream} instance returning results as they arrive.
+   * <p>
+   * For the parallelism of 1, the stream is executed by the calling thread.
+   *
+   * @param mapper      a transformation to be performed in parallel
+   * @param parallelism the max parallelism level
+   * @param <T>         the type of the collected elements
+   * @param <R>         the result returned by {@code mapper}
+   *
+   * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel.
+   */
+  public static <T, R> Collector<T, ?, Stream<R>> toParallelStream(Function<T, R> mapper, int parallelism) {
+    return ParallelCollectors.parallelToStream(mapper, WORK_EXECUTOR, parallelism);
+  }
+}


### PR DESCRIPTION
Java `parallelStream` uses the default `ForkJoinPool` which is heavily used by gradle as well for internal tasks. Because the size of this pool is limited to `maxProcessors - 1`, performance is unpredictable depending on what else gradle is running.

To get around this, use a dedicated executor via a streaming collector.