### PR TITLE
Fixed various issues in SpecificRecordClassGenerator methods overloaded for int/long

### DIFF
--- a/avro-builder/tests/codegen-110/src/main/avro/vs110/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-110/src/main/avro/vs110/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-111/src/main/avro/vs111/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-111/src/main/avro/vs111/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-14/src/main/avro/vs14/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-14/src/main/avro/vs14/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-15/src/main/avro/vs15/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-15/src/main/avro/vs15/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-16/src/main/avro/vs16/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-16/src/main/avro/vs16/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-17/src/main/avro/vs17/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-17/src/main/avro/vs17/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-18/src/main/avro/vs18/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-18/src/main/avro/vs18/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-19/src/main/avro/vs19/IntsAndLongs.avsc
+++ b/avro-builder/tests/codegen-19/src/main/avro/vs19/IntsAndLongs.avsc
@@ -20,6 +20,11 @@
       "name": "boxedIntField",
       "type": ["null", "int"],
       "default": null
+    },
+    {
+      "name": "strField",
+      "type": "string",
+      "default": "defaultStr"
     }
   ]
 }

--- a/avro-builder/tests/codegen-no-utf8-encoding/src/main/avro/noUtf8Encoding/TestCollections.avsc
+++ b/avro-builder/tests/codegen-no-utf8-encoding/src/main/avro/noUtf8Encoding/TestCollections.avsc
@@ -89,6 +89,10 @@
           "values": "int"
         }
       ]
+    },
+    {
+      "name": "intField",
+      "type": "int"
     }
   ],
   "type": "record"

--- a/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
+++ b/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java
@@ -1999,18 +1999,21 @@ TODO:// enable these test cases after AvroRecordUtil.deepConvert supports collec
     Method setIntFieldLongMethod = builder.getClass().getMethod("setIntField", long.class);
     Method setLongFieldMethod = builder.getClass().getMethod("setLongField", long.class);
     Method setLongFieldIntMethod = builder.getClass().getMethod("setLongField", int.class);
+    Method setStrFieldIntMethod = builder.getClass().getMethod("setStrField", String.class);
     Method buildMethod = builder.getClass().getMethod("build");
 
     // Case 1: Set int and long with matching int/long types (primitive)
     Object builder1 = newBuilderMethod.invoke(null);
     setIntFieldMethod.invoke(builder1, 123);
     setLongFieldMethod.invoke(builder1, 456L);
+    setStrFieldIntMethod.invoke(builder1, "testStr");
     Object record1 = buildMethod.invoke(builder1);
 
     // Case 2: Set int field with long type, and long field with int type (primitive)
     Object builder2 = newBuilderMethod.invoke(null);
     setIntFieldLongMethod.invoke(builder2, 123L);
     setLongFieldIntMethod.invoke(builder2, 456);
+    setStrFieldIntMethod.invoke(builder2, "testStr");
     Object record2 = buildMethod.invoke(builder2);
 
     // Case 3: Using the put method with primitive types
@@ -2018,16 +2021,19 @@ TODO:// enable these test cases after AvroRecordUtil.deepConvert supports collec
     Method putMethod = clazz.getMethod("put", int.class, Object.class);
     putMethod.invoke(record3, 0, 456L); // longField with long
     putMethod.invoke(record3, 1, 123); // intField with int
+    putMethod.invoke(record3, 4, "testStr");
 
     // Case 4: Using the put method with cross types
     Object record4 = clazz.newInstance();
     putMethod.invoke(record4, 0, 456); // longField with int
     putMethod.invoke(record4, 1, 123L); // intField with long
+    putMethod.invoke(record4, 4, "testStr");
 
     // Case 5: Using the put method with Integer/Long wrapper classes
     Object record5 = clazz.newInstance();
     putMethod.invoke(record5, 0, Integer.valueOf(456)); // longField with Integer
     putMethod.invoke(record5, 1, Long.valueOf(123L)); // intField with Long
+    putMethod.invoke(record5, 4, "testStr");
 
     // Verify all records are equal
     Assert.assertEquals(record1, record2);
@@ -2038,11 +2044,13 @@ TODO:// enable these test cases after AvroRecordUtil.deepConvert supports collec
     // Verify field values directly
     Method getIntFieldMethod = clazz.getMethod("getIntField");
     Method getLongFieldMethod = clazz.getMethod("getLongField");
