### PR TITLE
[schema builder] don't generate ref'ed arrays and maps

### DIFF
--- a/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
+++ b/avro-builder/builder/src/test/resources/test-projects/classpath-project/input/SchemaWithClasspathImport.avsc
@@ -7,6 +7,23 @@
     {
       "name": "date",
       "type": "build.generated.SimpleRecord"
+    },
+    {
+      "name": "unionArrayReference",
+      "type" :[
+        "null",
+        {
+          "type": "array",
+          "items": "build.generated.SimpleRecord"
+        }
+      ]
+    },
+    {
+      "name": "mapReference",
+        "type": {
+            "type": "map",
+            "values": "build.generated.SimpleRecord"
+        }
     }
   ]
 }

--- a/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordGeneratorUtil.java
+++ b/avro-codegen/src/main/java/com/linkedin/avroutil1/codegen/SpecificRecordGeneratorUtil.java
@@ -314,10 +314,16 @@ public class SpecificRecordGeneratorUtil {
           });
           break;
         case MAP:
-          schemaQueue.add(((AvroMapSchema) fieldSchema).getValueSchema());
+          AvroMapSchema mapSchema = (AvroMapSchema) fieldSchema;
+          if (mapSchema.getValueSchemaOrRef().getRef() == null) {
+            schemaQueue.add(mapSchema.getValueSchema());
+          }
           break;
         case ARRAY:
-          schemaQueue.add(((AvroArraySchema) fieldSchema).getValueSchema());
+          AvroArraySchema arraySchema = (AvroArraySchema) fieldSchema;
+          if (arraySchema.getValueSchemaOrRef().getRef() == null) {
+            schemaQueue.add(arraySchema.getValueSchema());
+          }
           break;
       }
     }


### PR DESCRIPTION
Before, we would incorrectly generate referenced schemas from classpath/resolver path if they were referenced from an array/map. This change fixes that by checking `getRef() == null` first before generating nested schemas (referenced in a map/array)