### PR TITLE
Handle Nullable Unions Of Enums Correctly

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -76,6 +76,26 @@ public class FastGenericDeserializerGeneratorTest {
     }
   }
 
+  @Test(groups = {"deserializationTest"}, dataProvider = "Implementation")
+  public void shouldReadNonUnionEnumTypesWithUnionEnumTypes(Implementation implementation) {
+    // given
+    Schema enumSchema = createEnumSchema("testEnum", new String[]{"A", "B"});
+    Schema writerSchema = createRecord(
+            createField("testEnum", enumSchema));
+    Schema readerSchema = createRecord(
+            createUnionFieldWithNull("testEnum", enumSchema));
+
+    GenericRecord originalRecord = new GenericData.Record(writerSchema);
+    originalRecord.put("testEnum",
+            AvroCompatibilityHelper.newEnumSymbol(enumSchema, "A"));
+
+    // when
+    GenericRecord record = implementation.decode(writerSchema, readerSchema, genericDataAsDecoder(originalRecord));
+
+    // then
+    Assert.assertEquals("A", record.get("testEnum").toString());
+  }
+
   @DataProvider(name = "Implementation")
   public static Object[][] implementations() {
     return new Object[][]{

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -207,11 +207,11 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
     }
   }
 
-  private void processSimpleType(Schema schema, Schema readerSchema, JBlock methodBody, FieldAction action,
+  private void processSimpleType(JVar fieldSchemaVar, String name, Schema schema, Schema readerSchema, JBlock methodBody, FieldAction action,
       BiConsumer<JBlock, JExpression> putExpressionIntoParent, Supplier<JExpression> reuseSupplier) {
     switch (schema.getType()) {
       case ENUM:
-        processEnum(readerSchema, methodBody, action, putExpressionIntoParent);
+        processEnum(fieldSchemaVar, name, schema, readerSchema, methodBody, action, putExpressionIntoParent);
         break;
       case FIXED:
         final Schema fixedFieldSchema;
@@ -417,7 +417,7 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
         processComplexType(fieldSchemaVar, field.name(), field.schema(), readerFieldSchema, popMethodBody, action,
             putExpressionInRecord, fieldReuseSupplier, customizationSupplier);
       } else {
-        processSimpleType(field.schema(), readerFieldSchema, popMethodBody, action, putExpressionInRecord, fieldReuseSupplier);
+        processSimpleType(fieldSchemaVar, field.name(), field.schema(), readerFieldSchema, popMethodBody, action, putExpressionInRecord, fieldReuseSupplier);
       }
 
       if (popMethod != null) {
@@ -723,15 +723,16 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
         optionSchemaVar = unionSchemaVar;
       }
 
+      String optionName = name + "Option";
+      if (Schema.Type.UNION.equals(optionSchema.getType())) {
+        throw new FastDeserializerGeneratorException("Union cannot be sub-type of union!");
+      }
       if (SchemaAssistant.isComplexType(optionSchema)) {
-        String optionName = name + "Option";
-        if (Schema.Type.UNION.equals(optionSchema.getType())) {
-          throw new FastDeserializerGeneratorException("Union cannot be sub-type of union!");
-        }
+
         processComplexType(optionSchemaVar, optionName, optionSchema, readerOptionSchema, thenBlock, unionAction,
             putValueIntoParent, reuseSupplier, customizationSupplier);
       } else {
-        processSimpleType(optionSchema, readerOptionSchema, thenBlock, unionAction, putValueIntoParent, reuseSupplier);
+        processSimpleType(optionSchemaVar, name, optionSchema, readerOptionSchema, thenBlock, unionAction, putValueIntoParent, reuseSupplier);
       }
     }
     if (ifBlock != null) {
@@ -894,11 +895,10 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
 
     if (SchemaAssistant.isComplexType(arraySchema.getElementType())) {
       String elemName = name + "Elem";
-
       processComplexType(elementSchemaVar, elemName, arraySchema.getElementType(), readerArrayElementSchema, forBody,
           finalAction, putValueInArray, elementReuseSupplier, customizationSupplier);
     } else {
-      processSimpleType(arraySchema.getElementType(), readerArrayElementSchema, forBody, finalAction, putValueInArray, elementReuseSupplier);
+      processSimpleType(elementSchemaVar, name, arraySchema.getElementType(), readerArrayElementSchema, forBody, finalAction, putValueInArray, elementReuseSupplier);
     }
     whileLoopToIterateOnBlocks.body().assign(chunkLen, JExpr.direct(DECODER + ".arrayNext()"));
 
@@ -1036,13 +1036,12 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
       putValueInMap = (block, expression) -> block.invoke(mapVar, "put").arg(key).arg(expression);
       readerMapValueSchema = effectiveMapReaderSchema.getValueType();
     }
-
     if (SchemaAssistant.isComplexType(mapSchema.getValueType())) {
       String valueName = name + "Value";
       processComplexType(mapValueSchemaVar, valueName, mapSchema.getValueType(), readerMapValueSchema, forBody, action,
           putValueInMap, EMPTY_SUPPLIER, customizationSupplier);
     } else {
-      processSimpleType(mapSchema.getValueType(), readerMapValueSchema, forBody, action, putValueInMap, EMPTY_SUPPLIER);
+      processSimpleType(mapValueSchemaVar, name, mapSchema.getValueType(), readerMapValueSchema, forBody, action, putValueInMap, EMPTY_SUPPLIER);
     }
     doLoop.body().assign(chunkLen, JExpr.direct(DECODER + ".mapNext()"));
     if (action.getShouldRead()) {
@@ -1100,9 +1099,36 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
     }
   }
 
