### PR TITLE
Compatible Record In Union Lookup Should Use Unqualified Name

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -320,12 +320,20 @@ public class FastGenericDeserializerGeneratorTest {
     originalRecord.put("innerRecord", innerRecord);
 
     // when
-    GenericRecord record = implementation.decode(writerSchema, readerSchema, genericDataAsDecoder(originalRecord));
-
-    // then
-    Assert.assertEquals(new Utf8("abc"), record.get("optionalString"));
-    GenericRecord innerRecordDecoded = (GenericRecord) record.get("innerRecord");
-    Assert.assertEquals(1, innerRecordDecoded.get("intField"));
+    try{
+      GenericRecord record = implementation.decode(writerSchema, readerSchema, genericDataAsDecoder(originalRecord));
+      // then
+      if(Utils.usesQualifiedNameForNamedTypedMatching()){
+        Assert.fail("1.5-1.7 don't support unqualified name for named type matching so we should have failed");
+      }
+      Assert.assertEquals(new Utf8("abc"), record.get("optionalString"));
+      GenericRecord innerRecordDecoded = (GenericRecord) record.get("innerRecord");
+      Assert.assertEquals(1, innerRecordDecoded.get("intField"));
+    } catch (Exception e){
+      if(!Utils.usesQualifiedNameForNamedTypedMatching()) {
+        Assert.fail("1.4, and 1.8+ support unqualified name for named type matching");
+      }
+    }
   }
 
   @Test(groups = {"deserializationTest"}, dataProvider = "Implementation")

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/OuterRecord_GenericDeserializer_998347834_1261326440.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/OuterRecord_GenericDeserializer_998347834_1261326440.java
@@ -1,0 +1,84 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class OuterRecord_GenericDeserializer_998347834_1261326440
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema optionalString0;
+    private final Schema innerRecord0;
+    private final Schema innerRecordNameRecordSchema0;
+
+    public OuterRecord_GenericDeserializer_998347834_1261326440(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.optionalString0 = readerSchema.getField("optionalString").schema();
+        this.innerRecord0 = readerSchema.getField("innerRecord").schema();
+        this.innerRecordNameRecordSchema0 = innerRecord0 .getTypes().get(1);
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        return deserializeOuterRecord0((reuse), (decoder), (customization));
+    }
+
+    public IndexedRecord deserializeOuterRecord0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        IndexedRecord outerRecord0;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            outerRecord0 = ((IndexedRecord)(reuse));
+        } else {
+            outerRecord0 = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+            outerRecord0 .put(0, null);
+        } else {
+            if (unionIndex0 == 1) {
+                Utf8 charSequence0;
+                Object oldString0 = outerRecord0 .get(0);
+                if (oldString0 instanceof Utf8) {
+                    charSequence0 = (decoder).readString(((Utf8) oldString0));
+                } else {
+                    charSequence0 = (decoder).readString(null);
+                }
+                outerRecord0 .put(0, charSequence0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'optionalString': "+ unionIndex0));
+            }
+        }
+        populate_OuterRecord0((outerRecord0), (customization), (decoder));
+        return outerRecord0;
+    }
+
+    private void populate_OuterRecord0(IndexedRecord outerRecord0, DatumReaderCustomization customization, Decoder decoder)
+        throws IOException
+    {
+        outerRecord0 .put(1, deserializeinnerRecordName0(outerRecord0 .get(1), (decoder), (customization)));
+    }
+
+    public IndexedRecord deserializeinnerRecordName0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        IndexedRecord innerRecordName0;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == innerRecordNameRecordSchema0)) {
+            innerRecordName0 = ((IndexedRecord)(reuse));
+        } else {
+            innerRecordName0 = new org.apache.avro.generic.GenericData.Record(innerRecordNameRecordSchema0);
+        }
+        innerRecordName0 .put(0, (decoder.readInt()));
+        return innerRecordName0;
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Wrapper_GenericDeserializer_1221519218_203960580.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Wrapper_GenericDeserializer_1221519218_203960580.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Wrapper_GenericDeserializer_1221519218_203960580
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema metadata0;
+    private final Schema metadataOptionSchema0;
+    private final Schema productTypeUUID0;
+
+    public Wrapper_GenericDeserializer_1221519218_203960580(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.metadata0 = readerSchema.getField("metadata").schema();
+        this.metadataOptionSchema0 = metadata0 .getTypes().get(1);
+        this.productTypeUUID0 = metadataOptionSchema0 .getField("productTypeUUID").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        return deserializeWrapper0((reuse), (decoder), (customization));
+    }
+
+    public IndexedRecord deserializeWrapper0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        IndexedRecord wrapper0;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            wrapper0 = ((IndexedRecord)(reuse));
+        } else {
+            wrapper0 = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+            wrapper0 .put(0, null);
+        } else {
+            if (unionIndex0 == 1) {
+                wrapper0 .put(0, deserializemetadata0(wrapper0 .get(0), (decoder), (customization)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'metadata': "+ unionIndex0));
+            }
+        }
+        return wrapper0;
+    }
+
+    public IndexedRecord deserializemetadata0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        IndexedRecord metadata1;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == metadataOptionSchema0)) {
+            metadata1 = ((IndexedRecord)(reuse));
+        } else {
+            metadata1 = new org.apache.avro.generic.GenericData.Record(metadataOptionSchema0);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
+            decoder.readNull();
+            metadata1 .put(0, null);
+        } else {
+            if (unionIndex1 == 1) {
+                Utf8 charSequence0;
+                Object oldString0 = metadata1 .get(0);
+                if (oldString0 instanceof Utf8) {
+                    charSequence0 = (decoder).readString(((Utf8) oldString0));
+                } else {
+                    charSequence0 = (decoder).readString(null);
+                }
+                metadata1 .put(0, charSequence0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'productTypeUUID': "+ unionIndex1));
+            }
+        }
+        return metadata1;
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Wrapper_GenericDeserializer_977858399_369594598.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Wrapper_GenericDeserializer_977858399_369594598.java
@@ -1,0 +1,87 @@
+
+package com.linkedin.avro.fastserde.generated.deserialization.AVRO_1_11;
+
+import java.io.IOException;
+import com.linkedin.avro.fastserde.FastDeserializer;
+import com.linkedin.avro.fastserde.customized.DatumReaderCustomization;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.util.Utf8;
+
+public class Wrapper_GenericDeserializer_977858399_369594598
+    implements FastDeserializer<IndexedRecord>
+{
+
+    private final Schema readerSchema;
+    private final Schema metadata0;
+    private final Schema metadataOptionSchema0;
+    private final Schema fieldName0;
+
+    public Wrapper_GenericDeserializer_977858399_369594598(Schema readerSchema) {
+        this.readerSchema = readerSchema;
+        this.metadata0 = readerSchema.getField("metadata").schema();
+        this.metadataOptionSchema0 = metadata0 .getTypes().get(1);
+        this.fieldName0 = metadataOptionSchema0 .getField("fieldName").schema();
+    }
+
+    public IndexedRecord deserialize(IndexedRecord reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        return deserializeWrapper0((reuse), (decoder), (customization));
+    }
+
+    public IndexedRecord deserializeWrapper0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        IndexedRecord wrapper0;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == readerSchema)) {
+            wrapper0 = ((IndexedRecord)(reuse));
+        } else {
+            wrapper0 = new org.apache.avro.generic.GenericData.Record(readerSchema);
+        }
+        int unionIndex0 = (decoder.readIndex());
+        if (unionIndex0 == 0) {
+            decoder.readNull();
+            wrapper0 .put(0, null);
+        } else {
+            if (unionIndex0 == 1) {
+                wrapper0 .put(0, deserializemetadata0(wrapper0 .get(0), (decoder), (customization)));
+            } else {
+                throw new RuntimeException(("Illegal union index for 'metadata': "+ unionIndex0));
+            }
+        }
+        return wrapper0;
+    }
+
+    public IndexedRecord deserializemetadata0(Object reuse, Decoder decoder, DatumReaderCustomization customization)
+        throws IOException
+    {
+        IndexedRecord metadata1;
+        if ((((reuse)!= null)&&((reuse) instanceof IndexedRecord))&&(((IndexedRecord)(reuse)).getSchema() == metadataOptionSchema0)) {
+            metadata1 = ((IndexedRecord)(reuse));
+        } else {
+            metadata1 = new org.apache.avro.generic.GenericData.Record(metadataOptionSchema0);
+        }
+        int unionIndex1 = (decoder.readIndex());
+        if (unionIndex1 == 0) {
+            decoder.readNull();
+            metadata1 .put(0, null);
+        } else {
+            if (unionIndex1 == 1) {
+                Utf8 charSequence0;
+                Object oldString0 = metadata1 .get(0);
+                if (oldString0 instanceof Utf8) {
+                    charSequence0 = (decoder).readString(((Utf8) oldString0));
+                } else {
+                    charSequence0 = (decoder).readString(null);
+                }
+                metadata1 .put(0, charSequence0);
+            } else {
+                throw new RuntimeException(("Illegal union index for 'fieldName': "+ unionIndex1));
+            }
+        }
+        return metadata1;
+    }
+
+}

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -663,10 +663,7 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
             Schema potentialReaderSchema = unionReaderSchema.getTypes().get(j);
             // Avro allows unnamed types to appear only once in a union, but named types may appear multiple times and
             // thus need to be disambiguated via their full-name (including aliases).
