### PR TITLE
[fast-avro][deserializer] Populate methods always with 'customization' argument

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/avro/recordWith2Fields.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/recordWith2Fields.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "RecordWithOneNullableText",
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "doc": "Used in tests of fast-serde to verify populate-methods works correctly with DatumReaderCustomization.",
+  "fields": [
+    {
+      "name": "text",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null,
+      "doc": "Corresponds with recordWith2FieldsAndDeeplyNestedRecord.avsc"
+    }
+  ]
+}

--- a/fastserde/avro-fastserde-tests-common/src/test/avro/recordWith2FieldsAndDeeplyNestedRecord.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/recordWith2FieldsAndDeeplyNestedRecord.avsc
@@ -1,0 +1,59 @@
+{
+  "type": "record",
+  "name": "RecordWithOneNullableTextAndDeeplyNestedRecord",
+  "namespace": "com.linkedin.avro.fastserde.generated.avro",
+  "doc": "Used in tests of fast-serde to verify populate-methods works correctly with DatumReaderCustomization. Just like OuterRecordWith2NestedBetaRecords but with one field more.",
+  "fields": [
+    {
+      "name": "text",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null,
+      "doc": "Corresponds with recordWith2Fields.avsc"
+    },
+    {
+      "name": "nestedField",
+      "type": [
+        "null",
+        {
+          "name": "NestedRecord",
+          "type": "record",
+          "fields": [
+            {
+              "name": "sampleText1",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null,
+              "doc": "field just to make crowd and force FastDeserializerGenerator to create populate*() method"
+            },
+            {
+              "name": "deeplyNestedField",
+              "type": [
+                "null",
+                {
+                  "name": "DeeplyNestedRecord",
+                  "type": "record",
+                  "fields": [
+                    {
+                      "name": "deeplyDeeplyNestedText",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "default": null
+    }
+  ]
+}

--- a/fastserde/avro-fastserde-tests-common/src/test/avro/recordWith2FieldsAndDeeplyNestedRecord.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/recordWith2FieldsAndDeeplyNestedRecord.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "RecordWithOneNullableTextAndDeeplyNestedRecord",
   "namespace": "com.linkedin.avro.fastserde.generated.avro",
-  "doc": "Used in tests of fast-serde to verify populate-methods works correctly with DatumReaderCustomization. Just like OuterRecordWith2NestedBetaRecords but with one field more.",
+  "doc": "Used in tests of fast-serde to verify populate-methods works correctly with DatumReaderCustomization.",
   "fields": [
     {
       "name": "text",
@@ -48,7 +48,8 @@
                     }
                   ]
                 }
-              ]
+              ],
+              "doc": "One more level of nested-records is needed to generate deserialize*() method called by populate*() method"
             }
           ]
         }

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastSpecificDeserializerGeneratorTest.java
@@ -48,7 +48,6 @@ import org.apache.avro.util.Utf8;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 import org.testng.internal.collections.Pair;
@@ -904,20 +903,11 @@ public class FastSpecificDeserializerGeneratorTest {
 
     // when (serialized reach record is read with schema without 'nestedField')
     BinaryDecoder decoder = AvroCompatibilityHelper.newBinaryDecoder(serializedReachRecord);
-    /*- Below is commented out due to fast-serde compilation error:
-    avro-util/fastserde/avro-fastserde-tests111/./build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237.java:98: error: cannot find symbol
-                deserializeDeeplyNestedRecord0(null, (decoder), (customization));
-                                                                 ^
-    symbol:   variable customization
-    location: class RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237
-
-
     RecordWithOneNullableText liteRecord = decodeRecordFast(readerSchema, writerSchema, decoder);
 
     // then (fast-serde compilation and deserialization succeeds)
     Assert.assertNotNull(liteRecord);
     Assert.assertEquals(getField(liteRecord, "text").toString(), "I am from reach record");
-    */
   }
 
   /**

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1090641932_438987109.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_GenericDeserializer_1090641932_438987109.java
@@ -82,10 +82,10 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedNestedRecord_
         throws IOException
     {
         decoder.skipString();
-        populate_subSubRecord0((decoder));
+        populate_subSubRecord0((customization), (decoder));
     }
 
-    private void populate_subSubRecord0(Decoder decoder)
+    private void populate_subSubRecord0(DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_1932590611_1452595291.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_GenericDeserializer_1932590611_1452595291.java
@@ -96,10 +96,10 @@ public class FastGenericDeserializerGeneratorTest_shouldSkipRemovedRecord_Generi
         throws IOException
     {
         decoder.skipString();
-        populate_subRecord20((decoder));
+        populate_subRecord20((customization), (decoder));
     }
 
-    private void populate_subRecord20(Decoder decoder)
+    private void populate_subRecord20(DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         decoder.skipString();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237.java
@@ -1,0 +1,120 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import com.linkedin.avro.fastserde.generated.avro.RecordWithOneNullableText;
+import org.apache.avro.Schema;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237
+    implements FastDeserializer<RecordWithOneNullableText>
+{
+
+    private final Schema readerSchema;
+
+    public RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+    }
+
+    public RecordWithOneNullableText deserialize(RecordWithOneNullableText reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        return deserializeRecordWithOneNullableText0((reuse), (decoder), (customization));
+    }
+
+    public RecordWithOneNullableText deserializeRecordWithOneNullableText0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        RecordWithOneNullableText RecordWithOneNullableTextAndDeeplyNestedRecord;
+        if ((reuse)!= null) {
+            RecordWithOneNullableTextAndDeeplyNestedRecord = ((RecordWithOneNullableText)(reuse));
+        } else {
+            RecordWithOneNullableTextAndDeeplyNestedRecord = new RecordWithOneNullableText();
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+            RecordWithOneNullableTextAndDeeplyNestedRecord.put(0, null);
+        } else {
+            if (unionIndex0 == 1) {
+                Utf8 charSequence0;
+                Object oldString0 = RecordWithOneNullableTextAndDeeplyNestedRecord.get(0);
+                if (oldString0 instanceof Utf8) {
+                    charSequence0 = (decoder).readString(((Utf8) oldString0));
+                } else {
+                    charSequence0 = (decoder).readString(null);
+                }
+                RecordWithOneNullableTextAndDeeplyNestedRecord.put(0, charSequence0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'text': "+ unionIndex0));
+            }
+        }
+        populate_RecordWithOneNullableTextAndDeeplyNestedRecord0((RecordWithOneNullableTextAndDeeplyNestedRecord), (customization), (decoder));
+        return RecordWithOneNullableTextAndDeeplyNestedRecord;
+    }
+
+    private void populate_RecordWithOneNullableTextAndDeeplyNestedRecord0(RecordWithOneNullableText RecordWithOneNullableTextAndDeeplyNestedRecord, DatumReaderCustomization customization, Decoder decoder)
+        throws IOException
+    {
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex1 == 1) {
+                deserializeNestedRecord0(null, (decoder), (customization));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'nestedField': "+ unionIndex1));
+            }
+        }
+    }
+
+    public void deserializeNestedRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        int unionIndex2 = (decoder.readIndex());
+        if (unionIndex2 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex2 == 1) {
+                decoder.skipString();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'sampleText1': "+ unionIndex2));
+            }
+        }
+        populate_NestedRecord0((decoder));
+    }
+
+    private void populate_NestedRecord0(Decoder decoder)
+        throws IOException
+    {
+        int unionIndex3 = (decoder.readIndex());
+        if (unionIndex3 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex3 == 1) {
+                deserializeDeeplyNestedRecord0(null, (decoder), (customization));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'deeplyNestedField': "+ unionIndex3));
+            }
+        }
+    }
+
+    public void deserializeDeeplyNestedRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        int unionIndex4 = (decoder.readIndex());
+        if (unionIndex4 == 0) {
+            decoder.readNull();
+        } else {
+            if (unionIndex4 == 1) {
+                decoder.skipString();
+            } else {
+                throw new RuntimeException(("Illegal union index for 'deeplyDeeplyNestedText': "+ unionIndex4));
+            }
+        }
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithOneNullableText_SpecificDeserializer_2111230429_1009500237.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/RecordWithOneNullableText_SpecificDeserializer_2111230429_1009500237.java
@@ -9,13 +9,13 @@ import org.apache.avro.Schema;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237
+public class RecordWithOneNullableText_SpecificDeserializer_2111230429_1009500237
     implements FastDeserializer<RecordWithOneNullableText>
 {
 
     private final Schema readerSchema;
 
-    public RecordWithOneNullableText_SpecificDeserializer_1753906665_1009500237(Schema readerSchema) {
+    public RecordWithOneNullableText_SpecificDeserializer_2111230429_1009500237(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 
@@ -84,10 +84,10 @@ public class RecordWithOneNullableText_SpecificDeserializer_1753906665_100950023
                 throw new RuntimeException(("Illegal union index for 'sampleText1': "+ unionIndex2));
             }
         }
-        populate_NestedRecord0((decoder));
+        populate_NestedRecord0((customization), (decoder));
     }
 
-    private void populate_NestedRecord0(Decoder decoder)
+    private void populate_NestedRecord0(DatumReaderCustomization customization, Decoder decoder)
         throws IOException
     {
         int unionIndex3 = (decoder.readIndex());

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -370,16 +370,17 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
         popMethod._throws(IOException.class);
         if (recordAction.getShouldRead()) {
           popMethod.param(recordClass, recordName);
-          popMethod.param(codeModel.ref(DatumReaderCustomization.class), VAR_NAME_FOR_CUSTOMIZATION);
         }
+        popMethod.param(codeModel.ref(DatumReaderCustomization.class), VAR_NAME_FOR_CUSTOMIZATION);
         popMethod.param(Decoder.class, DECODER);
         popMethodBody = popMethod.body();
 
         JInvocation invocation = methodBody.invoke(popMethod);
         if (recordAction.getShouldRead()) {
           invocation.arg(JExpr.direct(recordName));
-          invocation.arg(customizationSupplier.get());
         }
+        // even if recordAction.getShouldRead() == false we need to generate 'customization' argument for javac purposes
+        invocation.arg(customizationSupplier.get());
         invocation.arg(JExpr.direct(DECODER));
       }
       FieldAction action = seekFieldAction(recordAction.getShouldRead(), field, actionIterator);

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -268,8 +268,10 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
     if (methodAlreadyDefined(recordWriterSchema, effectiveRecordReaderSchema, recordAction.getShouldRead())) {
       JMethod method = getMethod(recordWriterSchema, effectiveRecordReaderSchema, recordAction.getShouldRead());
       updateActualExceptions(method);
-      JExpression readingExpression = JExpr.invoke(method).arg(reuseSupplier.get()).arg(JExpr.direct(DECODER)).arg(
-          customizationSupplier.get());
+      JExpression readingExpression = JExpr.invoke(method)
+              .arg(reuseSupplier.get())
+              .arg(JExpr.direct(DECODER))
+              .arg(customizationSupplier.get());
       if (recordAction.getShouldRead()) {
         putRecordIntoParent.accept(parentBody, readingExpression);
       } else {
@@ -304,9 +306,15 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
     schemaAssistant.resetExceptionsFromStringable();
 
     if (recordAction.getShouldRead()) {
-      putRecordIntoParent.accept(parentBody, JExpr.invoke(method).arg(reuseSupplier.get()).arg(JExpr.direct(DECODER)).arg(customizationSupplier.get()));
+      putRecordIntoParent.accept(parentBody, JExpr.invoke(method)
+              .arg(reuseSupplier.get())
+              .arg(JExpr.direct(DECODER))
+              .arg(customizationSupplier.get()));
     } else {
-      parentBody.invoke(method).arg(reuseSupplier.get()).arg(JExpr.direct(DECODER)).arg(customizationSupplier.get());
+      parentBody.invoke(method)
+              .arg(reuseSupplier.get())
+              .arg(JExpr.direct(DECODER))
+              .arg(customizationSupplier.get());
     }
 
     JBlock methodBody = method.body();


### PR DESCRIPTION
Populate methods now always have 'customization' argument because deserialize-method(s) of nested records may generate another populate methods that require 'customization' (at least for compilation purposes).

This may happen when record is deserialized with schema having less fields (usually: older schema) AND `populate_...()` helper method is generated on a field for which `recordAction.getShouldRead() == false`, so a bit of bad-luck is also needed.

In the added unit-test, without fix the methods chain is:
```
deserialize(RecordWithOneNullableText reuse, Decoder decoder, DatumReaderCustomization customization)
--> deserializeRecordWithOneNullableText0((reuse), (decoder), (customization))
 --> populate_RecordWithOneNullableTextAndDeeplyNestedRecord0((RecordWithOneNullableTextAndDeeplyNestedRecord), (customization), (decoder));
  --> deserializeNestedRecord0(null, (decoder), (customization));
   --> populate_NestedRecord0((decoder));
    --> deserializeDeeplyNestedRecord0(null, (decoder), (customization)); // ! unknown 'customization' variable
```