-  private void processEnum(final Schema schema, final JBlock body, FieldAction action,
+  private void processEnum(JVar fieldVar, final String name,  final Schema writerSchema, Schema schema, final JBlock body, FieldAction action,
       BiConsumer<JBlock, JExpression> putEnumIntoParent) {
     if (action.getShouldRead()) {
+      // if reader schema is a union type then the compatible union type must be selected
+      // as effectiveRecordReaderSchema and recordAction needs to be adjusted.
+      if (Schema.Type.UNION.equals(schema.getType())) {
+        Schema effectiveRecordReaderSchema = schemaAssistant.compatibleUnionSchema(writerSchema, schema);
+        if (fieldVar != null) {
+          declareSchemaVar(effectiveRecordReaderSchema, name + "EnumSchema",
+                  fieldVar.invoke("getTypes").invoke("get").arg(JExpr.lit(
+                          schemaAssistant.compatibleUnionSchemaIndex(writerSchema, schema)
+                  )));
+        }
+        Symbol symbol = action.getSymbol();
+        if (!(symbol instanceof Symbol.UnionAdjustAction)) {
+          for (Symbol aSymbol: symbol.production) {
+            if (aSymbol instanceof Symbol.UnionAdjustAction) {
+              symbol = aSymbol;
+              break;
+            }
+          }
+        }
+        if (symbol == null) {
+          throw new FastDeserializerGeneratorException("Symbol.UnionAdjustAction is expected but was not found");
+        }
+        action = FieldAction.fromValues(action.getType(), action.getShouldRead(),
+                ((Symbol.UnionAdjustAction) symbol).symToParse);
+        schema = effectiveRecordReaderSchema;
+      }
+
       Symbol.EnumAdjustAction enumAdjustAction = null;
       if (action.getSymbol() instanceof Symbol.EnumAdjustAction) {
         enumAdjustAction = (Symbol.EnumAdjustAction) action.getSymbol();


### PR DESCRIPTION
Nullable Enum on the reader side is not handled correctly currently. This change fixes it by following the same behavior that is followed for arrays and maps to account for UnionAdjustAction.

Fixes Issue #180 