### PR TITLE
Fix union branch resolution for primitive promotion

### DIFF
--- a/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
+++ b/fastserde/avro-fastserde-tests-common/src/test/java/com/linkedin/avro/fastserde/FastGenericDeserializerGeneratorTest.java
@@ -902,6 +902,28 @@ public class FastGenericDeserializerGeneratorTest {
   }
 
   @Test(groups = {"deserializationTest"}, dataProvider = "Implementation")
+  public void shouldPromoteNullableIntUnionToNullableLongUnion(Implementation implementation) {
+    // given
+    Schema writerSchema = createRecord(
+        createPrimitiveUnionFieldSchema("test", Schema.Type.INT));
+    Schema readerSchema = createRecord(
+        createPrimitiveUnionFieldSchema("test", Schema.Type.LONG));
+
+    GenericData.Record recordWithInt = new GenericData.Record(writerSchema);
+    recordWithInt.put("test", 1);
+    GenericData.Record recordWithNull = new GenericData.Record(writerSchema);
+    recordWithNull.put("test", null);
+
+    // when
+    GenericRecord intRecord = implementation.decode(writerSchema, readerSchema, genericDataAsDecoder(recordWithInt));
+    GenericRecord nullRecord = implementation.decode(writerSchema, readerSchema, genericDataAsDecoder(recordWithNull));
+
+    // then
+    Assert.assertEquals(intRecord.get("test"), 1L);
+    Assert.assertNull(nullRecord.get("test"));
+  }
+
+  @Test(groups = {"deserializationTest"}, dataProvider = "Implementation")
   public void shouldTolerateUnionReorderingWithNonString(Implementation implementation) {
     // given
     Schema record1Schema = createRecord(

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/FastDeserializerGenerator.java
@@ -225,8 +225,8 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
         break;
       default:
         final Schema primitiveFieldSchema;
-        if (action.getShouldRead() && readerSchema != null && Schema.Type.STRING.equals(readerSchema.getType())) {
-          // to preserve reader-specific options use reader field schema
+        if (action.getShouldRead() && readerSchema != null && !Schema.Type.UNION.equals(readerSchema.getType())) {
+          // preserve reader-specific options/promotions, but avoid forwarding a union schema
           primitiveFieldSchema = readerSchema;
         } else {
           primitiveFieldSchema = schema;
@@ -630,7 +630,16 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
 
     // Check if unionReaderSchema is really a union, if not then only the compatible writer union type can be deserialized
     final boolean readerSchemaNotAUnion = unionReaderSchema != null && !Schema.Type.UNION.equals(unionReaderSchema.getType());
-    final int compatibleWriterSchema = readerSchemaNotAUnion ? schemaAssistant.compatibleUnionSchemaIndex(unionReaderSchema, unionSchema) : -1;
+    int compatibleWriterSchema = -1;
+    if (readerSchemaNotAUnion) {
+      for (int i = 0; i < unionSchema.getTypes().size(); i++) {
+        Schema optionSchema = unionSchema.getTypes().get(i);
+        if (schemaAssistant.areTypesCompatible(optionSchema, unionReaderSchema)) {
+          compatibleWriterSchema = i;
+          break;
+        }
+      }
+    }
 
     for (int i = 0; i < unionSchema.getTypes().size(); i++) {
       Schema optionSchema = unionSchema.getTypes().get(i);
@@ -658,16 +667,12 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
             readerOptionSchema = (i == compatibleWriterSchema) ? unionReaderSchema : null;
         } else {
           // The reader's union could be re-ordered, so we need to find the one that matches.
-          // TODO: this code should support primitive type promotions
-          for (int j = 0; j < unionReaderSchema.getTypes().size(); j++) {
-            Schema potentialReaderSchema = unionReaderSchema.getTypes().get(j);
-            // Avro allows unnamed types to appear only once in a union, but named types may appear multiple times and
-            // thus need to be disambiguated via their full-name (including aliases).
-            if (schemaAssistant.areTypesCompatible(potentialReaderSchema, optionSchema)) {
-              readerOptionSchema = potentialReaderSchema;
-              readerOptionUnionBranchIndex = j;
-              break;
-            }
+          try {
+            readerOptionUnionBranchIndex = schemaAssistant.compatibleUnionSchemaIndex(optionSchema, unionReaderSchema);
+            readerOptionSchema = unionReaderSchema.getTypes().get(readerOptionUnionBranchIndex);
+          } catch (SchemaAssistantException e) {
+            // no compatible branch - readerOptionSchema stays null, and AvroTypeException
+            // is thrown below
           }
         }
 
@@ -698,17 +703,17 @@ public class FastDeserializerGenerator<T, U extends GenericData> extends FastDes
 
         if (readerSchemaNotAUnion) {
           unionAction =
-                  FieldAction.fromValues(optionSchema.getType(), action.getShouldRead(), alternative.symbols[compatibleWriterSchema]);
+                  FieldAction.fromValues(readerOptionSchema.getType(), action.getShouldRead(), alternative.symbols[compatibleWriterSchema]);
         } else {
           Symbol.UnionAdjustAction unionAdjustAction = (Symbol.UnionAdjustAction) alternative.symbols[i].production[0];
           //For maps and arrays, our processMap and processArray logic expect the map-end symbol whose production contains the maps values
           //We go from Symbol A(production = [map-start, map-end]) to Symbol map-end
           if(optionSchema.getType().equals(Schema.Type.MAP) || optionSchema.getType().equals(Schema.Type.ARRAY)){
             unionAction =
-                    FieldAction.fromValues(optionSchema.getType(), action.getShouldRead(), unionAdjustAction.symToParse.production[0]);
+                    FieldAction.fromValues(readerOptionSchema.getType(), action.getShouldRead(), unionAdjustAction.symToParse.production[0]);
           } else {
             unionAction =
-                    FieldAction.fromValues(optionSchema.getType(), action.getShouldRead(), unionAdjustAction.symToParse);
+                    FieldAction.fromValues(readerOptionSchema.getType(), action.getShouldRead(), unionAdjustAction.symToParse);
           }
         }
 

--- a/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
+++ b/fastserde/avro-fastserde/src/main/java/com/linkedin/avro/fastserde/SchemaAssistant.java
@@ -574,11 +574,16 @@ public class SchemaAssistant<T extends GenericData> {
     }
   }
 
-  // TODO: this code should support primitive type promotions
   public int compatibleUnionSchemaIndex(Schema schema, Schema unionSchema) {
     for (int i = 0; i < unionSchema.getTypes().size(); i++) {
       Schema potentialCompatibleSchema = unionSchema.getTypes().get(i);
-      if (areTypesCompatible(schema, potentialCompatibleSchema)) {
+      if (areTypesExactlyCompatible(schema, potentialCompatibleSchema)) {
+        return i;
+      }
+    }
+    for (int i = 0; i < unionSchema.getTypes().size(); i++) {
+      Schema potentialCompatibleSchema = unionSchema.getTypes().get(i);
+      if (isTypePromotable(schema, potentialCompatibleSchema)) {
         return i;
       }
     }
@@ -590,6 +595,11 @@ public class SchemaAssistant<T extends GenericData> {
   }
 
   public boolean areTypesCompatible(Schema schema, Schema potentialCompatibleSchema){
+    return areTypesExactlyCompatible(schema, potentialCompatibleSchema)
+        || isTypePromotable(schema, potentialCompatibleSchema);
+  }
+
+  private boolean areTypesExactlyCompatible(Schema schema, Schema potentialCompatibleSchema) {
     if(!potentialCompatibleSchema.getType().equals(schema.getType())) {
       return false;
     }
@@ -604,5 +614,25 @@ public class SchemaAssistant<T extends GenericData> {
     // Other avro versions (impl for all, spec for 1.9+) use unqualified name to compare named types (e.g. "test" instead of "com.test.test").
     return potentialCompatibleSchema.getName().equals(schema.getName()) ||
         potentialCompatibleSchema.getAliases().contains(AvroCompatibilityHelper.getSchemaFullName(schema));
+  }
+
+  private boolean isTypePromotable(Schema schema, Schema potentialCompatibleSchema) {
+    switch (schema.getType()) {
+      case INT:
+        return Schema.Type.LONG.equals(potentialCompatibleSchema.getType())
+            || Schema.Type.FLOAT.equals(potentialCompatibleSchema.getType())
+            || Schema.Type.DOUBLE.equals(potentialCompatibleSchema.getType());
+      case LONG:
+        return Schema.Type.FLOAT.equals(potentialCompatibleSchema.getType())
+            || Schema.Type.DOUBLE.equals(potentialCompatibleSchema.getType());
+      case FLOAT:
+        return Schema.Type.DOUBLE.equals(potentialCompatibleSchema.getType());
+      case STRING:
+        return Schema.Type.BYTES.equals(potentialCompatibleSchema.getType());
+      case BYTES:
+        return Schema.Type.STRING.equals(potentialCompatibleSchema.getType());
+      default:
+        return false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

This change fixes fastserde union resolution for schema evolution cases where a writer primitive should be promoted to a compatible reader primitive inside a union.

Previously, fastserde could fail on cases like:

writer: ["null", "int"]
reader: ["null", "long"]

## What changed

- `SchemaAssistant.areTypesCompatible(...)` now recognizes valid primitive promotions in addition to exact matches.
- Reader union branch selection now uses that compatibility logic consistently.
- Exact matches still win over promotions in case there are multiple matches.
- Added a regression test for ["null","int"] -> ["null","long"].