### PR TITLE
ensure FileReader `close()`es during avro parse

### DIFF
--- a/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
@@ -144,7 +144,6 @@ public class AvscParser {
 
     public AvscParseResult parse(File avscFile) {
         AvscFileParseContext context = new AvscFileParseContext(avscFile, this);
-        ;
         try (Reader reader = new FileReader(avscFile)) {
             return parse(context, reader);
         } catch (FileNotFoundException e) {

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
@@ -149,6 +149,8 @@ public class AvscParser {
             return parse(context, reader);
         } catch (FileNotFoundException e) {
             throw new IllegalStateException("input file " + avscFile.getAbsolutePath() + " not found", e);
+        } catch (IOException e) {
+            throw new IllegalStateException("error reading input file " + avscFile.getAbsolutePath(), e);
         }
     }
 

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
@@ -144,13 +144,12 @@ public class AvscParser {
 
     public AvscParseResult parse(File avscFile) {
         AvscFileParseContext context = new AvscFileParseContext(avscFile, this);
-        Reader reader;
-        try {
-            reader = new FileReader(avscFile);
+        ;
+        try (Reader reader = new FileReader(avscFile)) {
+            return parse(context, reader);
         } catch (FileNotFoundException e) {
             throw new IllegalStateException("input file " + avscFile.getAbsolutePath() + " not found", e);
         }
-        return parse(context, reader);
     }
 
     private AvscParseResult parse(AvscFileParseContext context, Reader reader) {

--- a/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
+++ b/parser/src/main/java/com/linkedin/avroutil1/parser/avsc/AvscParser.java
@@ -55,6 +55,7 @@ import com.linkedin.avroutil1.util.Util;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.Path;
 import java.util.HashMap;


### PR DESCRIPTION
FileReader was not being closed during `AvscParser#parse()`. This was causing `Too many open files` in some repositories.