+    Method getStrFieldMethod = clazz.getMethod("getStrField");
 
     Assert.assertEquals(123, getIntFieldMethod.invoke(record1));
     Assert.assertEquals(456L, getLongFieldMethod.invoke(record1));
     Assert.assertEquals(123, getIntFieldMethod.invoke(record5));
     Assert.assertEquals(456L, getLongFieldMethod.invoke(record5));
+    Assert.assertEquals("testStr", getStrFieldMethod.invoke(record1));
   }
 
   @Test(dataProvider = "intsAndLongsDataProvider")

--- a/avro-codegen/src/test/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGeneratorTest.java
+++ b/avro-codegen/src/test/java/com/linkedin/avroutil1/codegen/SpecificRecordClassGeneratorTest.java
@@ -38,7 +38,8 @@ public class SpecificRecordClassGeneratorTest {
         {"schemas/SimpleFixedWithHugeDoc.avsc", true},
         {"schemas/TestCollections.avsc", true},
         {"schemas/TestProblematicRecord.avsc", true},
-        {"schemas/TestRecord.avsc", false}
+        {"schemas/TestRecord.avsc", false},
+        {"schemas/IntLongString.avsc", true}
     };
   }
 

--- a/avro-codegen/src/test/resources/schemas/IntLongString.avsc
+++ b/avro-codegen/src/test/resources/schemas/IntLongString.avsc
@@ -1,0 +1,64 @@
+{
+  "type": "record",
+  "namespace": "com.linkedin.test",
+  "name": "IntLongString",
+  "fields": [
+    {
+      "name": "longField",
+      "type": "long"
+    },
+    {
+      "name": "intField",
+      "type": "int"
+    },
+    {
+      "name": "boxedLongField",
+      "type": ["null", "long"],
+      "default": null
+    },
+    {
+      "name": "boxedIntField",
+      "type": ["null", "int"],
+      "default": null
+    },
+    {
+      "name": "str",
+      "type": "string"
+    },
+    {
+      "name": "strAr",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    },
+    {
+      "name": "strArAr",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "array",
+          "items": "string"
+        }
+      }
+    },
+    {
+      "name": "unionOfArray",
+      "type": ["null", {
+        "type": "array",
+        "items": "string"
+      }
+      ]
+    },
+    {
+      "name": "arOfMap",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "map",
+          "values": "string"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Summary

Fixed various issues in SpecificRecordClassGenerator methods overloaded for int/long in https://github.com/linkedin/avro-util/pull/581:

1. Fixed constructor to handle CharSequence transformations. This fixes the compilation error:
<img width="3510" height="1658" alt="image" src="https://github.com/user-attachments/assets/8b47848d-5770-4622-b86b-3a9edad64ae9" />

A bug in the constructor between version 0.4.30 (before int/long changes) and master branch:
<img width="2139" height="1229" alt="OriginalAndMaster" src="https://github.com/user-attachments/assets/ec1d40d7-43ed-4f66-b240-a374736a7e29" />

Constructor with the fix:

<img width="1946" height="860" alt="image" src="https://github.com/user-attachments/assets/6fd7588e-727a-4aa0-9ec2-cec7ec38d647" />

- Added `IntLongString.avsc` record schema and a test case to `SpecificRecordClassGeneratorTest.testSchema` to verify that the generated java file can be compiled.
- Added an `intField` to `TestCollections.avsc` which is used in [SpecificRecordTest.testNoUtf8Encoding](https://github.com/linkedin/avro-util/blob/5a2c36b47977859c38223b8bc44545d8470fa727/avro-builder/tests/tests-allavro/src/test/java/com/linkedin/avroutil1/builder/SpecificRecordTest.java#L2097) case. The test invokes the all args constructor and verifies different aspects of string fields.
- Added `strField` to IntsAndLongs.avsc records to generate and compare diffs

2. Fixed Builder setters to be public and have validations within the method body. This was not an error but I noticed a difference between the original code and newly added code:

<img width="2487" height="565" alt="image" src="https://github.com/user-attachments/assets/3b9ed16f-1c29-442c-bb9f-68a51b379ee0" />


3. Fixed `getSerializedCustomDecodeBlock` to have full exception name. This also led to a compilation error.

### Testing Done
- unit tests
- manual inspection of the generated java files (see the screenshots above)
- built an internal application with the snapshot of these changes and verified it compiles and generated java files look correct:
```
./gradlew clean build javadoc --stacktrace --warning-mode all --no-daemon --parallel
./gradlew   publishToMavenLocal
```
