### PR TITLE
Support custom logical types derived from fixed types

### DIFF
--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -297,9 +297,12 @@ public class SchemaAssistant<T extends GenericData> {
   /* Note that settings abstractType and rawType are not passed to subcalls */
   public JClass classFromSchema(Schema schema, boolean abstractType, boolean rawType, boolean primitiveList,
           boolean allowLogicalTypes) {
-    if (allowLogicalTypes && logicalTypeEnabled(schema)) {
+    if (logicalTypeEnabled(schema)) {
       Class<?> logicalTypeClass = ((Conversion<?>) getConversion(schema.getLogicalType())).getConvertedType();
-      return codeModel.ref(logicalTypeClass);
+      fullyQualifiedClassNameSet.add(logicalTypeClass.getName());
+      if (allowLogicalTypes) {
+        return codeModel.ref(logicalTypeClass);
+      }
     }
 
     JClass outputClass;


### PR DESCRIPTION
This fixes #564 by adding classes to the classpath for logical types even when `SchemaAssistant.classFromSchema` is passed `allowLogicalTypes=false`.

This change doesn't come with an accompanying test because the only way to write a failing test would be to build a separate subproject jar for a custom type and another subproject jar for a custom `Conversion` class for each Avro version. It could be done but would complicate the existing test infrastructure.