### PR TITLE
Add negative int32 test coverage for Avro wire format and type widening

### DIFF
--- a/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroWireFormatCompatibilityTest.java
+++ b/helper/tests/helper-tests-allavro/src/test/java/com/linkedin/avroutil1/compatibility/AvroWireFormatCompatibilityTest.java
@@ -154,4 +154,65 @@ public class AvroWireFormatCompatibilityTest {
         AvroCodecUtil.deserializeAsGeneric(bytes, writerSchema, readerSchemaWithLong);
     Assert.assertEquals(deserializedGenericRecord.get(0), 1L);
   }
+
+  @Test
+  public void testNegativeInt32BinaryRoundtrip() throws Exception {
+    Schema schema = AvroCompatibilityHelper.parse(TestUtil.load("allavro/RecordWithNumericFields.avsc"));
+    int[] negativeValues = {-1, -100, Integer.MIN_VALUE};
+
+    for (int negativeValue : negativeValues) {
+      GenericData.Record record = new GenericData.Record(schema);
+      record.put("intField", negativeValue);
+      record.put("longField", 0L);
+      record.put("floatField", 0.0f);
+      record.put("doubleField", 0.0d);
+
+      byte[] bytes = AvroCodecUtil.serializeBinary(record);
+      GenericRecord deserialized = AvroCodecUtil.deserializeAsGeneric(bytes, schema, schema);
+
+      Assert.assertEquals(deserialized.get(schema.getField("intField").pos()), negativeValue,
+          "Negative int32 value " + negativeValue + " should survive binary roundtrip");
+    }
+  }
+
+  @Test
+  public void testNegativeInt32JsonRoundtrip() throws Exception {
+    Schema schema = AvroCompatibilityHelper.parse(TestUtil.load("allavro/RecordWithNumericFields.avsc"));
+    int[] negativeValues = {-1, -100, Integer.MIN_VALUE};
+
+    for (int negativeValue : negativeValues) {
+      GenericData.Record record = new GenericData.Record(schema);
+      record.put("intField", negativeValue);
+      record.put("longField", 0L);
+      record.put("floatField", 0.0f);
+      record.put("doubleField", 0.0d);
+
+      String json = AvroCodecUtil.serializeJson(record, AvroCompatibilityHelper.getRuntimeAvroVersion());
+      Decoder jsonDecoder = AvroCompatibilityHelper.newCompatibleJsonDecoder(schema, json);
+      GenericDatumReader<IndexedRecord> reader = new GenericDatumReader<>(schema);
+      IndexedRecord deserialized = reader.read(null, jsonDecoder);
+
+      Assert.assertEquals(deserialized.get(schema.getField("intField").pos()), negativeValue,
+          "Negative int32 value " + negativeValue + " should survive JSON roundtrip");
+    }
+  }
+
+  @Test
+  public void testNegativeInt32TypeWideningToLong() throws Exception {
+    Schema writerSchema =
+        AvroCompatibilityHelper.parse(TestUtil.load("allavro/WidenIntToLongInUnionField_writer.avsc"));
+    Schema readerSchema =
+        AvroCompatibilityHelper.parse(TestUtil.load("allavro/WidenIntToLongInUnionField_reader.avsc"));
+    int[] negativeValues = {-1, -100, Integer.MIN_VALUE};
+
+    for (int negativeValue : negativeValues) {
+      GenericData.Record record = new GenericData.Record(writerSchema);
+      record.put("f1", negativeValue);
+      byte[] bytes = AvroCodecUtil.serializeBinary(record);
+
+      GenericRecord deserialized = AvroCodecUtil.deserializeAsGeneric(bytes, writerSchema, readerSchema);
+      Assert.assertEquals(deserialized.get(0), (long) negativeValue,
+          "Negative int32 value " + negativeValue + " should widen to long correctly");
+    }
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds explicit test coverage proving that negative int32 values are correctly handled at the Avro serialization layer — both binary and JSON wire formats — and that int-to-long type widening preserves sign.

Negative int32 values and very large positive values share overlapping bit representations in two's complement. These tests build confidence that the serialization, deserialization, and schema evolution paths behave correctly for the full signed int32 range.

## What's Changed

Added 3 tests to `AvroWireFormatCompatibilityTest.java`, each exercising three negative values (`-1`, `-100`, `Integer.MIN_VALUE`):

| Test | Description |
|---|---|
| `testNegativeInt32BinaryRoundtrip` | Serialize negative int to Avro binary, deserialize, verify value preserved |
| `testNegativeInt32JsonRoundtrip` | Serialize negative int to Avro JSON, deserialize via compatible decoder, verify value preserved |
| `testNegativeInt32TypeWideningToLong` | Write with `union[null, int]` schema, read with `union[null, long]` schema, verify sign preserved |

**Total: 9 new test cases** (3 tests x 3 values)

These tests run across all supported Avro versions (1.4 through 1.11) via the existing multi-version test harness. No new schemas or dependencies — tests reuse existing `RecordWithNumericFields.avsc` and `WidenIntToLongInUnionField_{writer,reader}.avsc`.

## Test Plan

- [x] All 9 new test cases pass locally
- [x] Existing tests in `AvroWireFormatCompatibilityTest.java` remain green
- [x] CI passes
