### PR TITLE
Fix incorrect check for enableUtf8encoding flag

### DIFF
--- a/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
+++ b/avro-builder/builder/src/main/java/com/linkedin/avroutil1/builder/SchemaBuilder.java
@@ -250,7 +250,7 @@ public class SchemaBuilder {
     if (options.has(enableUtf8Encoding)) {
       String value = options.valueOf(enableUtf8Encoding);
       handleUtf8Encoding = Boolean.TRUE.equals(Boolean.parseBoolean(value));
-      if (handleUtf8Encoding) {
+      if (!handleUtf8Encoding) {
         if (methodStringRepresentation.equals(StringRepresentation.CharSequence) && stringRepresentation.equals(
             StringRepresentation.CharSequence)) {
           handleUtf8EncodingInPutByIndex = handleUtf8Encoding;


### PR DESCRIPTION
Fix incorrect check for enableUtf8encoding flag. The incorrect check was preventing from setting/overriding enableUtf8EncodingPutbyIndex flag correctly.