### PR TITLE
optimize StreamUtil and fix the LimitingExecutor

### DIFF
--- a/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/util/StreamUtil.java
+++ b/avro-builder/builder-spi/src/main/java/com/linkedin/avroutil1/builder/util/StreamUtil.java
@@ -132,7 +132,6 @@ public final class StreamUtil {
       }
       _mapper = mapper;
       _batchSize = batchSize;
-      //this.executor = new ForkJoinPool(parallelism);
       _executor = new LimitingExecutor(parallelism);
     }
 

--- a/avro-builder/builder-spi/src/test/java/com/linkedin/avroutil1/builder/util/StreamUtilTest.java
+++ b/avro-builder/builder-spi/src/test/java/com/linkedin/avroutil1/builder/util/StreamUtilTest.java
@@ -6,7 +6,6 @@
 
 package com.linkedin.avroutil1.builder.util;
 
-import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -17,22 +16,10 @@ import org.testng.annotations.Test;
  */
 public class StreamUtilTest {
   @Test
-  public void testParallelStreamUsingGlobalExecutor() throws Exception {
+  public void testParallelStreaming() throws Exception {
     int result = IntStream.rangeClosed(1, 100)
         .boxed()
         .collect(StreamUtil.toParallelStream(x -> x * x, 3, 4))
-        .reduce(0, Integer::sum);
-
-    int expected = IntStream.rangeClosed(1, 100).map(x -> x * x).sum();
-
-    Assert.assertEquals(result, expected);
-  }
-
-  @Test
-  public void testParallelStreamUsingSelfExecutor() throws Exception {
-    int result = IntStream.rangeClosed(1, 100)
-        .boxed()
-        .collect(StreamUtil.toParallelStream(x -> x * x, 4, new ForkJoinPool(5)))
         .reduce(0, Integer::sum);
 
     int expected = IntStream.rangeClosed(1, 100).map(x -> x * x).sum();

--- a/avro-builder/builder-spi/src/test/java/com/linkedin/avroutil1/builder/util/StreamUtilTest.java
+++ b/avro-builder/builder-spi/src/test/java/com/linkedin/avroutil1/builder/util/StreamUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 LinkedIn Corp.
+ * Licensed under the BSD 2-Clause License (the "License").
+ * See License in the project root for license information.
+ */
+
+package com.linkedin.avroutil1.builder.util;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.IntStream;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * This is to test {@link StreamUtil}
+ */
+public class StreamUtilTest {
+  @Test
+  public void testParallelStreamUsingGlobalExecutor() throws Exception {
+    int result = IntStream.rangeClosed(1, 100)
+        .boxed()
+        .collect(StreamUtil.toParallelStream(x -> x * x, 3, 4))
+        .reduce(0, Integer::sum);
+
+    int expected = IntStream.rangeClosed(1, 100).map(x -> x * x).sum();
+
+    Assert.assertEquals(result, expected);
+  }
+
+  @Test
+  public void testParallelStreamUsingSelfExecutor() throws Exception {
+    int result = IntStream.rangeClosed(1, 100)
+        .boxed()
+        .collect(StreamUtil.toParallelStream(x -> x * x, 4, new ForkJoinPool(5)))
+        .reduce(0, Integer::sum);
+
+    int expected = IntStream.rangeClosed(1, 100).map(x -> x * x).sum();
+
+    Assert.assertEquals(result, expected);
+  }
+}


### PR DESCRIPTION
(1)  https://github.com/linkedin/avro-util/pull/548 fixed the issue to execute mapper function to each batch in the thread-pool. but the batches are still executed sequentially.  We need to fix the issues to have the batches executed in parallel. Here we implement a Collector:
    - the **accumulate** method collect data from original stream, create batches, and submit jobs for executing each batch to thread-pool.
    - the **finisher** method handles the last batch, submit the job for the last batch to thread-pool. It also connect the result for the jobs executed in the thread-pool, combine the results, and stream the results.
 
Tested this can execute the batches in the thread-pool in parallel.

(2) Fix LimitingExecutor. LimitingExecutor use a Semaphore to control the maximum number of jobs concurrently executed in the thread-pool. But the Semaphore is just used to guard the **ThreadPool.execute(command)**, and the ThreadPool.execute just submit the job to the threadpool. So the Semaphore does not guard the number of jobs concurrently running in the pool. We fix this issue by:
 a. require a Semaphore when submitting a new job;
 b. release a Semaphore when a job completes;