### PR TITLE
Replace remaining occurrences of example.com URL

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/avro/defaultsTest.avsc
+++ b/fastserde/avro-fastserde-tests-common/src/test/avro/defaultsTest.avsc
@@ -90,7 +90,7 @@
     {
       "name": "testStringable",
       "type": { "type": "string", "java-class": "java.net.URL" },
-      "default": "http://www.example.com"
+      "default": "http://www.asdaldjaldladjal.sadjad"
     },
     {
       "name": "testStringUnion",
@@ -297,7 +297,7 @@
         "java-key-class": "java.net.URL",
         "values": { "type": "string", "java-class": "java.math.BigInteger" }
       },
-      "default": {"http://www.example2.com": "123"}
+      "default": {"http://www.asdaldjaldladjal.sadjad2": "123"}
     },
     {
       "name": "recordMap",

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastDeserializerDefaultsTest.java
@@ -217,9 +217,9 @@ public class FastDeserializerDefaultsTest {
     Assert.assertNull(getField(testRecord, "testBytesUnion"));
     Assert.assertEquals(new Utf8("testStringValue"), getField(testRecord, "testString"));
     if (Utils.isAbleToSupportStringableProps()) {
-      Assert.assertEquals(new URL("http://www.example.com"), getField(testRecord, "testStringable"));
+      Assert.assertEquals(new URL("http://www.asdaldjaldladjal.sadjad"), getField(testRecord, "testStringable"));
     } else {
-      Assert.assertEquals(new Utf8("http://www.example.com"), getField(testRecord, "testStringable"));
+      Assert.assertEquals(new Utf8("http://www.asdaldjaldladjal.sadjad"), getField(testRecord, "testStringable"));
     }
     Assert.assertNull(getField(testRecord, "testStringUnion"));
     DefaultsFixed expectedDefaultsFixed1 = new DefaultsFixed();
@@ -252,9 +252,9 @@ public class FastDeserializerDefaultsTest {
 
     Map stringableMap = new HashMap();
     if (Utils.isAbleToSupportStringableProps()) {
-      stringableMap.put(new URL("http://www.example2.com"), new BigInteger("123"));
+      stringableMap.put(new URL("http://www.asdaldjaldladjal.sadjad2"), new BigInteger("123"));
     } else {
-      stringableMap.put(new Utf8("http://www.example2.com"), new Utf8("123"));
+      stringableMap.put(new Utf8("http://www.asdaldjaldladjal.sadjad2"), new Utf8("123"));
     }
     Assert.assertEquals(stringableMap, (Map) getField(testRecord, "stringableMap"));
 
@@ -312,7 +312,7 @@ public class FastDeserializerDefaultsTest {
     Assert.assertEquals(ByteBuffer.wrap("1234".getBytes()), testRecord.get("testBytes"));
     Assert.assertNull(testRecord.get("testBytesUnion"));
     Assert.assertEquals(new Utf8("testStringValue"), testRecord.get("testString"));
-    Assert.assertEquals(new Utf8("http://www.example.com"), testRecord.get("testStringable"));
+    Assert.assertEquals(new Utf8("http://www.asdaldjaldladjal.sadjad"), testRecord.get("testStringable"));
 
     Assert.assertNull(testRecord.get("testStringUnion"));
     Schema fixedSchema = Schema.createFixed("DefaultsFixed", "", "", 1);
@@ -341,7 +341,7 @@ public class FastDeserializerDefaultsTest {
     Assert.assertTrue(listWithNull.equals(testRecord.get("recordUnionArray")));
 
     Map stringableMap = new HashMap();
-    stringableMap.put(new Utf8("http://www.example2.com"), new Utf8("123"));
+    stringableMap.put(new Utf8("http://www.asdaldjaldladjal.sadjad2"), new Utf8("123"));
     Assert.assertEquals(stringableMap, testRecord.get("stringableMap"));
 
     Map recordMap = new HashMap();

--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastStringableTest.java
@@ -111,7 +111,7 @@ public class FastStringableTest {
     BigDecimal exampleBigDecimal = new BigDecimal(Double.MIN_VALUE).pow(16);
     File exampleFile = new File("/tmp/test");
     URI exampleURI = new URI("urn:ISSN:1522-3611");
-    URL exampleURL = new URL("http://www.example.com");
+    URL exampleURL = new URL("http://www.asdaldjaldladjal.sadjad");
     String exampleString = "test_string";
 
     if (Utils.isSupportedAvroVersionsForSerializer()) {


### PR DESCRIPTION
This is a follow-up PR for https://github.com/linkedin/avro-util/pull/584/  to replace remaining occurrences of example.com URL (see the [search query](https://github.com/search?q=repo%3Alinkedin%2Favro-util+%22http%3A%2F%2Fwww.example%22&type=code)). We want to use un-resolvable URLs in tests to avoid intermittent test failures due to URLs resolving to different IPs.