-            if (potentialReaderSchema.getType().equals(optionSchema.getType()) &&
-                (!schemaAssistant.isNamedType(potentialReaderSchema) ||
-                    AvroCompatibilityHelper.getSchemaFullName(potentialReaderSchema).equals(AvroCompatibilityHelper.getSchemaFullName(optionSchema)) ||
-                    potentialReaderSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(optionSchema)))) {
+            if (schemaAssistant.areTypesCompatible(potentialReaderSchema, optionSchema)) {
               readerOptionSchema = potentialReaderSchema;
               readerOptionUnionBranchIndex = j;
               break;

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -578,10 +578,7 @@ public class SchemaAssistant<T extends GenericData> {
   public int compatibleUnionSchemaIndex(Schema schema, Schema unionSchema) {
     for (int i = 0; i < unionSchema.getTypes().size(); i++) {
       Schema potentialCompatibleSchema = unionSchema.getTypes().get(i);
-      if (potentialCompatibleSchema.getType().equals(schema.getType()) &&
-              (!isNamedType(potentialCompatibleSchema) ||
-                      potentialCompatibleSchema.getName().equals(schema.getName()) ||
-                      potentialCompatibleSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(schema)))) {
+      if (areTypesCompatible(schema, potentialCompatibleSchema)) {
         return i;
       }
     }
@@ -590,5 +587,22 @@ public class SchemaAssistant<T extends GenericData> {
 
   public Schema compatibleUnionSchema(Schema schema, Schema unionSchema) {
     return unionSchema.getTypes().get(compatibleUnionSchemaIndex(schema, unionSchema));
+  }
+
+  private boolean areTypesCompatible(Schema schema, Schema potentialCompatibleSchema){
+    if(!potentialCompatibleSchema.getType().equals(schema.getType())) {
+      return false;
+    }
+    if(!isNamedType(potentialCompatibleSchema)) {
+      return true;
+    }
+    // Avro 1.5-1.7 use full name to compare named types
+    if(Utils.usesQualifiedNameForNamedTypedMatching()) {
+      return potentialCompatibleSchema.getFullName().equals(schema.getFullName()) ||
+          potentialCompatibleSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(schema));
+    }
+    // Other avro versions (impl for all, spec for 1.9+) use unqualified name to compare named types (e.g. "test" instead of "com.test.test").
+    return potentialCompatibleSchema.getName().equals(schema.getName()) ||
+        potentialCompatibleSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(schema));
   }
 }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -589,7 +589,7 @@ public class SchemaAssistant<T extends GenericData> {
     return unionSchema.getTypes().get(compatibleUnionSchemaIndex(schema, unionSchema));
   }
 
-  private boolean areTypesCompatible(Schema schema, Schema potentialCompatibleSchema){
+  public boolean areTypesCompatible(Schema schema, Schema potentialCompatibleSchema){
     if(!potentialCompatibleSchema.getType().equals(schema.getType())) {
       return false;
     }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -580,7 +580,7 @@ public class SchemaAssistant<T extends GenericData> {
       Schema potentialCompatibleSchema = unionSchema.getTypes().get(i);
       if (potentialCompatibleSchema.getType().equals(schema.getType()) &&
               (!isNamedType(potentialCompatibleSchema) ||
-                      AvroCompatibilityHelper.getSchemaFullName(potentialCompatibleSchema).equals(AvroCompatibilityHelper.getSchemaFullName(schema)) ||
+                      potentialCompatibleSchema.getName().equals(schema.getName()) ||
                       potentialCompatibleSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(schema)))) {
         return i;
       }

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/Utils.java
@@ -93,6 +93,12 @@ public class Utils {
     return AvroCompatibilityHelperCommon.getRuntimeAvroVersion().laterThan(AvroVersion.AVRO_1_8);
   }
 
+  public static boolean usesQualifiedNameForNamedTypedMatching(){
+    return AvroCompatibilityHelper.getRuntimeAvroVersion().equals(AvroVersion.AVRO_1_5)
+            || AvroCompatibilityHelper.getRuntimeAvroVersion().equals(AvroVersion.AVRO_1_6)
+            || AvroCompatibilityHelper.getRuntimeAvroVersion().equals(AvroVersion.AVRO_1_7);
+  }
+
   public static boolean isWindows() {
     return IS_WINDOWS;
   }


### PR DESCRIPTION
The avro 1.8 and before spec says that two records match if their names are the same. However, more recent versions like 1.11 clarify that this matching should be done based on the unqualified name. The unit test added here and our experience with 1.8 at Uber suggest that all Avro versions except 1.5-1.7 use the unqualified name for the actual resolution. Thus, the behavior of the current compatible schema in union finder deviates from the standard avro impl and this change brings the two back in sync. 