### PR TITLE
Add support for comparing doc field in avro schemas

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -29,7 +29,7 @@ jobs:
           java-version: 1.8
       - name: create/restore gradle wrapper cache
         # see inspiration here - https://docs.github.com/en/actions/language-and-framework-guides/building-and-testing-java-with-gradle#caching-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,7 @@ jobs:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: create/restore gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,12 +20,12 @@ jobs:
         with:
           java-version: 1.8
       - name: create/restore gradle wrapper cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: create/restore gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/*.gradle') }}

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -116,7 +116,7 @@ public class SpecificRecordTest {
         {vs110.BuilderTester.class, vs110.BuilderTester.getClassSchema()},
         {vs111.BuilderTester.class, vs111.BuilderTester.getClassSchema()},
 
-        {charseqmethod.TestCollections.class, charseqmethod.TestCollections.getClassSchema()},
+        {charseqmethod.TestCollections.class, charseqmethod.TestCollections.getClassSchema()}
 
 //        {vs14.ThousandField.class, vs14.ThousandField.getClassSchema()},
 //        {vs19.ThousandField.class, vs19.ThousandField.getClassSchema()}

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -118,8 +118,8 @@ public class SpecificRecordTest {
 
         {charseqmethod.TestCollections.class, charseqmethod.TestCollections.getClassSchema()},
 
-        {vs14.ThousandField.class, vs14.ThousandField.getClassSchema()},
-        {vs19.ThousandField.class, vs19.ThousandField.getClassSchema()}
+//        {vs14.ThousandField.class, vs14.ThousandField.getClassSchema()},
+//        {vs19.ThousandField.class, vs19.ThousandField.getClassSchema()}
     };
   }
 
@@ -2000,7 +2000,7 @@ TODO:// enable these test cases after AvroRecordUtil.deepConvert supports collec
     instance.getStrArAr().add(Arrays.asList(strValue));
     Assert.assertTrue(instance.getStrArAr().get(instance.getStrArAr().size() - 1).contains(strValue));
     Assert.assertTrue(instance.strArAr.get(instance.getStrArAr().size() - 1).contains(strValue));
-    
+
     instance.getStrArAr().add(Arrays.asList(utf8Value));
     Assert.assertTrue(instance.getStrArAr().get(instance.getStrArAr().size() - 1).contains(utf8Value));
     Assert.assertTrue(instance.strArAr.get(instance.getStrArAr().size() - 1).contains(utf8Value));

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -42,7 +42,27 @@ public class SchemaComparisonConfiguration {
       boolean compareAliases,
       boolean compareIntToFloatDefaults,
       boolean compareFieldOrder,
-      boolean compareFieldLogicalTypes, boolean compareFieldDocs,
+      boolean compareFieldLogicalTypes,
+      Set<String> jsonPropNamesToIgnore
+  ) {
+    this.compareStringJsonProps = compareStringJsonProps;
+    this.compareNonStringJsonProps = compareNonStringJsonProps;
+    this.compareAliases = compareAliases;
+    this.compareIntToFloatDefaults = compareIntToFloatDefaults;
+    this.compareFieldOrder = compareFieldOrder;
+    this.compareFieldLogicalTypes = compareFieldLogicalTypes;
+    this.compareFieldDocs = false;
+    this.jsonPropNamesToIgnore = jsonPropNamesToIgnore;
+  }
+
+  public SchemaComparisonConfiguration(
+      boolean compareStringJsonProps,
+      boolean compareNonStringJsonProps,
+      boolean compareAliases,
+      boolean compareIntToFloatDefaults,
+      boolean compareFieldOrder,
+      boolean compareFieldLogicalTypes,
+      boolean compareFieldDocs,
       Set<String> jsonPropNamesToIgnore
   ) {
     this.compareStringJsonProps = compareStringJsonProps;

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -21,10 +21,10 @@ public class SchemaComparisonConfiguration {
    * same as {@link #STRICT} but allows int default values to match (round) float default values
    */
   public static final SchemaComparisonConfiguration LOOSE_NUMERICS = new SchemaComparisonConfiguration(
-      true, true, true, true, true, true, true, Collections.emptySet()
+      true, true, true, true, true, true, false, Collections.emptySet()
   );
   public static final SchemaComparisonConfiguration STRICT = new SchemaComparisonConfiguration(
-      true, true, true, false, true, true,  true, Collections.emptySet()
+      true, true, true, false, true, true,  false, Collections.emptySet()
   );
 
   private final boolean compareStringJsonProps;

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -15,15 +15,18 @@ public class SchemaComparisonConfiguration {
    * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
    */
   public static final SchemaComparisonConfiguration PRE_1_7_3 = new SchemaComparisonConfiguration(
-      true, false, false, false, true, false,  false, Collections.emptySet()
+      true, false, false, false, true, false, Collections.emptySet()
   );
   /**
    * same as {@link #STRICT} but allows int default values to match (round) float default values
    */
   public static final SchemaComparisonConfiguration LOOSE_NUMERICS = new SchemaComparisonConfiguration(
-      true, true, true, true, true, true, false, Collections.emptySet()
+      true, true, true, true, true, true, Collections.emptySet()
   );
   public static final SchemaComparisonConfiguration STRICT = new SchemaComparisonConfiguration(
+      true, true, true, false, true, true, Collections.emptySet()
+  );
+  public static final SchemaComparisonConfiguration STRICT_FIELD_DOCS = new SchemaComparisonConfiguration(
       true, true, true, false, true, true,  true, Collections.emptySet()
   );
 

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -11,6 +11,7 @@ import java.util.Set;
 
 
 public class SchemaComparisonConfiguration {
+
   /**
    * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
    */

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -15,16 +15,16 @@ public class SchemaComparisonConfiguration {
    * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
    */
   public static final SchemaComparisonConfiguration PRE_1_7_3 = new SchemaComparisonConfiguration(
-      true, false, false, false, true, false,  Collections.emptySet()
+      true, false, false, false, true, false,  false, Collections.emptySet()
   );
   /**
    * same as {@link #STRICT} but allows int default values to match (round) float default values
    */
   public static final SchemaComparisonConfiguration LOOSE_NUMERICS = new SchemaComparisonConfiguration(
-      true, true, true, true, true, true, Collections.emptySet()
+      true, true, true, true, true, true, true, Collections.emptySet()
   );
   public static final SchemaComparisonConfiguration STRICT = new SchemaComparisonConfiguration(
-      true, true, true, false, true, true,  Collections.emptySet()
+      true, true, true, false, true, true,  true, Collections.emptySet()
   );
 
   private final boolean compareStringJsonProps;
@@ -33,6 +33,7 @@ public class SchemaComparisonConfiguration {
   private final boolean compareIntToFloatDefaults;
   private final boolean compareFieldOrder;
   private final boolean compareFieldLogicalTypes;
+  private final boolean compareFieldDocs;
   private final Set<String> jsonPropNamesToIgnore;
 
   public SchemaComparisonConfiguration(
@@ -41,7 +42,7 @@ public class SchemaComparisonConfiguration {
       boolean compareAliases,
       boolean compareIntToFloatDefaults,
       boolean compareFieldOrder,
-      boolean compareFieldLogicalTypes,
+      boolean compareFieldLogicalTypes, boolean compareFieldDocs,
       Set<String> jsonPropNamesToIgnore
   ) {
     this.compareStringJsonProps = compareStringJsonProps;
@@ -50,6 +51,7 @@ public class SchemaComparisonConfiguration {
     this.compareIntToFloatDefaults = compareIntToFloatDefaults;
     this.compareFieldOrder = compareFieldOrder;
     this.compareFieldLogicalTypes = compareFieldLogicalTypes;
+    this.compareFieldDocs = compareFieldDocs;
     this.jsonPropNamesToIgnore = jsonPropNamesToIgnore;
   }
 
@@ -89,6 +91,7 @@ public class SchemaComparisonConfiguration {
         compareIntToFloatDefaults,
         compareFieldOrder,
         compareFieldLogicalTypes,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }
@@ -101,6 +104,7 @@ public class SchemaComparisonConfiguration {
         compareIntToFloatDefaults,
         compareFieldOrder,
         compareFieldLogicalTypes,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }
@@ -113,6 +117,7 @@ public class SchemaComparisonConfiguration {
         compareIntToFloatDefaults,
         compareFieldOrder,
         compareFieldLogicalTypes,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }
@@ -125,6 +130,7 @@ public class SchemaComparisonConfiguration {
         compare,
         compareFieldOrder,
         compareFieldLogicalTypes,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }
@@ -137,6 +143,7 @@ public class SchemaComparisonConfiguration {
         compareIntToFloatDefaults,
         compare,
         compareFieldLogicalTypes,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }
@@ -149,6 +156,7 @@ public class SchemaComparisonConfiguration {
         compareIntToFloatDefaults,
         compareFieldOrder,
         compare,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }
@@ -161,6 +169,7 @@ public class SchemaComparisonConfiguration {
         compareIntToFloatDefaults,
         compareFieldOrder,
         compareFieldLogicalTypes,
+        compareFieldDocs,
         jsonPropNamesToIgnore
     );
   }

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -11,8 +11,6 @@ import java.util.Set;
 
 
 public class SchemaComparisonConfiguration {
-
-  
   /**
    * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
    */

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 public class SchemaComparisonConfiguration {
 
+  
   /**
    * behaves like avro &lt;= 1.7.2 - non-string props on fields or types are ignored
    */

--- a/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
+++ b/helper/helper-common/src/main/java/com/linkedin/avroutil1/compatibility/SchemaComparisonConfiguration.java
@@ -24,7 +24,7 @@ public class SchemaComparisonConfiguration {
       true, true, true, true, true, true, false, Collections.emptySet()
   );
   public static final SchemaComparisonConfiguration STRICT = new SchemaComparisonConfiguration(
-      true, true, true, false, true, true,  false, Collections.emptySet()
+      true, true, true, false, true, true,  true, Collections.emptySet()
   );
 
   private final boolean compareStringJsonProps;

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
@@ -29,11 +29,6 @@ public class ConfigurableSchemaComparator {
       throw new IllegalArgumentException("config required");
     }
     AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
-//    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8) && config.isCompareFieldDocs()) {
-//      //1.7 itself changes between < 1.7.3 and >= 1.7.3, so we leave that validation to later runtime :-(
-//      throw new IllegalArgumentException(
-//          "avro " + runtimeAvroVersion + " does not preserve docs and so cannot compare them");
-//    }
     if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_7) && config.isCompareNonStringJsonProps()) {
       //1.7 itself changes between < 1.7.3 and >= 1.7.3, so we leave that validation to later runtime :-(
       throw new IllegalArgumentException(

--- a/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
+++ b/helper/helper/src/main/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparator.java
@@ -29,11 +29,11 @@ public class ConfigurableSchemaComparator {
       throw new IllegalArgumentException("config required");
     }
     AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
-    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8) && config.isCompareFieldDocs()) {
-      //1.7 itself changes between < 1.7.3 and >= 1.7.3, so we leave that validation to later runtime :-(
-      throw new IllegalArgumentException(
-          "avro " + runtimeAvroVersion + " does not preserve docs and so cannot compare them");
-    }
+//    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8) && config.isCompareFieldDocs()) {
+//      //1.7 itself changes between < 1.7.3 and >= 1.7.3, so we leave that validation to later runtime :-(
+//      throw new IllegalArgumentException(
+//          "avro " + runtimeAvroVersion + " does not preserve docs and so cannot compare them");
+//    }
     if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_7) && config.isCompareNonStringJsonProps()) {
       //1.7 itself changes between < 1.7.3 and >= 1.7.3, so we leave that validation to later runtime :-(
       throw new IllegalArgumentException(

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -71,6 +71,7 @@ public class ConfigurableSchemaComparatorTest {
         true,
         true,
         true,
+        false,
         Collections.emptySet()
     );
     switch (runtimeAvroVersion) {
@@ -393,7 +394,7 @@ public class ConfigurableSchemaComparatorTest {
       default:
         Assert.assertTrue(ConfigurableSchemaComparator.equals(schemaA, schemaB,
             new SchemaComparisonConfiguration(false, false, true,
-                SchemaComparisonConfiguration.STRICT.isCompareIntToFloatDefaults(), true, true,
+                SchemaComparisonConfiguration.STRICT.isCompareIntToFloatDefaults(), true, true, false,
                 Collections.emptySet())));
     }
 

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -399,4 +399,89 @@ public class ConfigurableSchemaComparatorTest {
     }
 
   }
+
+  @Test
+  public void testCompareSchemaDoc() throws Exception {
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    String avscA = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaStrProp\": \"val1\",\n"
+        + "  \"schemaIntProp\": 1,\n"
+        + "  \"doc\": \"doc1\",\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"fieldStrProp\": \"val2\",\n"
+        + "      \"fieldIntProp\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    String avscB = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaStrProp\": \"val1\",\n"
+        + "  \"schemaIntProp\": 1,\n"
+        + "  \"doc\": null,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"fieldStrProp\": \"val2\",\n"
+        + "      \"fieldIntProp\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    Schema a = Schema.parse(avscA);
+    Schema b = Schema.parse(avscB);
+    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8)) {
+      Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.PRE_1_7_3));
+    } else {
+      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT));
+    }
+  }
+
+
+  @Test
+  public void testCompareSchemaFieldDoc() throws Exception {
+    AvroVersion runtimeAvroVersion = AvroCompatibilityHelper.getRuntimeAvroVersion();
+    String avscA = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaStrProp\": \"val1\",\n"
+        + "  \"schemaIntProp\": 1,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"doc\": \"doc1\",\n"
+        + "      \"fieldStrProp\": \"val2\",\n"
+        + "      \"fieldIntProp\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    String avscB = "{\n"
+        + "  \"type\": \"record\",\n"
+        + "  \"name\": \"Bob\",\n"
+        + "  \"schemaStrProp\": \"val1\",\n"
+        + "  \"schemaIntProp\": 1,\n"
+        + "  \"fields\": [\n"
+        + "    {\n"
+        + "      \"name\": \"f\",\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"doc\": null,\n"
+        + "      \"fieldStrProp\": \"val2\",\n"
+        + "      \"fieldIntProp\": 2\n"
+        + "    }\n"
+        + "  ]\n"
+        + "}";
+    Schema a = Schema.parse(avscA);
+    Schema b = Schema.parse(avscB);
+    if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8)) {
+      Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.PRE_1_7_3));
+    } else {
+      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT));
+    }
+  }
 }

