### PR TITLE
Added handling of union type in AvscParser 

### DIFF
--- a/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
@@ -876,6 +876,16 @@ public class AvscParser {
                 return new LiteralOrIssue(new AvroRecordLiteral(
                     recordSchema, locationOf(context.getUri(), literalNode), map
                 ));
+            case UNION:
+                AvroUnionSchema unionSchema = (AvroUnionSchema) schema;
+                LiteralOrIssue branchValueOrIssue =
+                    parseLiteral(literalNode, unionSchema.getTypes().get(0).getSchema(), fieldName, context);
+                if (branchValueOrIssue.getIssue() == null) {
+                    return branchValueOrIssue;
+                }
+                return new LiteralOrIssue(
+                    AvscIssues.badFieldDefaultValue(locationOf(context.getUri(), literalNode), literalNode.toString(),
+                        avroType, fieldName));
             default:
                 throw new UnsupportedOperationException("dont know how to parse a " + avroType + " at " + literalNode.getStartLocation()
                         + " out of a " + literalNode.getValueType() + " (" + literalNode + ")");

--- a/parser/src/test/java/com/linkedin/avroutil1/parser/avsc/AvscParserTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/parser/avsc/AvscParserTest.java
@@ -704,6 +704,21 @@ public class AvscParserTest {
         Assert.assertEquals(recordParseResult.getIssues().size(), 0);
     }
 
+    @Test
+    public void testMapOfUnionDefault() throws Exception {
+        String recordAvsc = TestUtil.load("schemas/RecordWithMapOfUnion.avsc");
+        AvscParser avscParser = new AvscParser();
+
+        AvscParseResult recordParseResult = avscParser.parse(recordAvsc);
+        AvroRecordSchema topLevelSchema = (AvroRecordSchema) recordParseResult.getTopLevelSchema();
+
+        // Tests we don't have unparsed default values in for of AvscUnparsedLiteral.
+        new AvscSchemaWriter().writeSingle(topLevelSchema);
+
+        Assert.assertFalse(hasUnparsedDefault(topLevelSchema));
+        Assert.assertEquals(recordParseResult.getIssues().size(), 0);
+    }
+
     /**
      * Recursively goes through all fields and their schemas to check if any field has an unparsed default value
      * @param schema

--- a/parser/src/test/resources/schemas/RecordWithMapOfUnion.avsc
+++ b/parser/src/test/resources/schemas/RecordWithMapOfUnion.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "RecordWithMapOfUnion",
+  "fields": [
+    {
+      "name": "myField2",
+      "type": {
+        "type": "map",
+        "values": [
+          "string",
+          {
+            "type": "array",
+            "items": "string"
+          },
+          {
+            "type": "map",
+            "values": "string"
+          }
+        ]
+      },
+      "default": {"key1": "value1"}
+    }
+  ]
+}


### PR DESCRIPTION
### What
Adding `case UNION` in avsc parser handling of default values

### Why
Maps/Lists can have their item/value types as unions. Handling such schemas with default values.

### Test
Added unit tests
Build