### PR TITLE
Limit the max log size for schema in warning.

### DIFF
--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastGenericDatumReader.java
@@ -116,8 +116,21 @@ public class FastGenericDatumReader<T> implements DatumReader<T> {
             */
           cachedFastDeserializer.compareAndSet(null,
               getRegularAvroImplWhenGenerationFail(writerSchema, readerSchema, modelData, customization));
-          LOGGER.warn("FastGenericDeserializer generation fails, and will cache cold deserializer "
-              + "for reader schema: [" + readerSchema + "], writer schema: [" + writerSchema + "]");
+
+          LOGGER.warn("FastGenericDeserializer generation fails, and will cache cold deserializer for "
+              + "reader schema: [" + Utils.getTruncateSchemaForWarning(readerSchema) + "],"
+              + "writer schema: [" + Utils.getTruncateSchemaForWarning(writerSchema) + "].");
+
+          if (LOGGER.isDebugEnabled()) {
+            String readerSchemaStr = readerSchema.toString();
+            String writerSchemaStr = writerSchema.toString();
+            if (readerSchemaStr.length() > Utils.MAX_SCHEMA_LENGTH_IN_WARNING ||
+                writerSchemaStr.length() > Utils.MAX_SCHEMA_LENGTH_IN_WARNING) {
+              LOGGER.debug("FastGenericDeserializer generation fails, and will cache cold deserializer for "
+                  + "reader schema: [" + readerSchemaStr + "],"
+                  + "writer schema: [" + writerSchemaStr + "].");
+            }
+          }
         }
         fastDeserializer = cachedFastDeserializer.get();
       } else {

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
@@ -55,6 +55,9 @@ public class Utils {
   // Cache the mapping between Schema and the corresponding fingerprint
   private static final Map<Schema, Integer> SCHEMA_IDS_CACHE = new ConcurrentHashMap<>();
 
+  // Limit max schema length in WARNING logs.
+  static final int MAX_SCHEMA_LENGTH_IN_WARNING = 100;
+
   private Utils() {
   }
 
@@ -258,5 +261,15 @@ public class Utils {
     }
 
     return javaIdentifier;
+  }
+
+  static String getTruncateSchemaForWarning(Schema schema) {
+    if (schema == null) {
+      return "null";
+    }
+    String schemaString = schema.toString();
+    return (schemaString.length() > MAX_SCHEMA_LENGTH_IN_WARNING)
+        ? schemaString.substring(0, MAX_SCHEMA_LENGTH_IN_WARNING) + "..."
+        : schemaString;
   }
 }


### PR DESCRIPTION
Limit the max log size for schema in warning.

More background: Some users transit the warning log via network. When the schema is large, it adds a lot of burden to network.