### PR TITLE
Use valid schema for Fixed field when deserializing data

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorTest.java
@@ -1,0 +1,61 @@
+package com.linkedin.avro.fastserde;
+
+import com.linkedin.avroutil1.compatibility.AvroCompatibilityHelper;
+import com.linkedin.avroutil1.compatibility.AvroSchemaUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericFixed;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+
+public class FastDeserializerGeneratorTest {
+  @Test
+  public void testSchemaForFixedField() throws IOException, InterruptedException {
+    if (Utils.isAvro14()) {
+      throw new SkipException("Avro 1.4 doesn't have schemas for GenericFixed type");
+    }
+
+    Schema writerSchema = AvroCompatibilityHelper.parse("{\"type\":\"record\",\"name\":\"topLevelRecord\",\"fields\":[{\"name\":\"fixedField\",\"type\":{\"type\":\"fixed\",\"name\":\"FixedType\",\"size\":5}}]}");
+    Schema readerSchema = AvroCompatibilityHelper.parse("{\"type\":\"record\",\"name\":\"topLevelRecord\",\"fields\":[{\"name\":\"fixedField\",\"type\":{\"type\":\"fixed\",\"name\":\"FixedType\",\"size\":5,\"newField\": \"New field to change something\"}}]}");
+
+    GenericRecord writtenRecord = new GenericData.Record(writerSchema);
+    writtenRecord.put("fixedField", AvroCompatibilityHelper.newFixed(writerSchema.getField("fixedField").schema(), new byte[]{1,2,3,4,5}));
+
+    byte[] writeBytes = serialize(writtenRecord);
+
+    FastGenericDatumReader datumReader = new FastGenericDatumReader(writerSchema, readerSchema, FastSerdeCache.getDefaultInstance());
+    while (!datumReader.isFastDeserializerUsed()) {
+      deserialize(datumReader, writeBytes);
+      Thread.sleep(100);
+    }
+
+    Object data = deserialize(datumReader, writeBytes);
+    GenericFixed fixedField = ((GenericFixed) ((GenericData.Record) data).get("fixedField"));
+
+    Schema fixedFieldSchema = AvroSchemaUtil.getDeclaredSchema(fixedField);
+    Assert.assertNotNull(fixedFieldSchema, "Schema for field must always be set.");
+  }
+
+  private byte[] serialize(GenericRecord record) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    Encoder encoder = AvroCompatibilityHelper.newBinaryEncoder(baos, false, null);
+
+    DatumWriter datumWriter = new FastGenericDatumWriter(record.getSchema(), FastSerdeCache.getDefaultInstance());
+    datumWriter.write(record, encoder);
+    encoder.flush();
+
+    return baos.toByteArray();
+  }
+
+  private Object deserialize(DatumReader datumReader, byte[] bytes) throws IOException {
+    return datumReader.read(null, AvroCompatibilityHelper.newBinaryDecoder(bytes));
+  }
+}

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDeserializerGeneratorTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 
 public class FastDeserializerGeneratorTest {
   @Test
-  public void testSchemaForFixedField() throws IOException, InterruptedException {
+  public void testDeserializationOfFixedField() throws IOException, InterruptedException {
     if (Utils.isAvro14()) {
       throw new SkipException("Avro 1.4 doesn't have schemas for GenericFixed type");
     }
@@ -27,7 +27,9 @@ public class FastDeserializerGeneratorTest {
     Schema readerSchema = AvroCompatibilityHelper.parse("{\"type\":\"record\",\"name\":\"topLevelRecord\",\"fields\":[{\"name\":\"fixedField\",\"type\":{\"type\":\"fixed\",\"name\":\"FixedType\",\"size\":5,\"newField\": \"New field to change something\"}}]}");
 
     GenericRecord writtenRecord = new GenericData.Record(writerSchema);
-    writtenRecord.put("fixedField", AvroCompatibilityHelper.newFixed(writerSchema.getField("fixedField").schema(), new byte[]{1,2,3,4,5}));
+
+    byte[] writtenFixedFieldData = new byte[]{1,2,3,4,5};
+    writtenRecord.put("fixedField", AvroCompatibilityHelper.newFixed(writerSchema.getField("fixedField").schema(), writtenFixedFieldData));
 
     byte[] writeBytes = serialize(writtenRecord);
 
@@ -42,6 +44,7 @@ public class FastDeserializerGeneratorTest {
 
     Schema fixedFieldSchema = AvroSchemaUtil.getDeclaredSchema(fixedField);
     Assert.assertNotNull(fixedFieldSchema, "Schema for field must always be set.");
+    Assert.assertEquals(fixedField.bytes(), writtenFixedFieldData);
   }
 
   private byte[] serialize(GenericRecord record) throws IOException {

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -214,7 +214,12 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
         processEnum(readerSchema, methodBody, action, putExpressionIntoParent);
         break;
       case FIXED:
-        processFixed(schema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+        // to preserve reader fixed specific options use reader field schema
+        if (action.getShouldRead() && readerSchema != null && Schema.Type.FIXED.equals(readerSchema.getType())) {
+          processFixed(readerSchema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+        } else {
+          processFixed(schema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+        }
         break;
       default:
         // to preserve reader string specific options use reader field schema

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -214,20 +214,24 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
         processEnum(readerSchema, methodBody, action, putExpressionIntoParent);
         break;
       case FIXED:
-        // to preserve reader fixed specific options use reader field schema
+        final Schema fixedFieldSchema;
         if (action.getShouldRead() && readerSchema != null && Schema.Type.FIXED.equals(readerSchema.getType())) {
-          processFixed(readerSchema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+          // to preserve reader-specific options use reader field schema
+          fixedFieldSchema = readerSchema;
         } else {
-          processFixed(schema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+          fixedFieldSchema = schema;
         }
+        processFixed(fixedFieldSchema, methodBody, action, putExpressionIntoParent, reuseSupplier);
         break;
       default:
-        // to preserve reader string specific options use reader field schema
+        final Schema primitiveFieldSchema;
         if (action.getShouldRead() && readerSchema != null && Schema.Type.STRING.equals(readerSchema.getType())) {
-          processPrimitive(readerSchema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+          // to preserve reader-specific options use reader field schema
+          primitiveFieldSchema = readerSchema;
         } else {
-          processPrimitive(schema, methodBody, action, putExpressionIntoParent, reuseSupplier);
+          primitiveFieldSchema = schema;
         }
+        processPrimitive(primitiveFieldSchema, methodBody, action, putExpressionIntoParent, reuseSupplier);
         break;
     }
   }


### PR DESCRIPTION
When reader and writer schemas are different for fields of type `Fixed`, the deserialized objects are created with `null` schema. This commit fixes that handling and adds a test case for it

Without the fix, the generated class has this:
```
topLevelRecord.put(0, new org.apache.avro.generic.GenericData.Fixed(null, fixedType0));
```

With the fix, the generated class has this:
```
topLevelRecord.put(0, new org.apache.avro.generic.GenericData.Fixed(fixedField0, fixedType0));
```