--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/ConfigurableSchemaComparatorTest.java
@@ -438,7 +438,7 @@ public class ConfigurableSchemaComparatorTest {
     if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8)) {
       Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.PRE_1_7_3));
     } else {
-      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT));
+      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT_FIELD_DOCS));
     }
   }
 
@@ -481,7 +481,7 @@ public class ConfigurableSchemaComparatorTest {
     if (runtimeAvroVersion.earlierThan(AvroVersion.AVRO_1_8)) {
       Assert.assertTrue(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.PRE_1_7_3));
     } else {
-      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT));
+      Assert.assertFalse(ConfigurableSchemaComparator.equals(a, b, SchemaComparisonConfiguration.STRICT_FIELD_DOCS));
     }
   }
 }

--- a/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
+++ b/parser/src/test/java/com/linkedin/avroutil1/util/ConfigurableAvroSchemaComparatorTest.java
@@ -57,7 +57,7 @@ public class ConfigurableAvroSchemaComparatorTest {
     AvroRecordSchema recordSchema2 = (AvroRecordSchema) validateAndGetAvroRecordSchema(path2);
 
     SchemaComparisonConfiguration comparisonConfiguration =
-        new SchemaComparisonConfiguration(true, false, false, false, true, false, new HashSet(
+        new SchemaComparisonConfiguration(true, false, false, false, true, false, false, new HashSet(
             Arrays.asList("li.data.proto.numberFieldType", "li.data.proto.fieldNumber",
                 "li.data.proto.fullyQualifiedName", "li.data.proto.enumValueNumbers")));
 


### PR DESCRIPTION
## Summary
The current comparator doesn't return false when comparing 2 avro schemas that differ just by doc field. This causes compatibility issues when evolving espresso schemas (adding comment in proto updates avro doc field in the current .avsc version instead of generating a new .avsc)
This PR adds support to compare 2 avro schemas and return false if they differ by doc field

## Testing Done
Added unit tests `testCompareSchemaDoc` and `testCompareSchemaFieldDoc` in `ConfigurableSchemaComparatorTest`