### PR TITLE
ColdPrimitive*List classes use correct schema.

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/avro/primitiveArrays.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/primitiveArrays.avsc
@@ -1,0 +1,42 @@
+{
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "name": "PrimitiveArraysTestRecord",
+  "type": "record",
+  "fields": [
+    {
+      "name": "arrayOfInts",
+      "type": {
+        "type": "array",
+        "items": "int"
+      }
+    },
+    {
+      "name": "arrayOfLongs",
+      "type": {
+        "type": "array",
+        "items": "long"
+      }
+    },
+    {
+      "name": "arrayOfFloats",
+      "type": {
+        "type": "array",
+        "items": "float"
+      }
+    },
+    {
+      "name": "arrayOfDoubles",
+      "type": {
+        "type": "array",
+        "items": "double"
+      }
+    },
+    {
+      "name": "arrayOfBooleans",
+      "type": {
+        "type": "array",
+        "items": "boolean"
+      }
+    }
+  ]
+}

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/primitives/FastSerdePrimitivesArrayTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/primitives/FastSerdePrimitivesArrayTest.java
@@ -1,0 +1,70 @@
+package com.linkedin.avro.fastserde.primitives;
+
+import static com.linkedin.avro.fastserde.FastSerdeTestsSupport.getField;
+
+import java.io.IOException;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.specific.SpecificData;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import com.linkedin.avro.api.PrimitiveFloatList;
+import com.linkedin.avro.fastserde.FastSerdeTestsSupport;
+import com.linkedin.avro.fastserde.FastSpecificDatumReader;
+import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveBooleanList;
+import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveDoubleList;
+import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveFloatList;
+import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveIntList;
+import com.linkedin.avro.fastserde.coldstart.ColdPrimitiveLongList;
+import com.linkedin.avro.fastserde.generated.avro.PrimitiveArraysTestRecord;
+import com.linkedin.avro.fastserde.primitive.PrimitiveBooleanArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveDoubleArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveIntArrayList;
+import com.linkedin.avro.fastserde.primitive.PrimitiveLongArrayList;
+
+public class FastSerdePrimitivesArrayTest {
+
+    private final Schema schema = PrimitiveArraysTestRecord.SCHEMA$;
+    private final FastSpecificDatumReader<PrimitiveArraysTestRecord> reader = new FastSpecificDatumReader<>(
+            schema, schema, (SpecificData) null);
+
+    @Test
+    void shouldDeserializeUsingPrimitiveLists() throws IOException {
+        PrimitiveArraysTestRecord record = new PrimitiveArraysTestRecord();
+        FastSerdeTestsSupport.setField(record, "arrayOfInts", Lists.newArrayList(11, 12, 13));
+        FastSerdeTestsSupport.setField(record, "arrayOfLongs", Lists.newArrayList(21L, 22L, 23L));
+        FastSerdeTestsSupport.setField(record, "arrayOfFloats", Lists.newArrayList(0.1F, 0.2F, 0.3F));
+        FastSerdeTestsSupport.setField(record, "arrayOfDoubles", Lists.newArrayList(1.1, 1.1, 1.3));
+        FastSerdeTestsSupport.setField(record, "arrayOfBooleans", Lists.newArrayList(true, false, true));
+
+        PrimitiveArraysTestRecord deserializedRecord1 = serializeAndDeserialize(record);
+
+        Assert.assertTrue(getField(deserializedRecord1, "arrayOfInts") instanceof ColdPrimitiveIntList);
+        Assert.assertTrue(getField(deserializedRecord1, "arrayOfLongs") instanceof ColdPrimitiveLongList);
+        Assert.assertTrue(getField(deserializedRecord1, "arrayOfFloats") instanceof ColdPrimitiveFloatList);
+        Assert.assertTrue(getField(deserializedRecord1, "arrayOfDoubles") instanceof ColdPrimitiveDoubleList);
+        Assert.assertTrue(getField(deserializedRecord1, "arrayOfBooleans") instanceof ColdPrimitiveBooleanList);
+
+        Awaitility.await()
+                .atMost(Durations.TEN_SECONDS)
+                .pollInterval(Durations.ONE_HUNDRED_MILLISECONDS)
+                .until(() -> {
+                    PrimitiveArraysTestRecord deserializedRecord2 = serializeAndDeserialize(record);
+                    return getField(deserializedRecord2, "arrayOfInts") instanceof PrimitiveIntArrayList
+                            && getField(deserializedRecord2, "arrayOfLongs") instanceof PrimitiveLongArrayList
+                            && getField(deserializedRecord2, "arrayOfFloats") instanceof PrimitiveFloatList
+                            && getField(deserializedRecord2, "arrayOfDoubles") instanceof PrimitiveDoubleArrayList
+                            && getField(deserializedRecord2, "arrayOfBooleans") instanceof PrimitiveBooleanArrayList;
+                });
+    }
+
+    private PrimitiveArraysTestRecord serializeAndDeserialize(PrimitiveArraysTestRecord record) throws IOException {
+        Decoder decoder = FastSerdeTestsSupport.specificDataAsDecoder(record);
+        return reader.read(null, decoder);
+    }
+}

