### PR TITLE
Add option in SchemaBuilder to ignore user defined json properties during codegen.

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -114,6 +114,11 @@ public class SchemaBuilder {
         .defaultsTo("false")
         .describedAs("true/false");
 
+    OptionSpec<String> jsonPropsToIgnoreInCompareOpt = parser.accepts("jsonPropsToIgnoreInCompare", "json properties to ignore when comparing schemas on filesystem and classpath")
+        .withOptionalArg()
+        .defaultsTo("")
+        .withValuesSeparatedBy(',');
+
     //allow plugins to add CLI options
     for (BuilderPlugin plugin : plugins) {
       plugin.customizeCLI(parser);
@@ -238,6 +243,11 @@ public class SchemaBuilder {
       skipCodegenIfSchemaOnClasspath = Boolean.TRUE.equals(Boolean.parseBoolean(value));
     }
 
+    List<String> jsonPropsToIgnoreInCompare = new ArrayList<>();
+    if(options.has(jsonPropsToIgnoreInCompareOpt)) {
+      jsonPropsToIgnoreInCompare = options.valuesOf(jsonPropsToIgnoreInCompareOpt);
+    }
+
     //allow plugins to parse and validate their own added options
     for (BuilderPlugin plugin : plugins) {
       plugin.parseAndValidateOptions(options);
@@ -258,7 +268,8 @@ public class SchemaBuilder {
         minAvroVer,
         handleAvro702,
         handleUtf8EncodingInPutByIndex,
-        skipCodegenIfSchemaOnClasspath
+        skipCodegenIfSchemaOnClasspath,
+        jsonPropsToIgnoreInCompare
     );
 
     opConfig.validateParameters();

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -114,7 +114,8 @@ public class SchemaBuilder {
         .defaultsTo("false")
         .describedAs("true/false");
 
-    OptionSpec<String> jsonPropsToIgnoreInCompareOpt = parser.accepts("jsonPropsToIgnoreInCompare", "json properties to ignore when comparing schemas on filesystem and classpath")
+    OptionSpec<String> jsonPropsToIgnoreInCompareOpt = parser.accepts("jsonPropsToIgnoreInCompare",
+            "json properties to ignore when comparing schemas on filesystem and classpath. Example : jsonOption1, jsonOption2")
         .withOptionalArg()
         .defaultsTo("")
         .withValuesSeparatedBy(',');

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -21,9 +21,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
@@ -244,9 +246,10 @@ public class SchemaBuilder {
       skipCodegenIfSchemaOnClasspath = Boolean.TRUE.equals(Boolean.parseBoolean(value));
     }
 
-    List<String> jsonPropsToIgnoreInCompare = new ArrayList<>();
-    if(options.has(jsonPropsToIgnoreInCompareOpt)) {
-      jsonPropsToIgnoreInCompare = options.valuesOf(jsonPropsToIgnoreInCompareOpt);
+    Set<String> jsonPropsToIgnoreInCompare = Collections.EMPTY_SET;
+    if (options.has(jsonPropsToIgnoreInCompareOpt)) {
+      jsonPropsToIgnoreInCompare =
+          options.valuesOf(jsonPropsToIgnoreInCompareOpt).stream().map(String::trim).collect(Collectors.toSet());
     }
 
     //allow plugins to parse and validate their own added options

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/CodeGenOpConfig.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/CodeGenOpConfig.java
@@ -49,6 +49,10 @@ public class CodeGenOpConfig {
   boolean avro702Handling;
   boolean utf8EncodingPutByIndex;
   boolean skipCodegenIfSchemaOnClasspath;
+  /**
+   * List of JSON properties to ignore when comparing two schemas during codegen.
+   */
+  private List<String> jsonPropsToIgnoreInCompare;
 
   @Deprecated
   public CodeGenOpConfig(
@@ -201,6 +205,40 @@ public class CodeGenOpConfig {
     this.skipCodegenIfSchemaOnClasspath = skipCodegenIfSchemaOnClasspath;
   }
 
+  public CodeGenOpConfig(List<File> inputRoots,
+      List<File> nonImportableSourceRoots,
+      boolean includeClasspath,
+      File outputSpecificRecordClassesRoot,
+      File outputExpandedSchemasRoot,
+      List<File> resolverPath,
+      CodeGenerator generatorType,
+      DuplicateSchemaBehaviour dupBehaviour,
+      List<String> duplicateSchemasToIgnore,
+      StringRepresentation stringRepresentation,
+      StringRepresentation methodStringRepresentation,
+      AvroVersion minAvroVersion,
+      boolean avro702Handling,
+      boolean handleUtf8EncodingInPutByIndex,
+      boolean skipCodegenIfSchemaOnClasspath,
+      List<String> jsonPropsToIgnoreInCompare) {
+    this.inputRoots = inputRoots;
+    this.nonImportableSourceRoots = nonImportableSourceRoots;
+    this.includeClasspath = includeClasspath;
+    this.outputSpecificRecordClassesRoot = outputSpecificRecordClassesRoot;
+    this.outputExpandedSchemasRoot = outputExpandedSchemasRoot;
+    this.resolverPath = resolverPath;
+    this.generatorType = generatorType;
+    this.dupBehaviour = dupBehaviour;
+    this.duplicateSchemasToIgnore = duplicateSchemasToIgnore;
+    this.stringRepresentation = stringRepresentation;
+    this.methodStringRepresentation = methodStringRepresentation;
+    this.minAvroVersion = minAvroVersion;
+    this.avro702Handling = avro702Handling;
+    this.utf8EncodingPutByIndex = handleUtf8EncodingInPutByIndex;
+    this.skipCodegenIfSchemaOnClasspath = skipCodegenIfSchemaOnClasspath;
+    this.jsonPropsToIgnoreInCompare = jsonPropsToIgnoreInCompare;
+  }
+
   /**
    * validates all input parameters (set at construction time)
    */
@@ -310,6 +348,10 @@ public class CodeGenOpConfig {
 
   public boolean shouldSkipCodegenIfSchemaOnClasspath() {
     return skipCodegenIfSchemaOnClasspath;
+  }
+
+  public List<String> getJsonPropsToIgnoreInCompare() {
+    return jsonPropsToIgnoreInCompare;
   }
 
   private void validateInput(Collection<File> files, String desc) {

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/CodeGenOpConfig.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/CodeGenOpConfig.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 
 /**
@@ -52,7 +53,7 @@ public class CodeGenOpConfig {
   /**
    * List of JSON properties to ignore when comparing two schemas during codegen.
    */
-  private List<String> jsonPropsToIgnoreInCompare;
+  private Set<String> jsonPropsToIgnoreInCompare;
 
   @Deprecated
   public CodeGenOpConfig(
@@ -220,7 +221,7 @@ public class CodeGenOpConfig {
       boolean avro702Handling,
       boolean handleUtf8EncodingInPutByIndex,
       boolean skipCodegenIfSchemaOnClasspath,
-      List<String> jsonPropsToIgnoreInCompare) {
+      Set<String> jsonPropsToIgnoreInCompare) {
     this.inputRoots = inputRoots;
     this.nonImportableSourceRoots = nonImportableSourceRoots;
     this.includeClasspath = includeClasspath;
@@ -350,7 +351,7 @@ public class CodeGenOpConfig {
     return skipCodegenIfSchemaOnClasspath;
   }
 
-  public List<String> getJsonPropsToIgnoreInCompare() {
+  public Set<String> getJsonPropsToIgnoreInCompare() {
     return jsonPropsToIgnoreInCompare;
   }
 

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilOperationContextBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilOperationContextBuilder.java
@@ -123,7 +123,8 @@ public class AvroUtilOperationContextBuilder implements OperationContextBuilder 
             // check if the schema on classpath is the same as the one we are trying to generate
             AvroSchema avroSchemaFromClasspath = (new AvscParser()).parse(cpSchema.toString()).getTopLevelSchema();
             boolean areEqual = ConfigurableAvroSchemaComparator.equals(avroSchemaFromClasspath, schema,
-                SchemaComparisonConfiguration.STRICT);
+                SchemaComparisonConfiguration.newBuilder(SchemaComparisonConfiguration.STRICT).setJsonPropNamesToIgnore(
+                    config.getJsonPropsToIgnoreInCompare()).build());
             if (!areEqual) {
               throw new IllegalStateException("Schema with name " + fullName
                   + " is defined in the filesystem and on the classpath, but the two schemas are not equal.");

--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilOperationContextBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/operations/codegen/own/AvroUtilOperationContextBuilder.java
@@ -126,6 +126,7 @@ public class AvroUtilOperationContextBuilder implements OperationContextBuilder 
                 SchemaComparisonConfiguration.newBuilder(SchemaComparisonConfiguration.STRICT).setJsonPropNamesToIgnore(
                     config.getJsonPropsToIgnoreInCompare()).build());
             if (!areEqual) {
+
               throw new IllegalStateException("Schema with name " + fullName
                   + " is defined in the filesystem and on the classpath, but the two schemas are not equal.");
             }

--- a/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
+++ b/avro-builder/builder/src/test/java/com/linkedin/avroutil1/builder/SchemaBuilderTest.java
@@ -284,6 +284,29 @@ public class SchemaBuilderTest {
     Assert.assertEquals(javaFiles.size(), 2);
   }
 
+  @Test
+  public void testTopLevelUnionUsingOwnCodegenWithIngoreJsonPropOptipn() throws Exception {
+    File simpleProjectRoot = new File(locateTestProjectsRoot(), "union-schema-project");
+    File inputFolder = new File(simpleProjectRoot, "input");
+    File outputFolder = new File(simpleProjectRoot, "output");
+    if (outputFolder.exists()) { //clear output
+      FileUtils.deleteDirectory(outputFolder);
+    }
+    //run the builder
+    SchemaBuilder.main(new String[] {
+        "--input", inputFolder.getAbsolutePath(),
+        "--output", outputFolder.getAbsolutePath(),
+        "--generator", CodeGenerator.AVRO_UTIL.name(),
+        "enableUtf8EncodingInPutByIndex", "false",
+        "--jsonPropsToIgnoreInCompare", "option1, option2"
+    });
+    //see output was generated
+    List<Path> javaFiles = Files.find(outputFolder.toPath(), 5,
+        (path, basicFileAttributes) -> path.getFileName().toString().endsWith(".java")
+    ).collect(Collectors.toList());
+    Assert.assertEquals(javaFiles.size(), 2);
+  }
+
   private File locateTestProjectsRoot() {
     //the current working directory for test execution varies across gradle and IDEs.
     //as such, we need to get creative to locate the folder

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -7,8 +7,6 @@
 package com.linkedin.avroutil1.compatibility;
 
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 
@@ -223,12 +221,6 @@ public class SchemaComparisonConfiguration {
 
     public Builder setJsonPropNamesToIgnore(Set<String> jsonPropNamesToIgnore) {
       this.jsonPropNamesToIgnore = jsonPropNamesToIgnore;
-      return this;
-    }
-
-    // Overloaded method to accept List instead of Set
-    public Builder setJsonPropNamesToIgnore(List<String> jsonPropNamesToIgnore) {
-      this.jsonPropNamesToIgnore = new HashSet<>(jsonPropNamesToIgnore);
       return this;
     }
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -7,6 +7,8 @@
 package com.linkedin.avroutil1.compatibility;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 
@@ -80,6 +82,9 @@ public class SchemaComparisonConfiguration {
   public Set<String> getJsonPropNamesToIgnore() {
     return jsonPropNamesToIgnore;
   }
+
+  // Builder class
+
 
   public SchemaComparisonConfiguration compareStringJsonProps(boolean compare) {
     return new SchemaComparisonConfiguration(
@@ -163,6 +168,92 @@ public class SchemaComparisonConfiguration {
         compareFieldLogicalTypes,
         jsonPropNamesToIgnore
     );
+  }
+
+  /**
+   * Get instance of SchemaComparisonConfiguration.Builder
+   * @param schemaConfig SchemaComparisonConfiguration
+   * @return Builder instance
+   */
+  public static Builder newBuilder(SchemaComparisonConfiguration schemaConfig) {
+    return new Builder().from(schemaConfig);
+  }
+
+  /**
+   * Builder class for {@link SchemaComparisonConfiguration}
+   */
+  public static class Builder {
+    private boolean compareStringJsonProps;
+    private boolean compareNonStringJsonProps;
+    private boolean compareAliases;
+    private boolean compareIntToFloatDefaults;
+    private boolean compareFieldOrder;
+    private boolean compareFieldLogicalTypes;
+    private Set<String> jsonPropNamesToIgnore;
+
+    public Builder setCompareStringJsonProps(boolean compareStringJsonProps) {
+      this.compareStringJsonProps = compareStringJsonProps;
+      return this;
+    }
+
+    public Builder setCompareNonStringJsonProps(boolean compareNonStringJsonProps) {
+      this.compareNonStringJsonProps = compareNonStringJsonProps;
+      return this;
+    }
+
+    public Builder setCompareAliases(boolean compareAliases) {
+      this.compareAliases = compareAliases;
+      return this;
+    }
+
+    public Builder setCompareIntToFloatDefaults(boolean compareIntToFloatDefaults) {
+      this.compareIntToFloatDefaults = compareIntToFloatDefaults;
+      return this;
+    }
+
+    public Builder setCompareFieldOrder(boolean compareFieldOrder) {
+      this.compareFieldOrder = compareFieldOrder;
+      return this;
+    }
+
+    public Builder setCompareFieldLogicalTypes(boolean compareFieldLogicalTypes) {
+      this.compareFieldLogicalTypes = compareFieldLogicalTypes;
+      return this;
+    }
+
+    public Builder setJsonPropNamesToIgnore(Set<String> jsonPropNamesToIgnore) {
+      this.jsonPropNamesToIgnore = jsonPropNamesToIgnore;
+      return this;
+    }
+
+    // Overloaded method to accept List instead of Set
+    public Builder setJsonPropNamesToIgnore(List<String> jsonPropNamesToIgnore) {
+      this.jsonPropNamesToIgnore = new HashSet<>(jsonPropNamesToIgnore);
+      return this;
+    }
+
+    Builder from(SchemaComparisonConfiguration config) {
+      this.compareStringJsonProps = config.isCompareStringJsonProps();
+      this.compareNonStringJsonProps = config.isCompareNonStringJsonProps();
+      this.compareAliases = config.isCompareAliases();
+      this.compareIntToFloatDefaults = config.isCompareIntToFloatDefaults();
+      this.compareFieldOrder = config.isCompareFieldOrder();
+      this.compareFieldLogicalTypes = config.isCompareFieldLogicalTypes();
+      this.jsonPropNamesToIgnore = config.getJsonPropNamesToIgnore();
+      return this;
+    }
+
+    public SchemaComparisonConfiguration build() {
+      return new SchemaComparisonConfiguration(
+          compareStringJsonProps,
+          compareNonStringJsonProps,
+          compareAliases,
+          compareIntToFloatDefaults,
+          compareFieldOrder,
+          compareFieldLogicalTypes,
+          jsonPropNamesToIgnore
+      );
+    }
   }
 }
 


### PR DESCRIPTION
### What
Adding option to ignore json properties in SchemaBuilder

### Why
During avro codegen, the if the generator detects conflicting defintions of a schema, where the filesystem definition is different from the one in classpath, it throws.
Relaxing this check by allowing the user to specify json properties to be ignored during this check.

It is useful if the duplicate schema is "almost" same but has certain properties which may store metadata for another flow. 

### Test 
Added Sanity Unit test
build