### PR TITLE
The variable for a union should use a valid identifier

### DIFF
--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
@@ -246,7 +246,7 @@ public class FastSerializerGenerator<T, U extends GenericData> extends FastSerde
 
     final Schema elementSchema = arraySchema.getElementType();
     if (SchemaAssistant.isComplexType(elementSchema)) {
-      JVar containerVar = declareValueVar(elementSchema.getName(), elementSchema, forBody);
+      JVar containerVar = declareValueVar(getUniqueName("element"), elementSchema, forBody);
       forBody.assign(containerVar, JExpr.invoke(JExpr.cast(arrayClass, arrayExpr), getMethodName).arg(counter));
       processComplexType(elementSchema, containerVar, forBody, customizationSupplier);
     } else {
@@ -290,7 +290,7 @@ public class FastSerializerGenerator<T, U extends GenericData> extends FastSerde
 
     JVar containerVar;
     if (SchemaAssistant.isComplexType(valueSchema)) {
-      containerVar = declareValueVar(valueSchema.getName(), valueSchema, forBody);
+      containerVar = declareValueVar(getUniqueName("element"), valueSchema, forBody);
       forBody.assign(containerVar, JExpr.invoke(JExpr.cast(mapClass, mapExpr), "get").arg(mapKeysLoop.var()));
 
       processComplexType(valueSchema, containerVar, forBody, customizationSupplier);


### PR DESCRIPTION
This fixes https://github.com/linkedin/avro-util/issues/561 by ensuring that a valid Java identifier is used instead of `Schema.UnionSchema.getName()`.