--- a/fastserde/avro-fastserde-tests110/build.gradle
+++ b/fastserde/avro-fastserde-tests110/build.gradle
@@ -51,9 +51,11 @@ dependencies {
 
   testImplementation 'org.testng:testng:6.14.3'
   testImplementation 'org.slf4j:slf4j-simple:1.7.14'
+  testImplementation 'org.awaitility:awaitility:4.2.0'
 
   testFixturesApi 'org.testng:testng:6.14.3'
   testFixturesApi 'org.slf4j:slf4j-simple:1.7.14'
+  testFixturesApi 'org.awaitility:awaitility:4.2.0'
   testFixturesApi ("org.apache.avro:avro:1.10.2") {
     exclude group: "org.slf4j"
   }

--- a/fastserde/avro-fastserde-tests111/build.gradle
+++ b/fastserde/avro-fastserde-tests111/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   testImplementation project(":helper:helper")
 
   testImplementation "org.slf4j:slf4j-api:1.7.14"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
 

--- a/fastserde/avro-fastserde-tests14/build.gradle
+++ b/fastserde/avro-fastserde-tests14/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   testImplementation project(":helper:helper")
 
   testImplementation "org.slf4j:slf4j-api:1.7.14"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
 

--- a/fastserde/avro-fastserde-tests15/build.gradle
+++ b/fastserde/avro-fastserde-tests15/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
   testImplementation 'org.testng:testng:6.14.3'
   testImplementation 'org.slf4j:slf4j-simple:1.7.14'
+  testImplementation 'org.awaitility:awaitility:4.2.0'
 
   codegen project(":helper:helper")
   codegen "org.apache.avro:avro-tools:1.5.4"

--- a/fastserde/avro-fastserde-tests16/build.gradle
+++ b/fastserde/avro-fastserde-tests16/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   testImplementation project(":helper:helper")
 
   testImplementation "org.slf4j:slf4j-api:1.7.14"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
 

--- a/fastserde/avro-fastserde-tests17/build.gradle
+++ b/fastserde/avro-fastserde-tests17/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   testImplementation project(":helper:helper")
 
   testImplementation "org.slf4j:slf4j-api:1.7.14"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
 

--- a/fastserde/avro-fastserde-tests18/build.gradle
+++ b/fastserde/avro-fastserde-tests18/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   testImplementation project(":helper:helper")
 
   testImplementation "org.slf4j:slf4j-api:1.7.14"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
   implementation "joda-time:joda-time:2.12.5"  // required by generated Avro classes with logical types

--- a/fastserde/avro-fastserde-tests19/build.gradle
+++ b/fastserde/avro-fastserde-tests19/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   testImplementation project(":helper:helper")
 
   testImplementation "org.slf4j:slf4j-api:1.7.14"
+  testImplementation 'org.awaitility:awaitility:4.2.0'
   testImplementation "org.apache.commons:commons-lang3:3.4"
   testImplementation "com.sun.codemodel:codemodel:2.6"
 

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -783,8 +783,8 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
      */
     if (action.getShouldRead() && arraySchema.getElementType().getType().equals(Schema.Type.FLOAT)) {
       JClass primitiveFloatList = codeModel.ref(BufferBackedPrimitiveFloatList.class);
-      JExpression readPrimitiveFloatArrayInvocation = primitiveFloatList.staticInvoke("readPrimitiveFloatArray").
-          arg(reuseSupplier.get()).arg(JExpr.direct(DECODER));
+      JExpression readPrimitiveFloatArrayInvocation = primitiveFloatList.staticInvoke("readPrimitiveFloatArray")
+              .arg(reuseSupplier.get()).arg(JExpr.direct(DECODER));
       JExpression castedResult =
           JExpr.cast(codeModel.ref(PrimitiveFloatList.class), readPrimitiveFloatArrayInvocation);
 

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveBooleanList.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveBooleanList.java
@@ -15,7 +15,7 @@ import org.apache.avro.generic.GenericData;
  * available, even when Fast-Avro isn't warmed up yet.
  */
 public class ColdPrimitiveBooleanList extends GenericData.Array<Boolean> implements PrimitiveBooleanList {
-  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.FLOAT));
+  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.BOOLEAN));
   public ColdPrimitiveBooleanList(int capacity) {
     super(capacity, SCHEMA);
   }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveDoubleList.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveDoubleList.java
@@ -15,7 +15,7 @@ import org.apache.avro.generic.GenericData;
  * available, even when Fast-Avro isn't warmed up yet.
  */
 public class ColdPrimitiveDoubleList extends GenericData.Array<Double> implements PrimitiveDoubleList {
-  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.FLOAT));
+  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.DOUBLE));
   public ColdPrimitiveDoubleList(int capacity) {
     super(capacity, SCHEMA);
   }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveIntList.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveIntList.java
@@ -15,7 +15,7 @@ import org.apache.avro.generic.GenericData;
  * available, even when Fast-Avro isn't warmed up yet.
  */
 public class ColdPrimitiveIntList extends GenericData.Array<Integer> implements PrimitiveIntList {
-  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.FLOAT));
+  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.INT));
   public ColdPrimitiveIntList(int capacity) {
     super(capacity, SCHEMA);
   }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveLongList.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/coldstart/ColdPrimitiveLongList.java
@@ -10,12 +10,12 @@ import org.apache.avro.generic.GenericData;
  * implementation, both in terms of functionality and (lack of) performance. It provides the primitive
  * API that the interface requires, but actually just returns an unboxed Float Object, thus providing
  * no GC benefit. This should be possible to improve upon in the future, however.
- *
+ * <br>
  * The main motivation for this class is merely to provide a guarantee that the extended API is always
  * available, even when Fast-Avro isn't warmed up yet.
  */
 public class ColdPrimitiveLongList extends GenericData.Array<Long> implements PrimitiveLongList {
-  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.FLOAT));
+  private static final Schema SCHEMA = Schema.createArray(Schema.create(Schema.Type.LONG));
   public ColdPrimitiveLongList(int capacity) {
     super(capacity, SCHEMA);
   }


### PR DESCRIPTION
Just a minor fix.

The main change is in 4 classes:
- `ColdPrimitiveBooleanList`
- `ColdPrimitiveDoubleList`
- `ColdPrimitiveIntList`
- `ColdPrimitiveLongList`