### PR TITLE
Fix union type naming in FastSerializerGenerator

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericSerializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericSerializerGeneratorTest.java
@@ -443,6 +443,137 @@ public class FastGenericSerializerGeneratorTest {
   }
 
   @Test(groups = {"serializationTest"})
+  public void shouldWriteArrayOfUnionPrimitives() {
+    // given - this tests the fix for the bug where union types in arrays
+    // caused invalid Java variable names to be generated (e.g., "union[null, string]0")
+    Schema unionSchema = Schema.createUnion(Arrays.asList(
+        Schema.create(Schema.Type.NULL),
+        Schema.create(Schema.Type.STRING)
+    ));
+    Schema arrayOfUnionSchema = Schema.createArray(unionSchema);
+
+    GenericData.Array<CharSequence> unionArray = new GenericData.Array<>(0, arrayOfUnionSchema);
+    unionArray.add(new Utf8("test1"));
+    unionArray.add(null);
+    unionArray.add(new Utf8("test2"));
+
+    // when
+    List<CharSequence> result = decodeRecord(arrayOfUnionSchema, dataAsBinaryDecoder(unionArray));
+
+    // then
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals(result.get(0).toString(), "test1");
+    Assert.assertNull(result.get(1));
+    Assert.assertEquals(result.get(2).toString(), "test2");
+  }
+
+  @Test(groups = {"serializationTest"})
+  public void shouldWriteMapOfUnionPrimitives() {
+    // given - this tests the fix for the bug where union types in map values
+    // caused invalid Java variable names to be generated
+    Schema unionSchema = Schema.createUnion(Arrays.asList(
+        Schema.create(Schema.Type.NULL),
+        Schema.create(Schema.Type.STRING)
+    ));
+    Schema mapOfUnionSchema = Schema.createMap(unionSchema);
+
+    Map<String, CharSequence> unionMap = new HashMap<>();
+    unionMap.put("key1", new Utf8("value1"));
+    unionMap.put("key2", null);
+    unionMap.put("key3", new Utf8("value3"));
+
+    // when
+    Map<Utf8, CharSequence> result = decodeRecord(mapOfUnionSchema, dataAsBinaryDecoder(unionMap, mapOfUnionSchema));
+
+    // then
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals(result.get(new Utf8("key1")).toString(), "value1");
+    Assert.assertNull(result.get(new Utf8("key2")));
+    Assert.assertEquals(result.get(new Utf8("key3")).toString(), "value3");
+  }
+
+  @Test(groups = {"serializationTest"})
+  public void shouldWriteRecordWithArrayOfUnionPrimitives() {
+    // given - this tests the exact schema that triggered the original bug report
+    String schemaJson = "{\n" +
+        "  \"type\": \"record\",\n" +
+        "  \"name\": \"TestRecord\",\n" +
+        "  \"namespace\": \"com.linkedin.avro.fastserde.test\",\n" +
+        "  \"fields\": [\n" +
+        "    {\"name\": \"fields\", \"type\": {\"type\": \"array\", \"items\": [\"null\", \"string\"]}}\n" +
+        "  ]\n" +
+        "}";
+    Schema recordSchema = Schema.parse(schemaJson);
+
+    GenericData.Record record = new GenericData.Record(recordSchema);
+    GenericData.Array<CharSequence> fieldsArray = new GenericData.Array<>(0, recordSchema.getField("fields").schema());
+    fieldsArray.add(new Utf8("value1"));
+    fieldsArray.add(null);
+    fieldsArray.add(new Utf8("value2"));
+    record.put("fields", fieldsArray);
+
+    // when
+    GenericRecord result = decodeRecord(recordSchema, dataAsBinaryDecoder(record));
+
+    // then
+    @SuppressWarnings("unchecked")
+    List<CharSequence> resultFields = (List<CharSequence>) result.get("fields");
+    Assert.assertEquals(resultFields.size(), 3);
+    Assert.assertEquals(resultFields.get(0).toString(), "value1");
+    Assert.assertNull(resultFields.get(1));
+    Assert.assertEquals(resultFields.get(2).toString(), "value2");
+  }
+
+  @Test(groups = {"serializationTest"})
+  public void shouldWriteArrayOfMultiTypeUnion() {
+    // given - this tests multi-type unions (not just nullable) to ensure
+    // the naming generates valid identifiers like "union_INT_STRING_DOUBLE"
+    Schema unionSchema = Schema.createUnion(Arrays.asList(
+        Schema.create(Schema.Type.INT),
+        Schema.create(Schema.Type.STRING),
+        Schema.create(Schema.Type.DOUBLE)
+    ));
+    Schema arrayOfUnionSchema = Schema.createArray(unionSchema);
+
+    GenericData.Array<Object> unionArray = new GenericData.Array<>(0, arrayOfUnionSchema);
+    unionArray.add(42);
+    unionArray.add(new Utf8("test"));
+    unionArray.add(3.14);
+
+    // when
+    List<Object> result = decodeRecord(arrayOfUnionSchema, dataAsBinaryDecoder(unionArray));
+
+    // then
+    Assert.assertEquals(result.size(), 3);
+    Assert.assertEquals(result.get(0), 42);
+    Assert.assertEquals(result.get(1).toString(), "test");
+    Assert.assertEquals((Double) result.get(2), 3.14, 0.0001);
+  }
+
+  @Test(groups = {"serializationTest"})
+  public void shouldWriteMapOfMultiTypeUnion() {
+    // given - this tests multi-type unions in map values to ensure
+    // proper variable naming in generated code
+    Schema unionSchema = Schema.createUnion(Arrays.asList(
+        Schema.create(Schema.Type.INT),
+        Schema.create(Schema.Type.STRING)
+    ));
+    Schema mapOfUnionSchema = Schema.createMap(unionSchema);
+
+    Map<String, Object> unionMap = new HashMap<>();
+    unionMap.put("int_value", 100);
+    unionMap.put("string_value", new Utf8("hello"));
+
+    // when
+    Map<Utf8, Object> result = decodeRecord(mapOfUnionSchema, dataAsBinaryDecoder(unionMap, mapOfUnionSchema));
+
+    // then
+    Assert.assertEquals(result.size(), 2);
+    Assert.assertEquals(result.get(new Utf8("int_value")), 100);
+    Assert.assertEquals(result.get(new Utf8("string_value")).toString(), "hello");
+  }
+
+  @Test(groups = {"serializationTest"})
   public void shouldWriteArrayOfRecords() {
     // given
     Schema recordSchema = createRecord("record", createPrimitiveUnionFieldSchema("field", Schema.Type.STRING));

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_union_NULL_TestRecord_SpecificDeserializer_1277939469_1277939469.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_union_NULL_TestRecord_SpecificDeserializer_1277939469_1277939469.java
@@ -29,13 +29,13 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class Array_of_UNION_SpecificDeserializer_1277939469_1277939469
+public class Array_of_union_NULL_TestRecord_SpecificDeserializer_1277939469_1277939469
     implements FastDeserializer<List<TestRecord>>
 {
 
     private final Schema readerSchema;
 
-    public Array_of_UNION_SpecificDeserializer_1277939469_1277939469(Schema readerSchema) {
+    public Array_of_union_NULL_TestRecord_SpecificDeserializer_1277939469_1277939469(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_union_NULL_record_GenericDeserializer_777827233_777827233.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Array_of_union_NULL_record_GenericDeserializer_777827233_777827233.java
@@ -11,7 +11,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class Array_of_UNION_GenericDeserializer_777827233_777827233
+public class Array_of_union_NULL_record_GenericDeserializer_777827233_777827233
     implements FastDeserializer<List<IndexedRecord>>
 {
 
@@ -20,7 +20,7 @@ public class Array_of_UNION_GenericDeserializer_777827233_777827233
     private final Schema arrayElemOptionSchema0;
     private final Schema field0;
 
-    public Array_of_UNION_GenericDeserializer_777827233_777827233(Schema readerSchema) {
+    public Array_of_union_NULL_record_GenericDeserializer_777827233_777827233(Schema readerSchema) {
         this.readerSchema = readerSchema;
         this.arrayArrayElemSchema0 = readerSchema.getElementType();
         this.arrayElemOptionSchema0 = arrayArrayElemSchema0 .getTypes().get(1);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_union_NULL_TestRecord_SpecificDeserializer_971650236_971650236.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_union_NULL_TestRecord_SpecificDeserializer_971650236_971650236.java
@@ -29,13 +29,13 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class Map_of_UNION_SpecificDeserializer_971650236_971650236
+public class Map_of_union_NULL_TestRecord_SpecificDeserializer_971650236_971650236
     implements FastDeserializer<Map<Utf8, TestRecord>>
 {
 
     private final Schema readerSchema;
 
-    public Map_of_UNION_SpecificDeserializer_971650236_971650236(Schema readerSchema) {
+    public Map_of_union_NULL_TestRecord_SpecificDeserializer_971650236_971650236(Schema readerSchema) {
         this.readerSchema = readerSchema;
     }
 

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_union_NULL_record_GenericDeserializer_2140000109_2140000109.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/Map_of_union_NULL_record_GenericDeserializer_2140000109_2140000109.java
@@ -10,7 +10,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class Map_of_UNION_GenericDeserializer_2140000109_2140000109
+public class Map_of_union_NULL_record_GenericDeserializer_2140000109_2140000109
     implements FastDeserializer<Map<Utf8, IndexedRecord>>
 {
 
@@ -19,7 +19,7 @@ public class Map_of_UNION_GenericDeserializer_2140000109_2140000109
     private final Schema mapValueOptionSchema0;
     private final Schema field0;
 
-    public Map_of_UNION_GenericDeserializer_2140000109_2140000109(Schema readerSchema) {
+    public Map_of_union_NULL_record_GenericDeserializer_2140000109_2140000109(Schema readerSchema) {
         this.readerSchema = readerSchema;
         this.mapMapValueSchema0 = readerSchema.getValueType();
         this.mapValueOptionSchema0 = mapMapValueSchema0 .getTypes().get(1);

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/union_NULL_Array_of_record_GenericDeserializer_2018567528_1606337179.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/union_NULL_Array_of_record_GenericDeserializer_2018567528_1606337179.java
@@ -10,7 +10,7 @@ import org.apache.avro.generic.GenericArray;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
 
-public class UNION_GenericDeserializer_2018567528_1606337179
+public class union_NULL_Array_of_record_GenericDeserializer_2018567528_1606337179
     implements FastDeserializer<List<IndexedRecord>>
 {
 
@@ -18,7 +18,7 @@ public class UNION_GenericDeserializer_2018567528_1606337179
     private final Schema arrayArraySchema0;
     private final Schema arrayArrayElemSchema0;
 
-    public UNION_GenericDeserializer_2018567528_1606337179(Schema readerSchema) {
+    public union_NULL_Array_of_record_GenericDeserializer_2018567528_1606337179(Schema readerSchema) {
         this.readerSchema = readerSchema;
         this.arrayArraySchema0 = readerSchema.getTypes().get(1);
         this.arrayArrayElemSchema0 = arrayArraySchema0 .getElementType();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/union_NULL_Map_of_record_GenericDeserializer_568621313_1223705675.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/union_NULL_Map_of_record_GenericDeserializer_568621313_1223705675.java
@@ -10,7 +10,7 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.util.Utf8;
 
-public class UNION_GenericDeserializer_568621313_1223705675
+public class union_NULL_Map_of_record_GenericDeserializer_568621313_1223705675
     implements FastDeserializer<Map<Utf8, IndexedRecord>>
 {
 
@@ -18,7 +18,7 @@ public class UNION_GenericDeserializer_568621313_1223705675
     private final Schema mapMapSchema0;
     private final Schema mapMapValueSchema0;
 
-    public UNION_GenericDeserializer_568621313_1223705675(Schema readerSchema) {
+    public union_NULL_Map_of_record_GenericDeserializer_568621313_1223705675(Schema readerSchema) {
         this.readerSchema = readerSchema;
         this.mapMapSchema0 = readerSchema.getTypes().get(1);
         this.mapMapValueSchema0 = mapMapSchema0 .getValueType();

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/union_NULL_record_GenericDeserializer_1971822364_1672473580.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/deserialization/AVRO_1_11/union_NULL_record_GenericDeserializer_1971822364_1672473580.java
@@ -8,14 +8,14 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Decoder;
 
-public class UNION_GenericDeserializer_1971822364_1672473580
+public class union_NULL_record_GenericDeserializer_1971822364_1672473580
     implements FastDeserializer<IndexedRecord>
 {
 
     private final Schema readerSchema;
     private final Schema recordRecordSchema0;
 
-    public UNION_GenericDeserializer_1971822364_1672473580(Schema readerSchema) {
+    public union_NULL_record_GenericDeserializer_1971822364_1672473580(Schema readerSchema) {
         this.readerSchema = readerSchema;
         this.recordRecordSchema0 = readerSchema.getTypes().get(1);
     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_union_INT_STRING_DOUBLE_GenericSerializer_895888951.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_union_INT_STRING_DOUBLE_GenericSerializer_895888951.java
@@ -1,0 +1,51 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_union_INT_STRING_DOUBLE_GenericSerializer_895888951
+    implements FastSerializer<List<Object>>
+{
+
+
+    public void serialize(List<Object> data, Encoder encoder, DatumWriterCustomization customization)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter0 = 0; (counter0 <data.size()); counter0 ++) {
+                (encoder).startItem();
+                Object union_INT_STRING_DOUBLE0 = null;
+                union_INT_STRING_DOUBLE0 = ((List<Object> ) data).get(counter0);
+                if (union_INT_STRING_DOUBLE0 instanceof Integer) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeInt(((Integer) union_INT_STRING_DOUBLE0));
+                } else {
+                    if (union_INT_STRING_DOUBLE0 instanceof CharSequence) {
+                        (encoder).writeIndex(1);
+                        if (((CharSequence) union_INT_STRING_DOUBLE0) instanceof Utf8) {
+                            (encoder).writeString(((Utf8)((CharSequence) union_INT_STRING_DOUBLE0)));
+                        } else {
+                            (encoder).writeString(((CharSequence) union_INT_STRING_DOUBLE0).toString());
+                        }
+                    } else {
+                        if (union_INT_STRING_DOUBLE0 instanceof Double) {
+                            (encoder).writeIndex(2);
+                            (encoder).writeDouble(((Double) union_INT_STRING_DOUBLE0));
+                        }
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_union_NULL_STRING_GenericSerializer_317583799.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_union_NULL_STRING_GenericSerializer_317583799.java
@@ -1,0 +1,44 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Array_of_union_NULL_STRING_GenericSerializer_317583799
+    implements FastSerializer<List<CharSequence>>
+{
+
+
+    public void serialize(List<CharSequence> data, Encoder encoder, DatumWriterCustomization customization)
+        throws IOException
+    {
+        (encoder).writeArrayStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (int counter0 = 0; (counter0 <data.size()); counter0 ++) {
+                (encoder).startItem();
+                CharSequence union_NULL_STRING0 = null;
+                union_NULL_STRING0 = ((List<CharSequence> ) data).get(counter0);
+                if (union_NULL_STRING0 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    (encoder).writeIndex(1);
+                    if (((CharSequence) union_NULL_STRING0) instanceof Utf8) {
+                        (encoder).writeString(((Utf8)((CharSequence) union_NULL_STRING0)));
+                    } else {
+                        (encoder).writeString(((CharSequence) union_NULL_STRING0).toString());
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_union_NULL_record_GenericSerializer_777827233.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Array_of_union_NULL_record_GenericSerializer_777827233.java
@@ -2,44 +2,42 @@
 package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import com.linkedin.avro.fastserde.FastSerializer;
 import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 
-public class Map_of_UNION_GenericSerializer_2140000109
-    implements FastSerializer<Map<CharSequence, IndexedRecord>>
+public class Array_of_union_NULL_record_GenericSerializer_777827233
+    implements FastSerializer<List<IndexedRecord>>
 {
 
 
-    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
+    public void serialize(List<IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        (customization).getCheckMapTypeFunction().apply(data);
-        (encoder).writeMapStart();
+        (encoder).writeArrayStart();
         if ((data == null)||data.isEmpty()) {
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
+            for (int counter0 = 0; (counter0 <data.size()); counter0 ++) {
                 (encoder).startItem();
-                (encoder).writeString(key0);
-                IndexedRecord union0 = null;
-                union0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
-                if (union0 == null) {
+                IndexedRecord union_NULL_record0 = null;
+                union_NULL_record0 = ((List<IndexedRecord> ) data).get(counter0);
+                if (union_NULL_record0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
+                    if ((union_NULL_record0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record".equals(((IndexedRecord) union_NULL_record0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializeRecord0(((IndexedRecord) union0), (encoder), (customization));
+                        serializeRecord0(((IndexedRecord) union_NULL_record0), (encoder), (customization));
                     }
                 }
             }
         }
-        (encoder).writeMapEnd();
+        (encoder).writeArrayEnd();
     }
 
     @SuppressWarnings("unchecked")

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums_GenericSerializer_496788239.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnums_GenericSerializer_496788239.java
@@ -90,16 +90,16 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithEnum
             (encoder).setItemCount(testEnumUnionArray0 .size());
             for (int counter1 = 0; (counter1 <testEnumUnionArray0 .size()); counter1 ++) {
                 (encoder).startItem();
-                GenericEnumSymbol union0 = null;
-                union0 = ((List<GenericEnumSymbol> ) testEnumUnionArray0).get(counter1);
-                if (union0 == null) {
+                GenericEnumSymbol union_NULL_ENUM0 = null;
+                union_NULL_ENUM0 = ((List<GenericEnumSymbol> ) testEnumUnionArray0).get(counter1);
+                if (union_NULL_ENUM0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union0 instanceof GenericEnumSymbol)&&"com.linkedin.avro.fastserde.generated.avro.testEnum".equals(((GenericEnumSymbol) union0).getSchema().getFullName())) {
+                    if ((union_NULL_ENUM0 instanceof GenericEnumSymbol)&&"com.linkedin.avro.fastserde.generated.avro.testEnum".equals(((GenericEnumSymbol) union_NULL_ENUM0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
                         int valueToWrite3;
-                        Object enumValue3 = union0;
+                        Object enumValue3 = union_NULL_ENUM0;
                         if (enumValue3 instanceof Enum) {
                             valueToWrite3 = ((Enum) enumValue3).ordinal();
                         } else {

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed_GenericSerializer_1473954146.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixed_GenericSerializer_1473954146.java
@@ -69,15 +69,15 @@ public class FastGenericSerializerGeneratorTest_shouldWriteGenericRecordWithFixe
             (encoder).setItemCount(testFixedUnionArray0 .size());
             for (int counter1 = 0; (counter1 <testFixedUnionArray0 .size()); counter1 ++) {
                 (encoder).startItem();
-                GenericFixed union0 = null;
-                union0 = ((List<GenericFixed> ) testFixedUnionArray0).get(counter1);
-                if (union0 == null) {
+                GenericFixed union_NULL_FIXED0 = null;
+                union_NULL_FIXED0 = ((List<GenericFixed> ) testFixedUnionArray0).get(counter1);
+                if (union_NULL_FIXED0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union0 instanceof GenericFixed)&&"com.linkedin.avro.fastserde.generated.avro.testFixed".equals(((GenericFixed) union0).getSchema().getFullName())) {
+                    if ((union_NULL_FIXED0 instanceof GenericFixed)&&"com.linkedin.avro.fastserde.generated.avro.testFixed".equals(((GenericFixed) union_NULL_FIXED0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        (encoder).writeFixed(((GenericFixed) union0).bytes());
+                        (encoder).writeFixed(((GenericFixed) union_NULL_FIXED0).bytes());
                     }
                 }
             }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_1348736347.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsField_GenericSerializer_1348736347.java
@@ -95,15 +95,15 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                     (encoder).setItemCount(((List<IndexedRecord> ) recordsArrayUnion0).size());
                     for (int counter1 = 0; (counter1 <((List<IndexedRecord> ) recordsArrayUnion0).size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union0 = null;
-                        union0 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).get(counter1);
-                        if (union0 == null) {
+                        IndexedRecord union_NULL_subRecord0 = null;
+                        union_NULL_subRecord0 = ((List<IndexedRecord> )((List<IndexedRecord> ) recordsArrayUnion0)).get(counter1);
+                        if (union_NULL_subRecord0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
+                            if ((union_NULL_subRecord0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union_NULL_subRecord0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union0), (encoder), (customization));
+                                serializeSubRecord0(((IndexedRecord) union_NULL_subRecord0), (encoder), (customization));
                             }
                         }
                     }
@@ -133,15 +133,15 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordCollectionsF
                     for (CharSequence key1 : ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).keySet()) {
                         (encoder).startItem();
                         (encoder).writeString(key1);
-                        IndexedRecord union1 = null;
-                        union1 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).get(key1);
-                        if (union1 == null) {
+                        IndexedRecord union_NULL_subRecord1 = null;
+                        union_NULL_subRecord1 = ((Map<CharSequence, IndexedRecord> )((Map<CharSequence, IndexedRecord> ) recordsMapUnion0)).get(key1);
+                        if (union_NULL_subRecord1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union1 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
+                            if ((union_NULL_subRecord1 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union_NULL_subRecord1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union1), (encoder), (customization));
+                                serializeSubRecord0(((IndexedRecord) union_NULL_subRecord1), (encoder), (customization));
                             }
                         }
                     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_1813582373.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexCollectionsField_GenericSerializer_1813582373.java
@@ -33,26 +33,26 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             (encoder).setItemCount(recordsArrayMap0 .size());
             for (int counter0 = 0; (counter0 <recordsArrayMap0 .size()); counter0 ++) {
                 (encoder).startItem();
-                Map<CharSequence, IndexedRecord> map0 = null;
-                map0 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).get(counter0);
-                (customization).getCheckMapTypeFunction().apply(map0);
+                Map<CharSequence, IndexedRecord> map_of_union_NULL_subRecord0 = null;
+                map_of_union_NULL_subRecord0 = ((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMap0).get(counter0);
+                (customization).getCheckMapTypeFunction().apply(map_of_union_NULL_subRecord0);
                 (encoder).writeMapStart();
-                if ((map0 == null)||map0 .isEmpty()) {
+                if ((map_of_union_NULL_subRecord0 == null)||map_of_union_NULL_subRecord0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(map0 .size());
-                    for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) map0).keySet()) {
+                    (encoder).setItemCount(map_of_union_NULL_subRecord0 .size());
+                    for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) map_of_union_NULL_subRecord0).keySet()) {
                         (encoder).startItem();
                         (encoder).writeString(key0);
-                        IndexedRecord union0 = null;
-                        union0 = ((Map<CharSequence, IndexedRecord> ) map0).get(key0);
-                        if (union0 == null) {
+                        IndexedRecord union_NULL_subRecord0 = null;
+                        union_NULL_subRecord0 = ((Map<CharSequence, IndexedRecord> ) map_of_union_NULL_subRecord0).get(key0);
+                        if (union_NULL_subRecord0 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union0).getSchema().getFullName())) {
+                            if ((union_NULL_subRecord0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union_NULL_subRecord0).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union0), (encoder), (customization));
+                                serializeSubRecord0(((IndexedRecord) union_NULL_subRecord0), (encoder), (customization));
                             }
                         }
                     }
@@ -97,24 +97,24 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
             for (CharSequence key1 : ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).keySet()) {
                 (encoder).startItem();
                 (encoder).writeString(key1);
-                List<IndexedRecord> array0 = null;
-                array0 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).get(key1);
+                List<IndexedRecord> array_of_union_NULL_subRecord0 = null;
+                array_of_union_NULL_subRecord0 = ((Map<CharSequence, List<IndexedRecord>> ) recordsMapArray0).get(key1);
                 (encoder).writeArrayStart();
-                if ((array0 == null)||array0 .isEmpty()) {
+                if ((array_of_union_NULL_subRecord0 == null)||array_of_union_NULL_subRecord0 .isEmpty()) {
                     (encoder).setItemCount(0);
                 } else {
-                    (encoder).setItemCount(array0 .size());
-                    for (int counter1 = 0; (counter1 <array0 .size()); counter1 ++) {
+                    (encoder).setItemCount(array_of_union_NULL_subRecord0 .size());
+                    for (int counter1 = 0; (counter1 <array_of_union_NULL_subRecord0 .size()); counter1 ++) {
                         (encoder).startItem();
-                        IndexedRecord union1 = null;
-                        union1 = ((List<IndexedRecord> ) array0).get(counter1);
-                        if (union1 == null) {
+                        IndexedRecord union_NULL_subRecord1 = null;
+                        union_NULL_subRecord1 = ((List<IndexedRecord> ) array_of_union_NULL_subRecord0).get(counter1);
+                        if (union_NULL_subRecord1 == null) {
                             (encoder).writeIndex(0);
                             (encoder).writeNull();
                         } else {
-                            if ((union1 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union1).getSchema().getFullName())) {
+                            if ((union_NULL_subRecord1 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union_NULL_subRecord1).getSchema().getFullName())) {
                                 (encoder).writeIndex(1);
-                                serializeSubRecord0(((IndexedRecord) union1), (encoder), (customization));
+                                serializeSubRecord0(((IndexedRecord) union_NULL_subRecord1), (encoder), (customization));
                             }
                         }
                     }
@@ -137,26 +137,26 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                     (encoder).setItemCount(((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).size());
                     for (int counter2 = 0; (counter2 <((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0).size()); counter2 ++) {
                         (encoder).startItem();
-                        Map<CharSequence, IndexedRecord> map1 = null;
-                        map1 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).get(counter2);
-                        (customization).getCheckMapTypeFunction().apply(map1);
+                        Map<CharSequence, IndexedRecord> map_of_union_NULL_subRecord1 = null;
+                        map_of_union_NULL_subRecord1 = ((List<Map<CharSequence, IndexedRecord>> )((List<Map<CharSequence, IndexedRecord>> ) recordsArrayMapUnion0)).get(counter2);
+                        (customization).getCheckMapTypeFunction().apply(map_of_union_NULL_subRecord1);
                         (encoder).writeMapStart();
-                        if ((map1 == null)||map1 .isEmpty()) {
+                        if ((map_of_union_NULL_subRecord1 == null)||map_of_union_NULL_subRecord1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(map1 .size());
-                            for (CharSequence key2 : ((Map<CharSequence, IndexedRecord> ) map1).keySet()) {
+                            (encoder).setItemCount(map_of_union_NULL_subRecord1 .size());
+                            for (CharSequence key2 : ((Map<CharSequence, IndexedRecord> ) map_of_union_NULL_subRecord1).keySet()) {
                                 (encoder).startItem();
                                 (encoder).writeString(key2);
-                                IndexedRecord union2 = null;
-                                union2 = ((Map<CharSequence, IndexedRecord> ) map1).get(key2);
-                                if (union2 == null) {
+                                IndexedRecord union_NULL_subRecord2 = null;
+                                union_NULL_subRecord2 = ((Map<CharSequence, IndexedRecord> ) map_of_union_NULL_subRecord1).get(key2);
+                                if (union_NULL_subRecord2 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union2 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union2).getSchema().getFullName())) {
+                                    if ((union_NULL_subRecord2 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union_NULL_subRecord2).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializeSubRecord0(((IndexedRecord) union2), (encoder), (customization));
+                                        serializeSubRecord0(((IndexedRecord) union_NULL_subRecord2), (encoder), (customization));
                                     }
                                 }
                             }
@@ -189,24 +189,24 @@ public class FastGenericSerializerGeneratorTest_shouldWriteSubRecordComplexColle
                     for (CharSequence key3 : ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).keySet()) {
                         (encoder).startItem();
                         (encoder).writeString(key3);
-                        List<IndexedRecord> array1 = null;
-                        array1 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).get(key3);
+                        List<IndexedRecord> array_of_union_NULL_subRecord1 = null;
+                        array_of_union_NULL_subRecord1 = ((Map<CharSequence, List<IndexedRecord>> )((Map<CharSequence, List<IndexedRecord>> ) recordsMapArrayUnion0)).get(key3);
                         (encoder).writeArrayStart();
-                        if ((array1 == null)||array1 .isEmpty()) {
+                        if ((array_of_union_NULL_subRecord1 == null)||array_of_union_NULL_subRecord1 .isEmpty()) {
                             (encoder).setItemCount(0);
                         } else {
-                            (encoder).setItemCount(array1 .size());
-                            for (int counter3 = 0; (counter3 <array1 .size()); counter3 ++) {
+                            (encoder).setItemCount(array_of_union_NULL_subRecord1 .size());
+                            for (int counter3 = 0; (counter3 <array_of_union_NULL_subRecord1 .size()); counter3 ++) {
                                 (encoder).startItem();
-                                IndexedRecord union3 = null;
-                                union3 = ((List<IndexedRecord> ) array1).get(counter3);
-                                if (union3 == null) {
+                                IndexedRecord union_NULL_subRecord3 = null;
+                                union_NULL_subRecord3 = ((List<IndexedRecord> ) array_of_union_NULL_subRecord1).get(counter3);
+                                if (union_NULL_subRecord3 == null) {
                                     (encoder).writeIndex(0);
                                     (encoder).writeNull();
                                 } else {
-                                    if ((union3 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union3).getSchema().getFullName())) {
+                                    if ((union_NULL_subRecord3 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.subRecord".equals(((IndexedRecord) union_NULL_subRecord3).getSchema().getFullName())) {
                                         (encoder).writeIndex(1);
-                                        serializeSubRecord0(((IndexedRecord) union3), (encoder), (customization));
+                                        serializeSubRecord0(((IndexedRecord) union_NULL_subRecord3), (encoder), (customization));
                                     }
                                 }
                             }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_GenericSerializer_229156053.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_GenericSerializer_229156053.java
@@ -54,17 +54,17 @@ public class FastSerdeLogicalTypesDefined_GenericSerializer_229156053
             (encoder).setItemCount(arrayOfUnionOfDateAndTimestampMillis0 .size());
             for (int counter0 = 0; (counter0 <arrayOfUnionOfDateAndTimestampMillis0 .size()); counter0 ++) {
                 (encoder).startItem();
-                Object union0 = null;
-                union0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
-                if (union0 instanceof LocalDate) {
+                Object union_INT_LONG0 = null;
+                union_INT_LONG0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
+                if (union_INT_LONG0 instanceof LocalDate) {
                     (encoder).writeIndex(0);
-                    Object convertedValue2 = union0;
+                    Object convertedValue2 = union_INT_LONG0;
                     convertedValue2 = Conversions.convertToRawType(convertedValue2, this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date);
                     (encoder).writeInt(((Integer) convertedValue2));
                 } else {
-                    if (union0 instanceof Instant) {
+                    if (union_INT_LONG0 instanceof Instant) {
                         (encoder).writeIndex(1);
-                        Object convertedValue3 = union0;
+                        Object convertedValue3 = union_INT_LONG0;
                         convertedValue3 = Conversions.convertToRawType(convertedValue3, this.logicalTypeSchema_1074306973, this.logicalTypeSchema_1074306973 .getLogicalType(), this.conversion_timestamp_millis);
                         (encoder).writeLong(((Long) convertedValue3));
                     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_SpecificSerializer_229156053.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesDefined_SpecificSerializer_229156053.java
@@ -54,17 +54,17 @@ public class FastSerdeLogicalTypesDefined_SpecificSerializer_229156053
             (encoder).setItemCount(arrayOfUnionOfDateAndTimestampMillis0 .size());
             for (int counter0 = 0; (counter0 <arrayOfUnionOfDateAndTimestampMillis0 .size()); counter0 ++) {
                 (encoder).startItem();
-                Object union0 = null;
-                union0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
-                if (union0 instanceof LocalDate) {
+                Object union_INT_LONG0 = null;
+                union_INT_LONG0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
+                if (union_INT_LONG0 instanceof LocalDate) {
                     (encoder).writeIndex(0);
-                    Object convertedValue2 = union0;
+                    Object convertedValue2 = union_INT_LONG0;
                     convertedValue2 = Conversions.convertToRawType(convertedValue2, this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date);
                     (encoder).writeInt(((Integer) convertedValue2));
                 } else {
-                    if (union0 instanceof Instant) {
+                    if (union_INT_LONG0 instanceof Instant) {
                         (encoder).writeIndex(1);
-                        Object convertedValue3 = union0;
+                        Object convertedValue3 = union_INT_LONG0;
                         convertedValue3 = Conversions.convertToRawType(convertedValue3, this.logicalTypeSchema_1074306973, this.logicalTypeSchema_1074306973 .getLogicalType(), this.conversion_timestamp_millis);
                         (encoder).writeLong(((Long) convertedValue3));
                     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_GenericSerializer_1007574890.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_GenericSerializer_1007574890.java
@@ -119,17 +119,17 @@ public class FastSerdeLogicalTypesTest1_GenericSerializer_1007574890
             for (CharSequence key1 : ((Map<CharSequence, Object> ) mapOfUnionsOfDateAndTimestampMillis0).keySet()) {
                 (encoder).startItem();
                 (encoder).writeString(key1);
-                Object union0 = null;
-                union0 = ((Map<CharSequence, Object> ) mapOfUnionsOfDateAndTimestampMillis0).get(key1);
-                if (union0 instanceof LocalDate) {
+                Object union_INT_LONG0 = null;
+                union_INT_LONG0 = ((Map<CharSequence, Object> ) mapOfUnionsOfDateAndTimestampMillis0).get(key1);
+                if (union_INT_LONG0 instanceof LocalDate) {
                     (encoder).writeIndex(0);
-                    Object convertedValue3 = union0;
+                    Object convertedValue3 = union_INT_LONG0;
                     convertedValue3 = Conversions.convertToRawType(convertedValue3, this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date);
                     (encoder).writeInt(((Integer) convertedValue3));
                 } else {
-                    if (union0 instanceof Instant) {
+                    if (union_INT_LONG0 instanceof Instant) {
                         (encoder).writeIndex(1);
-                        Object convertedValue4 = union0;
+                        Object convertedValue4 = union_INT_LONG0;
                         convertedValue4 = Conversions.convertToRawType(convertedValue4, this.logicalTypeSchema_1074306973, this.logicalTypeSchema_1074306973 .getLogicalType(), this.conversion_timestamp_millis);
                         (encoder).writeLong(((Long) convertedValue4));
                     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890.java
@@ -120,17 +120,17 @@ public class FastSerdeLogicalTypesTest1_SpecificSerializer_1007574890
             for (CharSequence key1 : ((Map<CharSequence, Object> ) mapOfUnionsOfDateAndTimestampMillis0).keySet()) {
                 (encoder).startItem();
                 (encoder).writeString(key1);
-                Object union0 = null;
-                union0 = ((Map<CharSequence, Object> ) mapOfUnionsOfDateAndTimestampMillis0).get(key1);
-                if (union0 instanceof LocalDate) {
+                Object union_INT_LONG0 = null;
+                union_INT_LONG0 = ((Map<CharSequence, Object> ) mapOfUnionsOfDateAndTimestampMillis0).get(key1);
+                if (union_INT_LONG0 instanceof LocalDate) {
                     (encoder).writeIndex(0);
-                    Object convertedValue3 = union0;
+                    Object convertedValue3 = union_INT_LONG0;
                     convertedValue3 = Conversions.convertToRawType(convertedValue3, this.logicalTypeSchema__59052268, this.logicalTypeSchema__59052268 .getLogicalType(), this.conversion_date);
                     (encoder).writeInt(((Integer) convertedValue3));
                 } else {
-                    if (union0 instanceof Instant) {
+                    if (union_INT_LONG0 instanceof Instant) {
                         (encoder).writeIndex(1);
-                        Object convertedValue4 = union0;
+                        Object convertedValue4 = union_INT_LONG0;
                         convertedValue4 = Conversions.convertToRawType(convertedValue4, this.logicalTypeSchema_1074306973, this.logicalTypeSchema_1074306973 .getLogicalType(), this.conversion_timestamp_millis);
                         (encoder).writeLong(((Long) convertedValue4));
                     }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_GenericSerializer_1982763418.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_GenericSerializer_1982763418.java
@@ -40,15 +40,15 @@ public class FastSerdeLogicalTypesUndefined_GenericSerializer_1982763418
             (encoder).setItemCount(arrayOfUnionOfDateAndTimestampMillis0 .size());
             for (int counter0 = 0; (counter0 <arrayOfUnionOfDateAndTimestampMillis0 .size()); counter0 ++) {
                 (encoder).startItem();
-                Object union0 = null;
-                union0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
-                if (union0 instanceof Integer) {
+                Object union_INT_LONG0 = null;
+                union_INT_LONG0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
+                if (union_INT_LONG0 instanceof Integer) {
                     (encoder).writeIndex(0);
-                    (encoder).writeInt(((Integer) union0));
+                    (encoder).writeInt(((Integer) union_INT_LONG0));
                 } else {
-                    if (union0 instanceof Long) {
+                    if (union_INT_LONG0 instanceof Long) {
                         (encoder).writeIndex(1);
-                        (encoder).writeLong(((Long) union0));
+                        (encoder).writeLong(((Long) union_INT_LONG0));
                     }
                 }
             }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_SpecificSerializer_1982763418.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/FastSerdeLogicalTypesUndefined_SpecificSerializer_1982763418.java
@@ -40,15 +40,15 @@ public class FastSerdeLogicalTypesUndefined_SpecificSerializer_1982763418
             (encoder).setItemCount(arrayOfUnionOfDateAndTimestampMillis0 .size());
             for (int counter0 = 0; (counter0 <arrayOfUnionOfDateAndTimestampMillis0 .size()); counter0 ++) {
                 (encoder).startItem();
-                Object union0 = null;
-                union0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
-                if (union0 instanceof Integer) {
+                Object union_INT_LONG0 = null;
+                union_INT_LONG0 = ((List<Object> ) arrayOfUnionOfDateAndTimestampMillis0).get(counter0);
+                if (union_INT_LONG0 instanceof Integer) {
                     (encoder).writeIndex(0);
-                    (encoder).writeInt(((Integer) union0));
+                    (encoder).writeInt(((Integer) union_INT_LONG0));
                 } else {
-                    if (union0 instanceof Long) {
+                    if (union_INT_LONG0 instanceof Long) {
                         (encoder).writeIndex(1);
-                        (encoder).writeLong(((Long) union0));
+                        (encoder).writeLong(((Long) union_INT_LONG0));
                     }
                 }
             }

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_union_INT_STRING_GenericSerializer_2132803162.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_union_INT_STRING_GenericSerializer_2132803162.java
@@ -1,0 +1,48 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_union_INT_STRING_GenericSerializer_2132803162
+    implements FastSerializer<Map<CharSequence, Object>>
+{
+
+
+    public void serialize(Map<CharSequence, Object> data, Encoder encoder, DatumWriterCustomization customization)
+        throws IOException
+    {
+        (customization).getCheckMapTypeFunction().apply(data);
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key0 : ((Map<CharSequence, Object> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key0);
+                Object union_INT_STRING0 = null;
+                union_INT_STRING0 = ((Map<CharSequence, Object> ) data).get(key0);
+                if (union_INT_STRING0 instanceof Integer) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeInt(((Integer) union_INT_STRING0));
+                } else {
+                    if (union_INT_STRING0 instanceof CharSequence) {
+                        (encoder).writeIndex(1);
+                        if (((CharSequence) union_INT_STRING0) instanceof Utf8) {
+                            (encoder).writeString(((Utf8)((CharSequence) union_INT_STRING0)));
+                        } else {
+                            (encoder).writeString(((CharSequence) union_INT_STRING0).toString());
+                        }
+                    }
+                }
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_union_NULL_STRING_GenericSerializer_1486935134.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_union_NULL_STRING_GenericSerializer_1486935134.java
@@ -1,0 +1,46 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.Map;
+import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class Map_of_union_NULL_STRING_GenericSerializer_1486935134
+    implements FastSerializer<Map<CharSequence, CharSequence>>
+{
+
+
+    public void serialize(Map<CharSequence, CharSequence> data, Encoder encoder, DatumWriterCustomization customization)
+        throws IOException
+    {
+        (customization).getCheckMapTypeFunction().apply(data);
+        (encoder).writeMapStart();
+        if ((data == null)||data.isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(data.size());
+            for (CharSequence key0 : ((Map<CharSequence, CharSequence> ) data).keySet()) {
+                (encoder).startItem();
+                (encoder).writeString(key0);
+                CharSequence union_NULL_STRING0 = null;
+                union_NULL_STRING0 = ((Map<CharSequence, CharSequence> ) data).get(key0);
+                if (union_NULL_STRING0 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    (encoder).writeIndex(1);
+                    if (((CharSequence) union_NULL_STRING0) instanceof Utf8) {
+                        (encoder).writeString(((Utf8)((CharSequence) union_NULL_STRING0)));
+                    } else {
+                        (encoder).writeString(((CharSequence) union_NULL_STRING0).toString());
+                    }
+                }
+            }
+        }
+        (encoder).writeMapEnd();
+    }
+
+}

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_union_NULL_record_GenericSerializer_2140000109.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/Map_of_union_NULL_record_GenericSerializer_2140000109.java
@@ -2,42 +2,44 @@
 package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Map;
 import com.linkedin.avro.fastserde.FastSerializer;
 import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 
-public class Array_of_UNION_GenericSerializer_777827233
-    implements FastSerializer<List<IndexedRecord>>
+public class Map_of_union_NULL_record_GenericSerializer_2140000109
+    implements FastSerializer<Map<CharSequence, IndexedRecord>>
 {
 
 
-    public void serialize(List<IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
+    public void serialize(Map<CharSequence, IndexedRecord> data, Encoder encoder, DatumWriterCustomization customization)
         throws IOException
     {
-        (encoder).writeArrayStart();
+        (customization).getCheckMapTypeFunction().apply(data);
+        (encoder).writeMapStart();
         if ((data == null)||data.isEmpty()) {
             (encoder).setItemCount(0);
         } else {
             (encoder).setItemCount(data.size());
-            for (int counter0 = 0; (counter0 <data.size()); counter0 ++) {
+            for (CharSequence key0 : ((Map<CharSequence, IndexedRecord> ) data).keySet()) {
                 (encoder).startItem();
-                IndexedRecord union0 = null;
-                union0 = ((List<IndexedRecord> ) data).get(counter0);
-                if (union0 == null) {
+                (encoder).writeString(key0);
+                IndexedRecord union_NULL_record0 = null;
+                union_NULL_record0 = ((Map<CharSequence, IndexedRecord> ) data).get(key0);
+                if (union_NULL_record0 == null) {
                     (encoder).writeIndex(0);
                     (encoder).writeNull();
                 } else {
-                    if ((union0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record".equals(((IndexedRecord) union0).getSchema().getFullName())) {
+                    if ((union_NULL_record0 instanceof IndexedRecord)&&"com.linkedin.avro.fastserde.generated.avro.record".equals(((IndexedRecord) union_NULL_record0).getSchema().getFullName())) {
                         (encoder).writeIndex(1);
-                        serializeRecord0(((IndexedRecord) union0), (encoder), (customization));
+                        serializeRecord0(((IndexedRecord) union_NULL_record0), (encoder), (customization));
                     }
                 }
             }
         }
-        (encoder).writeArrayEnd();
+        (encoder).writeMapEnd();
     }
 
     @SuppressWarnings("unchecked")

--- a/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/TestRecord_GenericSerializer_331683882.java
+++ b/fastserde/avro-fastserde-tests111/build/codegen/java/com/linkedin/avro/fastserde/generated/serialization/AVRO_1_11/TestRecord_GenericSerializer_331683882.java
@@ -1,0 +1,53 @@
+
+package com.linkedin.avro.fastserde.generated.serialization.AVRO_1_11;
+
+import java.io.IOException;
+import java.util.List;
+import com.linkedin.avro.fastserde.FastSerializer;
+import com.linkedin.avro.fastserde.customized.DatumWriterCustomization;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.util.Utf8;
+
+public class TestRecord_GenericSerializer_331683882
+    implements FastSerializer<IndexedRecord>
+{
+
+
+    public void serialize(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
+        throws IOException
+    {
+        serializeTestRecord0(data, (encoder), (customization));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void serializeTestRecord0(IndexedRecord data, Encoder encoder, DatumWriterCustomization customization)
+        throws IOException
+    {
+        List<CharSequence> fields0 = ((List<CharSequence> ) data.get(0));
+        (encoder).writeArrayStart();
+        if ((fields0 == null)||fields0 .isEmpty()) {
+            (encoder).setItemCount(0);
+        } else {
+            (encoder).setItemCount(fields0 .size());
+            for (int counter0 = 0; (counter0 <fields0 .size()); counter0 ++) {
+                (encoder).startItem();
+                CharSequence union_NULL_STRING0 = null;
+                union_NULL_STRING0 = ((List<CharSequence> ) fields0).get(counter0);
+                if (union_NULL_STRING0 == null) {
+                    (encoder).writeIndex(0);
+                    (encoder).writeNull();
+                } else {
+                    (encoder).writeIndex(1);
+                    if (((CharSequence) union_NULL_STRING0) instanceof Utf8) {
+                        (encoder).writeString(((Utf8)((CharSequence) union_NULL_STRING0)));
+                    } else {
+                        (encoder).writeString(((CharSequence) union_NULL_STRING0).toString());
+                    }
+                }
+            }
+        }
+        (encoder).writeArrayEnd();
+    }
+
+}

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastSerializerGenerator.java
@@ -246,7 +246,7 @@ public class FastSerializerGenerator<T, U extends GenericData> extends FastSerde
 
     final Schema elementSchema = arraySchema.getElementType();
     if (SchemaAssistant.isComplexType(elementSchema)) {
-      JVar containerVar = declareValueVar(elementSchema.getName(), elementSchema, forBody);
+      JVar containerVar = declareValueVar(SchemaAssistant.getTypeName(elementSchema), elementSchema, forBody);
       forBody.assign(containerVar, JExpr.invoke(JExpr.cast(arrayClass, arrayExpr), getMethodName).arg(counter));
       processComplexType(elementSchema, containerVar, forBody, customizationSupplier);
     } else {
@@ -290,7 +290,7 @@ public class FastSerializerGenerator<T, U extends GenericData> extends FastSerde
 
     JVar containerVar;
     if (SchemaAssistant.isComplexType(valueSchema)) {
-      containerVar = declareValueVar(valueSchema.getName(), valueSchema, forBody);
+      containerVar = declareValueVar(SchemaAssistant.getTypeName(valueSchema), valueSchema, forBody);
       forBody.assign(containerVar, JExpr.invoke(JExpr.cast(mapClass, mapExpr), "get").arg(mapKeysLoop.var()));
 
       processComplexType(valueSchema, containerVar, forBody, customizationSupplier);

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -214,6 +214,12 @@ public class SchemaAssistant<T extends GenericData> {
       return "Array_of_" + getTypeName(schema.getElementType());
     } else if (Schema.Type.MAP.equals(schemaType)) {
       return "Map_of_" + getTypeName(schema.getValueType());
+    } else if (Schema.Type.UNION.equals(schemaType)) {
+      StringBuilder sb = new StringBuilder("union");
+      for (Schema unionType : schema.getTypes()) {
+        sb.append("_").append(getTypeName(unionType));
+      }
+      return sb.toString();
     } else {
       return schema.getType().name();
     }


### PR DESCRIPTION
## Problem
  When generating serializers for arrays or maps containing union types, the code was calling `schema.getName()` which doesn't work for unions (they don't have names). This caused invalid Java variable names like `UNION0` to be generated, leading to compilation failures.

## Solution
  - Enhanced `SchemaAssistant.getTypeName()` to handle UNION types by concatenating branch type names (e.g., `union_NULL_STRING`).
  - Updated `FastSerializerGenerator` to use `getTypeName()` instead of `getName()` when declaring variables for array elements and map values.
  - Added 5 comprehensive tests covering nullable and multi-type unions in arrays, maps, and records.
  
## Examples of Generated Names
  - `union_NULL_STRING0` (instead of `UNION0`)
  - `union_INT_STRING_DOUBLE0` (for multi-type unions)
  - `union_NULL_record0` (for nullable record unions)

## Files Changed
  - `FastSerializerGenerator.java` - Fixed two locations where union schemas needed proper naming
  - `SchemaAssistant.java` - Added UNION case to `getTypeName()` method
  - `FastGenericSerializerGeneratorTest.java` - Added 5 new test cases
  - Generated test files - Show the corrected naming in action

  ## Testing
  All existing tests pass, plus 5 new tests validate:
  - Arrays of nullable unions
  - Maps of nullable unions
  - Records containing union arrays
  - Arrays of multi-type unions
  - Maps of multi-type unions