### PR TITLE
Fix a flaky fastserde test

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
@@ -280,7 +280,7 @@ public class FastStringableTest {
     BigDecimal exampleBigDecimal = new BigDecimal(Double.MIN_VALUE).pow(16);
     File exampleFile = new File("/tmp/test");
     URI exampleURI = new URI("urn:ISSN:1522-3611");
-    URL exampleURL = new URL("http://www.example.com");
+    URL exampleURL = new URL("http://www.asdaldjaldladjal.sadjad");
     String exampleString = "test_string";
 
     StringableRecord record = generateRecord(exampleURL, exampleURI, exampleFile, exampleBigDecimal, exampleBigInteger, exampleString);


### PR DESCRIPTION
This PR fixes a flaky fastserde test.

See example build failure https://github.com/linkedin/avro-util/actions/runs/16304263099/job/46046422395
```
Gradle suite > Gradle test > com.linkedin.avro.fastserde.FastStringableTest > deserializeStringableFields[0](true) FAILED
    java.lang.AssertionError: expected [[http://www.example.com/]] but found [[http://www.example.com/]]
        at org.testng.Assert.fail(Assert.java:96)
        at org.testng.Assert.failNotEquals(Assert.java:776)
        at org.testng.Assert.assertEqualsImpl(Assert.java:137)
        at org.testng.Assert.assertEquals(Assert.java:118)
        at org.testng.Assert.assertEquals(Assert.java:442)
        at com.linkedin.avro.fastserde.FastStringableTest.deserializeStringableFields(FastStringableTest.java:303)
...
* What went wrong:
170 actionable tasks: 111 executed, 59 up-to-date
Execution failed for task ':fastserde:avro-fastserde-tests110:test'.
> There were failing tests. See the report at: file:///home/runner/work/avro-util/avro-util/fastserde/avro-fastserde-tests110/build/reports/tests/test/index.html
```

The test is failing because of URL comparison failure. The URL object `equals` method does DNS lookup of the hostname and if the IPs do not match then `equals` will return `false`, from [the doc](https://docs.oracle.com/javase/8/docs/api/java/net/URL.html#equals-java.lang.Object-):
```
Two hosts are considered equivalent if both host names can be resolved into the same IP addresses; else if either host name can't be resolved, the host names must be equal without regard to case; or both host names equal to null.
```
In the existing case, `http://www.example.com` is a resolvable hostname that resolves to multiple IPs. To fix the test, we can use a completely made-up URL example, which cannot be resolved, then only hostnames will be compared.