### PR TITLE
Reduce keep alive time of thread pool to 100ms

### DIFF
--- a/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/util/StreamUtil.java
+++ b/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/util/StreamUtil.java
@@ -31,7 +31,7 @@ public final class StreamUtil {
    * sane values for parallelism to avoid spawning a crazy number of concurrent threads.
    */
   private static final ExecutorService WORK_EXECUTOR =
-      new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue<>());
+      new ThreadPoolExecutor(0, Integer.MAX_VALUE, 100, TimeUnit.MILLISECONDS, new SynchronousQueue<>());
 
   private StreamUtil() {
     // Disallow external instantiation.


### PR DESCRIPTION
This prevents processes from staying alive for a minute just waiting for idle timeout to expire on threads after actual work finishes.