### PR TITLE
Utf8 and String types supported in StringList√iew.addAll

### DIFF
--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/collectiontransformer/StringListView.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/collectiontransformer/StringListView.java
@@ -65,32 +65,12 @@ public class StringListView extends AbstractList<String> {
   @Override
   public boolean addAll(int index, java.util.Collection<? extends String> c) {
     boolean modified = false;
-    for (String element : c) {
-      _utf8List.add(index++, new Utf8(element));
-      modified = true;
-    }
-    return modified;
-  }
-
-  /**
-   * Overloaded method to add all Utf8 elements of a collection at a specific index.
-   */
-  public boolean addAll(int index, java.util.List<? extends Utf8> c) {
-    boolean modified = false;
-    for (Utf8 element : c) {
-      _utf8List.add(index++, element);
-      modified = true;
-    }
-    return modified;
-  }
-
-  /**
-   * Overloaded method to add all Utf8 elements of a set at a specific index.
-   */
-  public boolean addAll(int index, java.util.Set<? extends Utf8> c) {
-    boolean modified = false;
-    for (Utf8 element : c) {
-      _utf8List.add(index++, element);
+    for (Object element : c) {
+      if (element instanceof Utf8) {
+        _utf8List.add(index++, (Utf8) element);
+      } else {
+        _utf8List.add(index++, new Utf8(String.valueOf(element)));
+      }
       modified = true;
     }
     return modified;


### PR DESCRIPTION
Adding handling for Utf8 type in StringListView.addAll method.

Even if `addAll` method metions `<? extends String>`, this should still catch a collection of Utf8 elements as the compiled code does not have the generic information.

Hence we can type cast the object in the implementation.